### PR TITLE
Ensure thumbnail updates use Qt signals

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -5,17 +5,40 @@ import sys
 import os
 import re
 import threading
+import requests
 from PyQt6.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,
                              QLabel, QLineEdit, QPushButton, QTabWidget, QTableWidget,
                              QTableWidgetItem, QHeaderView, QComboBox, QCheckBox,
                              QTextEdit, QMessageBox, QProgressBar, QSplitter, QDialog,
                              QTextBrowser, QFileDialog, QMenu, QGroupBox, QSpinBox,
                              QTreeWidget, QTreeWidgetItem, QPlainTextEdit, QStyle)
-from PyQt6.QtCore import Qt, QTimer, QUrl, QSize, pyqtSignal
-from PyQt6.QtGui import QFont, QIcon, QDesktopServices, QGuiApplication, QAction
+from PyQt6.QtCore import Qt, QTimer, QUrl, QSize, pyqtSignal, QObject
+from PyQt6.QtGui import QFont, QIcon, QDesktopServices, QGuiApplication, QAction, QPixmap, QImage
 
 from genizah_core import Config, MetadataManager, VariantManager, SearchEngine, Indexer, AIManager
 from gui_threads import SearchThread, IndexerThread, ShelfmarkLoaderThread, CompositionThread, GroupingThread, AIWorkerThread
+
+
+class _ThumbnailDispatcher(QObject):
+    """Relay thumbnail UI updates onto the main Qt thread."""
+
+    apply = pyqtSignal(object)
+
+
+_thumbnail_dispatcher = None
+
+
+def _get_thumbnail_dispatcher():
+    """Return a singleton dispatcher bound to the QApplication thread."""
+    global _thumbnail_dispatcher
+    if _thumbnail_dispatcher is None:
+        app = QApplication.instance()
+        if app is None:
+            return None
+
+        _thumbnail_dispatcher = _ThumbnailDispatcher()
+        _thumbnail_dispatcher.apply.connect(lambda fn: fn())
+    return _thumbnail_dispatcher
 
 class HelpDialog(QDialog):
     """Display static HTML help content inside a simple dialog."""
@@ -155,6 +178,7 @@ class ResultDialog(QDialog):
         self.current_sys_id = None
         self.current_p_num = None
         self.current_fl_id = None
+        self.current_thumb_url = None
         
         self.current_meta_request = 0
 
@@ -220,6 +244,13 @@ class ResultDialog(QDialog):
         self.lbl_info.setStyleSheet("background-color: #ecf0f1; color: #2c3e50; border-radius: 6px; padding: 8px;")
         self.lbl_info.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
         header_layout.addWidget(self.lbl_info, 1)
+
+        self.lbl_thumb = QLabel("No preview available")
+        self.lbl_thumb.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.lbl_thumb.setFixedSize(220, 220)
+        self.lbl_thumb.setStyleSheet("border: 1px solid #bdc3c7; background: #f8f9fa; color: #7f8c8d;")
+        self.lbl_thumb.setScaledContents(True)
+        header_layout.addWidget(self.lbl_thumb)
         
         # --- Page Controls ---
         ctrl_layout = QVBoxLayout()
@@ -318,6 +349,9 @@ class ResultDialog(QDialog):
 
         info_html = f"<b>System ID:</b> {self.current_sys_id}<br><b>File ID (FL):</b> {self.current_fl_id or 'N/A'}"
         self.lbl_info.setText(info_html)
+        self.lbl_thumb.setText("Loading preview…")
+        self.lbl_thumb.setPixmap(QPixmap())
+        self.current_thumb_url = None
         
         self.spin_page.blockSignals(True); self.spin_page.setValue(self.current_p_num); self.spin_page.blockSignals(False)
         self.lbl_total.setText(f"/ {page_data['total_pages']}")
@@ -347,10 +381,31 @@ class ResultDialog(QDialog):
         self.lbl_title.setText(meta.get('title', ''))
         self.lbl_meta_loading.setVisible(False)
 
+        self.update_thumbnail(meta)
+
     def on_metadata_loaded(self, request_id, meta):
         if request_id != self.current_meta_request:
             return
         self.apply_metadata(meta or {})
+
+    def update_thumbnail(self, meta):
+        thumb_url = meta.get('thumb_url') if meta else None
+
+        if meta and not meta.get('thumb_checked'):
+            def worker():
+                url = self.meta_mgr.get_thumbnail(self.current_sys_id)
+                QTimer.singleShot(0, lambda: self._apply_thumbnail(url))
+
+            threading.Thread(target=worker, daemon=True).start()
+            return
+
+        self._apply_thumbnail(thumb_url)
+
+    def _apply_thumbnail(self, thumb_url):
+        if thumb_url == self.current_thumb_url:
+            return
+        self.current_thumb_url = thumb_url
+        load_thumbnail_to_label(self.lbl_thumb, thumb_url)
 
     def open_catalog(self):
         if self.current_sys_id: QDesktopServices.openUrl(QUrl(f"https://www.nli.org.il/he/discover/manuscripts/hebrew-manuscripts/itempage?vid=KTIV&scope=KTIV&docId=PNX_MANUSCRIPTS{self.current_sys_id}"))
@@ -404,6 +459,7 @@ class GenizahGUI(QMainWindow):
             self.meta_cached_count = 0
             self.meta_to_fetch_count = 0
             self.meta_progress_current = 0
+            self.browse_thumb_url = None
 
             self.init_ui() # בונה את self.tabs
             
@@ -588,6 +644,14 @@ class GenizahGUI(QMainWindow):
         meta_col.addWidget(self.browse_info_lbl)
         meta_col.addWidget(self.browse_title_lbl)
         info_row.addLayout(meta_col, 1)
+
+        self.browse_thumb = QLabel("No preview available")
+        self.browse_thumb.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.browse_thumb.setFixedSize(200, 200)
+        self.browse_thumb.setStyleSheet("border: 1px solid #95a5a6; background: #fafafa; color: #7f8c8d;")
+        self.browse_thumb.setScaledContents(True)
+        info_row.addWidget(self.browse_thumb)
+
         self.btn_b_catalog = QPushButton("Go to Ktiv Catalog")
         self.btn_b_catalog.clicked.connect(self.browse_open_catalog)
         self.btn_b_catalog.setEnabled(False)
@@ -1386,6 +1450,9 @@ class GenizahGUI(QMainWindow):
         if not sid: return
         self.current_browse_sid = sid; self.current_browse_p = None
         self.btn_b_catalog.setEnabled(True)
+        self.browse_thumb.setText("Loading preview…")
+        self.browse_thumb.setPixmap(QPixmap())
+        self.browse_thumb_url = None
         self.browse_update_view(0)
 
     def browse_navigate(self, d): self.browse_update_view(d)
@@ -1400,15 +1467,38 @@ class GenizahGUI(QMainWindow):
             meta = self.meta_mgr.fetch_nli_data(self.current_browse_sid)
             title = title or meta.get('title', '')
             shelf = shelf or meta.get('shelfmark', '')
+        else:
+            meta = self.meta_mgr.nli_cache.get(self.current_browse_sid, {})
 
         self.browse_info_lbl.setText(f"{shelf} | Img: {pd['p_num']}")
         self.browse_title_lbl.setText(title or "")
         self.lbl_page_count.setText(f"{pd['current_idx']}/{pd['total_pages']}")
         self.btn_b_prev.setEnabled(pd['current_idx']>1); self.btn_b_next.setEnabled(pd['current_idx']<pd['total_pages'])
 
+        self.update_browse_thumbnail(meta)
+
     def browse_open_catalog(self):
         if self.current_browse_sid:
             QDesktopServices.openUrl(QUrl(f"https://www.nli.org.il/he/discover/manuscripts/hebrew-manuscripts/itempage?vid=KTIV&scope=KTIV&docId=PNX_MANUSCRIPTS{self.current_browse_sid}"))
+
+    def update_browse_thumbnail(self, meta):
+        thumb_url = meta.get('thumb_url') if meta else None
+
+        if meta and not meta.get('thumb_checked'):
+            def worker():
+                url = self.meta_mgr.get_thumbnail(self.current_browse_sid)
+                QTimer.singleShot(0, lambda: self._apply_browse_thumb(url))
+
+            threading.Thread(target=worker, daemon=True).start()
+            return
+
+        self._apply_browse_thumb(thumb_url)
+
+    def _apply_browse_thumb(self, thumb_url):
+        if thumb_url == self.browse_thumb_url:
+            return
+        self.browse_thumb_url = thumb_url
+        load_thumbnail_to_label(self.browse_thumb, thumb_url)
 
     def run_indexing(self):
         if QMessageBox.question(self, "Index", "Start indexing?", QMessageBox.StandardButton.Yes|QMessageBox.StandardButton.No) == QMessageBox.StandardButton.Yes:
@@ -1474,6 +1564,51 @@ def resource_path(relative_path):
     except Exception:
         base_path = os.path.dirname(os.path.abspath(__file__))
     return os.path.join(base_path, relative_path)
+
+
+def load_thumbnail_to_label(label, thumb_url):
+    """Fetch an external thumbnail and place it inside the provided QLabel."""
+    label.setPixmap(QPixmap())
+
+    if not thumb_url:
+        label.setText("Preview unavailable")
+        return
+
+    label.setProperty("thumb_url", thumb_url)
+    label.setText("Loading preview…")
+
+    def worker():
+        try:
+            resp = requests.get(thumb_url, timeout=10, proxies={}, allow_redirects=True, trust_env=False)
+            if resp.status_code != 200:
+                raise ValueError(f"Unexpected status: {resp.status_code}")
+
+            img = QImage.fromData(resp.content)
+            if img.isNull():
+                raise ValueError("Invalid image data")
+
+            def apply_image():
+                if label.property("thumb_url") != thumb_url:
+                    return
+                pix = QPixmap.fromImage(img)
+                scaled = pix.scaled(label.size(), Qt.AspectRatioMode.KeepAspectRatio, Qt.TransformationMode.SmoothTransformation)
+                label.setPixmap(scaled)
+                label.setText("")
+
+            dispatcher = _get_thumbnail_dispatcher()
+            if dispatcher:
+                dispatcher.apply.emit(apply_image)
+        except Exception:
+            def apply_error():
+                if label.property("thumb_url") != thumb_url:
+                    return
+                label.setText("Preview unavailable")
+
+            dispatcher = _get_thumbnail_dispatcher()
+            if dispatcher:
+                dispatcher.apply.emit(apply_error)
+
+    threading.Thread(target=worker, daemon=True).start()
 
 if __name__ == "__main__":
     try:

--- a/genizah_core.py
+++ b/genizah_core.py
@@ -362,14 +362,20 @@ class MetadataManager:
         return result
 
     def fetch_nli_data(self, system_id):
-        if system_id in self.nli_cache: return self.nli_cache[system_id]
+        if system_id in self.nli_cache:
+            meta = self.nli_cache[system_id]
+            if not meta.get('thumb_checked') or not meta.get('thumb_url'):
+                meta['thumb_url'] = meta.get('thumb_url') or self.get_thumbnail(system_id)
+                meta['thumb_checked'] = True
+            return meta
+
         _, meta = self._fetch_single_worker(system_id)
         self.nli_cache[system_id] = meta
         return meta
 
     def _fetch_single_worker(self, system_id):
         url = f"https://iiif.nli.org.il/IIIFv21/marc/bib/{system_id}"
-        meta = {'shelfmark': 'Unknown', 'title': '', 'desc': ''}
+        meta = {'shelfmark': 'Unknown', 'title': '', 'desc': '', 'fl_ids': [], 'thumb_url': None, 'thumb_checked': False}
         
         # כותרות כדי להיראות כמו דפדפן
         headers = {
@@ -384,13 +390,15 @@ class MetadataManager:
                 # המתנה קלה כדי לא להעמיס
                 time.sleep(0.3)
                 
-                resp = requests.get(url, headers=headers, timeout=5)
+                resp = requests.get(url, headers=headers, timeout=5, proxies={}, allow_redirects=True, trust_env=False)
                 
                 if resp.status_code == 200:
                     try:
                         root = ET.fromstring(resp.content)
                         # ... הלוגיקה הרגילה של ה-XML ...
                         c_942 = None; c_907 = None; c_090 = None; c_avd = None
+
+                        fl_ids = self._extract_fl_ids(root)
 
                         for df in root.findall('marc:datafield', self.ns):
                             tag = df.get('tag')
@@ -418,6 +426,10 @@ class MetadataManager:
 
                         final = c_942 or c_907 or c_090 or c_avd
                         if final: meta['shelfmark'] = final
+
+                        meta['fl_ids'] = fl_ids
+                        meta['thumb_url'] = self._resolve_thumbnail(fl_ids)
+                        meta['thumb_checked'] = True
                         
                         # הצלחה - צא מהלולאה והחזר תוצאה
                         return system_id, meta
@@ -436,6 +448,61 @@ class MetadataManager:
                 time.sleep(1)
         
         return system_id, meta
+
+    def _extract_fl_ids(self, root):
+        fl_ids = []
+        for df in root.findall("marc:datafield[@tag='907']", self.ns):
+            for sf in df.findall("marc:subfield[@code='d']", self.ns):
+                val = (sf.text or "").strip()
+                if val.startswith("FL"):
+                    fl_ids.append(val)
+        return fl_ids
+
+    def _resolve_thumbnail(self, fl_ids, size=320):
+        for fl_id in fl_ids:
+            base = f"https://iiif.nli.org.il/IIIFv21/{fl_id}"
+            try:
+                info = requests.get(f"{base}/info.json", timeout=5, proxies={}, allow_redirects=True, trust_env=False)
+                if info.status_code == 200:
+                    return f"{base}/full/!{size},{size}/0/default.jpg"
+            except Exception:
+                continue
+        return None
+
+    def _fetch_fl_ids(self, system_id):
+        url = f"https://iiif.nli.org.il/IIIFv21/marc/bib/{system_id}"
+        headers = {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+        }
+        try:
+            resp = requests.get(url, headers=headers, timeout=5, proxies={}, allow_redirects=True, trust_env=False)
+            if resp.status_code == 200:
+                root = ET.fromstring(resp.content)
+                return self._extract_fl_ids(root)
+        except Exception:
+            return []
+        return []
+
+    def get_thumbnail(self, system_id, size=320):
+        meta = self.nli_cache.get(system_id)
+        if meta and meta.get('thumb_checked') and meta.get('thumb_url'):
+            return meta.get('thumb_url')
+
+        fl_ids = []
+        if meta:
+            fl_ids = meta.get('fl_ids', [])
+        if not fl_ids:
+            fl_ids = self._fetch_fl_ids(system_id)
+
+        thumb_url = self._resolve_thumbnail(fl_ids, size=size)
+
+        if meta is None:
+            meta = {'shelfmark': 'Unknown', 'title': '', 'desc': '', 'fl_ids': fl_ids}
+        meta['fl_ids'] = fl_ids
+        meta['thumb_url'] = thumb_url
+        meta['thumb_checked'] = True
+        self.nli_cache[system_id] = meta
+        return thumb_url
         
     def batch_fetch_shelfmarks(self, system_ids, progress_callback=None):
         to_fetch = [sid for sid in system_ids if sid not in self.nli_cache]
@@ -465,7 +532,8 @@ class MetadataManager:
             'title': meta.get('title', ''),
             'img': p_num,
             'source': src_label,
-            'id': sys_id
+            'id': sys_id,
+            'thumb_url': meta.get('thumb_url')
         }
 
 # ==============================================================================


### PR DESCRIPTION
## Summary
- add a Qt signal dispatcher to relay thumbnail callbacks onto the main thread safely on PyQt6
- replace invokeMethod usage with dispatcher emits to avoid callable overload issues while keeping proxy-free fetches

## Testing
- python -m compileall genizah_app.py genizah_core.py gui_threads.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6936ec3648e08321883efbf11a229f72)