### PR TITLE
Add default report save locations

### DIFF
--- a/genizah_core.py
+++ b/genizah_core.py
@@ -39,6 +39,7 @@ class Config:
     FILE_V7 = os.path.join(BASE_DIR, "AllGenizah_OLD.txt")
     INPUT_FILE = os.path.join(BASE_DIR, "input.txt")
     RESULTS_DIR = os.path.join(BASE_DIR, "Results")
+    REPORTS_DIR = os.path.join(BASE_DIR, "Reports")
 
     # 3. User Data Directory (Index, Caches)
     INDEX_DIR = os.path.join(os.path.expanduser("~"), "Genizah_Tantivy_Index")


### PR DESCRIPTION
## Summary
- add a Reports directory configuration and ensure it exists on startup
- provide sanitized default filenames for text search exports and composition reports
- remember the last search query so exported results default to a relevant name

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69351c16d48883219cf6038397a0f1f9)