### PR TITLE
Fix grouping progress bar and prefer metadata shelfmarks

### DIFF
--- a/genizah_core.py
+++ b/genizah_core.py
@@ -755,9 +755,10 @@ class SearchEngine:
             sid, _ = self.meta_mgr.parse_header_smart(item['raw_header'])
             meta = self.meta_mgr.nli_cache.get(sid, {})
             t = meta.get('title', '').strip()
+            shelfmark = self.meta_mgr.get_shelfmark_from_header(item['raw_header']) or meta.get('shelfmark', 'Unknown')
             wrapped.append({
-                'item': item, 'title': t, 'clean': " ".join(_get_clean_words(t)), 
-                'grouped': False, 'shelfmark': meta.get('shelfmark', 'Unknown')
+                'item': item, 'title': t, 'clean': " ".join(_get_clean_words(t)),
+                'grouped': False, 'shelfmark': shelfmark
             })
 
         wrapped.sort(key=lambda x: len(x['title']))


### PR DESCRIPTION
## Summary
- make the grouping progress bar determinate and start from zero
- prefer shelfmarks from metadata bank across composition, browse, and reports, falling back to NLI only when missing
- ensure grouping uses metadata-sourced shelfmarks when summarizing compositions

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69359b258d248321874315ce51a6ef8e)