### PR TITLE
Add default threshold to CompositionThread constructor

### DIFF
--- a/gui_threads.py
+++ b/gui_threads.py
@@ -40,7 +40,7 @@ class CompositionThread(QThread):
     finished_signal = pyqtSignal(list, dict, dict)
     error_signal = pyqtSignal(str)
 
-    def __init__(self, searcher, text, chunk, freq, mode, threshold):
+    def __init__(self, searcher, text, chunk, freq, mode, threshold=5):
         super().__init__()
         self.searcher = searcher; self.text = text; self.chunk = chunk
         self.freq = freq; self.mode = mode; self.threshold = threshold


### PR DESCRIPTION
## Summary
- add a default threshold parameter to `CompositionThread` so it accepts the filter value used by the UI
- keep composition grouping using the provided threshold value

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69351e16c20c8321ab513cda0d03e534)