### PR TITLE
Handle optional MS prefix in shelfmark filtering

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -715,7 +715,11 @@ class GenizahGUI(QMainWindow):
     def normalize_shelfmark(self, shelf: str):
         if not shelf:
             return ""
-        return re.sub(r"[^\w]", "", shelf).lower()
+        cleaned = re.sub(r"[^\w]", "", shelf).lower()
+        # Treat optional "ms" prefix as non-significant for comparisons
+        if cleaned.startswith("ms"):
+            cleaned = cleaned[2:]
+        return cleaned
 
     def _get_meta_for_header(self, raw_header):
         """Return (sys_id, p_num, shelfmark, title) preferring metadata bank for shelfmarks."""

--- a/genizah_core.py
+++ b/genizah_core.py
@@ -244,7 +244,14 @@ class MetadataManager:
     def _normalize_shelfmark(self, raw):
         if not raw: return None
         cleaned = str(raw).strip().strip('-').strip()
-        return cleaned if cleaned else None
+        cleaned = cleaned if cleaned else None
+        if not cleaned: return None
+
+        # Ignore optional "MS" prefix when comparing shelfmarks
+        no_spaces = re.sub(r"[^\w]", "", cleaned).lower()
+        if no_spaces.startswith("ms"):
+            cleaned = cleaned[2:].lstrip()
+        return cleaned
 
     def _load_metadata_bank(self):
         if not os.path.exists(Config.METADATA_BANK): return


### PR DESCRIPTION
## Summary
- Ignore the optional `MS` prefix when normalizing shelfmarks so manuscript filters match regardless of the prefix
- Apply the same normalization to metadata loading to keep shelfmark comparisons consistent

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6935a0acd7088321a32eb229efea8505)