### PR TITLE
Make metadata fetching cancellable and threaded

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -2,15 +2,13 @@
 import sys
 import os
 import re
-import threading
-import time
 from PyQt6.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,
                              QLabel, QLineEdit, QPushButton, QTabWidget, QTableWidget,
                              QTableWidgetItem, QHeaderView, QComboBox, QCheckBox,
                              QTextEdit, QMessageBox, QProgressBar, QSplitter, QDialog,
                              QTextBrowser, QFileDialog, QMenu, QGroupBox, QSpinBox,
-                             QTreeWidget, QTreeWidgetItem, QPlainTextEdit)
-from PyQt6.QtCore import Qt, QTimer, QUrl, QSize
+                             QTreeWidget, QTreeWidgetItem, QPlainTextEdit, QProgressDialog)
+from PyQt6.QtCore import Qt, QTimer, QUrl, QSize, QEventLoop
 from PyQt6.QtGui import QFont, QIcon, QDesktopServices, QGuiApplication, QAction
 
 from genizah_core import Config, MetadataManager, VariantManager, SearchEngine, Indexer, AIManager
@@ -655,7 +653,8 @@ class GenizahGUI(QMainWindow):
 
         self.meta_loader = ShelfmarkLoaderThread(self.meta_mgr, ids)
         self.meta_loader.progress_signal.connect(self.on_meta_progress)
-        self.meta_loader.finished_signal.connect(lambda: self.status_label.setText(f"Loaded {len(results)} items."))
+        self.meta_loader.finished_signal.connect(lambda cancelled: self.status_label.setText(f"Loaded {len(results)} items." if not cancelled else "Metadata load cancelled"))
+        self.meta_loader.error_signal.connect(lambda err: QMessageBox.critical(self, "Metadata Error", err))
         self.meta_loader.start()
 
     def on_meta_progress(self, curr, total, sid):
@@ -1025,7 +1024,9 @@ class GenizahGUI(QMainWindow):
         for item in self.comp_known:
             sid, _ = self.meta_mgr.parse_header_smart(item['raw_header'])
             if sid: all_ids.append(sid)
-        self._fetch_metadata_with_dialog(list(set(all_ids)), title="Fetching metadata before export...")
+        cancelled = self._fetch_metadata_with_dialog(list(set(all_ids)), title="Fetching metadata before export...")
+        if cancelled:
+            return
 
         missing_ids = []
         for item in self.comp_main + self.comp_known:
@@ -1045,8 +1046,9 @@ class GenizahGUI(QMainWindow):
                 QMessageBox.StandardButton.No
             )
             if choice == QMessageBox.StandardButton.No:
-                self._fetch_metadata_with_dialog(list(set(missing_ids)), title="Loading missing metadata...")
-                self._refresh_comp_tree_metadata()
+                cancelled = self._fetch_metadata_with_dialog(list(set(missing_ids)), title="Loading missing metadata...")
+                if not cancelled:
+                    self._refresh_comp_tree_metadata()
 
         title = self.comp_title_input.text().strip() or "Untitled Composition"
         default_path = self._default_report_path(title, "Composition_Report")
@@ -1178,49 +1180,52 @@ class GenizahGUI(QMainWindow):
     def _fetch_metadata_with_dialog(self, system_ids, title="Loading metadata..."):
         to_fetch = [sid for sid in system_ids if sid and sid not in self.meta_mgr.nli_cache]
         if not to_fetch:
-            return
+            return False
 
-        dialog = QMessageBox(self)
+        dialog = QProgressDialog("Loading shelfmarks and titles...", "Cancel", 0, len(to_fetch), self)
         dialog.setWindowTitle(title)
-        dialog.setText("Please wait while shelfmarks and titles are loaded...\nThis may take a few seconds.")
-        dialog.setStandardButtons(QMessageBox.StandardButton.NoButton)
+        dialog.setWindowModality(Qt.WindowModality.ApplicationModal)
+        dialog.setAutoClose(False)
+        dialog.setAutoReset(False)
+        dialog.setMinimumDuration(0)
+
+        loop = QEventLoop(self)
+        cancelled = False
+
+        worker = ShelfmarkLoaderThread(self.meta_mgr, to_fetch)
+
+        def on_progress(curr, total, sid):
+            dialog.setMaximum(total)
+            dialog.setValue(curr)
+            dialog.setLabelText(f"Loaded {curr}/{total} (ID: {sid})")
+
+        def on_finished(was_cancelled):
+            nonlocal cancelled
+            cancelled = was_cancelled
+            dialog.reset()
+            loop.quit()
+            if was_cancelled:
+                QMessageBox.information(self, "Metadata", "Metadata loading was cancelled.")
+
+        def on_error(err):
+            QMessageBox.critical(self, "Metadata Error", err)
+            dialog.reset()
+            loop.quit()
+
+        def handle_cancel():
+            worker.request_cancel()
+
+        dialog.canceled.connect(handle_cancel)
+        worker.progress_signal.connect(on_progress)
+        worker.finished_signal.connect(on_finished)
+        worker.error_signal.connect(on_error)
+
+        worker.start()
         dialog.show()
+        loop.exec()
+        worker.wait()
 
-        progress = {'count': 0}
-        start_time = time.time()
-        long_wait_prompted = False
-
-        def progress_cb(count, total, sid):
-            progress['count'] = count
-            dialog.setInformativeText(f"Loaded {count}/{total} (ID: {sid})")
-            QApplication.processEvents()
-
-        def run_fetch():
-            self.meta_mgr.batch_fetch_shelfmarks(to_fetch, progress_callback=progress_cb)
-
-        thread = threading.Thread(target=run_fetch, daemon=True)
-        thread.start()
-
-        while thread.is_alive():
-            QApplication.processEvents()
-
-            elapsed = time.time() - start_time
-            if not long_wait_prompted and elapsed > 12:
-                long_wait_prompted = True
-                choice = QMessageBox.question(
-                    self,
-                    "Still Loading...",
-                    "Metadata fetching is taking longer than expected.\n"
-                    "Do you want to keep waiting?",
-                    QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
-                    QMessageBox.StandardButton.Yes
-                )
-                if choice == QMessageBox.StandardButton.No:
-                    dialog.hide()
-                    return
-
-        thread.join()
-        dialog.hide()
+        return cancelled
 
     def _resolve_meta_labels(self, raw_header):
         sid, page, shelf, title = self._get_meta_for_header(raw_header)


### PR DESCRIPTION
## Summary
- move metadata fetching to a cancellable `ShelfmarkLoaderThread` that reports progress and errors
- refactor metadata dialog to use a `QProgressDialog` with a cancel option instead of busy-waiting
- update consumers to handle new signals and cancellation outcomes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693661d60510832184ac0f32e24eafc8)