### PR TITLE
Fix NameError during composition report export

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -1138,15 +1138,6 @@ class GenizahGUI(QMainWindow):
             else:
                 detail_lines.append("No known manuscripts supplied for exclusion.")
 
-            if self.comp_known:
-                lines.extend([
-                    sep,
-                    "KNOWN MANUSCRIPTS (Excluded)",
-                    sep,
-                ])
-                for item in self.comp_known:
-                    lines.extend(_fmt_item(item))
-
             if self.comp_appendix:
                 detail_lines.extend([
                     sep,


### PR DESCRIPTION
## Summary
- remove the unused block that referenced an undefined variable when exporting composition reports
- rely on the existing detail_lines list to include excluded manuscripts before saving the report

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693589d6940c83219529b3af758fe8ca)