### PR TITLE
Handle Ms prefix with optional punctuation

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -715,7 +715,12 @@ class GenizahGUI(QMainWindow):
     def normalize_shelfmark(self, shelf: str):
         if not shelf:
             return ""
-        return re.sub(r"[^\w]", "", shelf).lower()
+        without_prefix = re.sub(r"^\s*m[\.\s]*s[\.\s]*\.?\s*", "", shelf, flags=re.IGNORECASE)
+        cleaned = re.sub(r"[^\w]", "", without_prefix).lower()
+        # Treat optional "ms" prefix as non-significant for comparisons
+        if cleaned.startswith("ms"):
+            cleaned = cleaned[2:]
+        return cleaned
 
     def _get_meta_for_header(self, raw_header):
         """Return (sys_id, p_num, shelfmark, title) preferring metadata bank for shelfmarks."""

--- a/genizah_core.py
+++ b/genizah_core.py
@@ -244,7 +244,16 @@ class MetadataManager:
     def _normalize_shelfmark(self, raw):
         if not raw: return None
         cleaned = str(raw).strip().strip('-').strip()
-        return cleaned if cleaned else None
+        cleaned = cleaned if cleaned else None
+        if not cleaned: return None
+
+        # Ignore optional "MS"/"Ms" prefix (with optional punctuation/spacing like "M.S." or "Ms.")
+        cleaned = re.sub(r"^\s*m[\.\s]*s[\.\s]*\.?\s*", "", cleaned, flags=re.IGNORECASE)
+
+        no_spaces = re.sub(r"[^\w]", "", cleaned).lower()
+        if no_spaces.startswith("ms"):
+            cleaned = cleaned[2:].lstrip()
+        return cleaned
 
     def _load_metadata_bank(self):
         if not os.path.exists(Config.METADATA_BANK): return


### PR DESCRIPTION
## Summary
- allow shelfmark normalization to strip Ms prefixes even when they include dots or spaces
- apply the same flexible Ms-prefix handling when normalizing exclusions

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6935a0acd7088321a32eb229efea8505)