### PR TITLE
Fix requests trust_env usage for thumbnail loading

### DIFF
--- a/genizah_core.py
+++ b/genizah_core.py
@@ -236,6 +236,12 @@ class MetadataManager:
         self._load_caches()
         threading.Thread(target=self._build_file_map_background, daemon=True).start()
 
+    def _make_session(self):
+        session = requests.Session()
+        session.trust_env = False
+        session.proxies = {}
+        return session
+
     def _load_caches(self):
         self._load_metadata_bank()
         if os.path.exists(Config.CACHE_NLI):
@@ -362,14 +368,20 @@ class MetadataManager:
         return result
 
     def fetch_nli_data(self, system_id):
-        if system_id in self.nli_cache: return self.nli_cache[system_id]
+        if system_id in self.nli_cache:
+            meta = self.nli_cache[system_id]
+            if not meta.get('thumb_checked') or not meta.get('thumb_url'):
+                meta['thumb_url'] = meta.get('thumb_url') or self.get_thumbnail(system_id)
+                meta['thumb_checked'] = True
+            return meta
+
         _, meta = self._fetch_single_worker(system_id)
         self.nli_cache[system_id] = meta
         return meta
 
     def _fetch_single_worker(self, system_id):
         url = f"https://iiif.nli.org.il/IIIFv21/marc/bib/{system_id}"
-        meta = {'shelfmark': 'Unknown', 'title': '', 'desc': ''}
+        meta = {'shelfmark': 'Unknown', 'title': '', 'desc': '', 'fl_ids': [], 'thumb_url': None, 'thumb_checked': False}
         
         # כותרות כדי להיראות כמו דפדפן
         headers = {
@@ -384,13 +396,16 @@ class MetadataManager:
                 # המתנה קלה כדי לא להעמיס
                 time.sleep(0.3)
                 
-                resp = requests.get(url, headers=headers, timeout=5)
+                session = self._make_session()
+                resp = session.get(url, headers=headers, timeout=5, allow_redirects=True)
                 
                 if resp.status_code == 200:
                     try:
                         root = ET.fromstring(resp.content)
                         # ... הלוגיקה הרגילה של ה-XML ...
                         c_942 = None; c_907 = None; c_090 = None; c_avd = None
+
+                        fl_ids = self._extract_fl_ids(root)
 
                         for df in root.findall('marc:datafield', self.ns):
                             tag = df.get('tag')
@@ -418,6 +433,10 @@ class MetadataManager:
 
                         final = c_942 or c_907 or c_090 or c_avd
                         if final: meta['shelfmark'] = final
+
+                        meta['fl_ids'] = fl_ids
+                        meta['thumb_url'] = self._resolve_thumbnail(fl_ids, session=session)
+                        meta['thumb_checked'] = True
                         
                         # הצלחה - צא מהלולאה והחזר תוצאה
                         return system_id, meta
@@ -436,6 +455,63 @@ class MetadataManager:
                 time.sleep(1)
         
         return system_id, meta
+
+    def _extract_fl_ids(self, root):
+        fl_ids = []
+        for df in root.findall("marc:datafield[@tag='907']", self.ns):
+            for sf in df.findall("marc:subfield[@code='d']", self.ns):
+                val = (sf.text or "").strip()
+                if val.startswith("FL"):
+                    fl_ids.append(val)
+        return fl_ids
+
+    def _resolve_thumbnail(self, fl_ids, size=320, session=None):
+        session = session or self._make_session()
+        for fl_id in fl_ids:
+            base = f"https://iiif.nli.org.il/IIIFv21/{fl_id}"
+            try:
+                info = session.get(f"{base}/info.json", timeout=5, allow_redirects=True)
+                if info.status_code == 200:
+                    return f"{base}/full/!{size},{size}/0/default.jpg"
+            except Exception:
+                continue
+        return None
+
+    def _fetch_fl_ids(self, system_id):
+        url = f"https://iiif.nli.org.il/IIIFv21/marc/bib/{system_id}"
+        headers = {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+        }
+        try:
+            session = self._make_session()
+            resp = session.get(url, headers=headers, timeout=5, allow_redirects=True)
+            if resp.status_code == 200:
+                root = ET.fromstring(resp.content)
+                return self._extract_fl_ids(root)
+        except Exception:
+            return []
+        return []
+
+    def get_thumbnail(self, system_id, size=320):
+        meta = self.nli_cache.get(system_id)
+        if meta and meta.get('thumb_checked') and meta.get('thumb_url'):
+            return meta.get('thumb_url')
+
+        fl_ids = []
+        if meta:
+            fl_ids = meta.get('fl_ids', [])
+        if not fl_ids:
+            fl_ids = self._fetch_fl_ids(system_id)
+
+        thumb_url = self._resolve_thumbnail(fl_ids, size=size)
+
+        if meta is None:
+            meta = {'shelfmark': 'Unknown', 'title': '', 'desc': '', 'fl_ids': fl_ids}
+        meta['fl_ids'] = fl_ids
+        meta['thumb_url'] = thumb_url
+        meta['thumb_checked'] = True
+        self.nli_cache[system_id] = meta
+        return thumb_url
         
     def batch_fetch_shelfmarks(self, system_ids, progress_callback=None):
         to_fetch = [sid for sid in system_ids if sid not in self.nli_cache]
@@ -465,7 +541,8 @@ class MetadataManager:
             'title': meta.get('title', ''),
             'img': p_num,
             'source': src_label,
-            'id': sys_id
+            'id': sys_id,
+            'thumb_url': meta.get('thumb_url')
         }
 
 # ==============================================================================


### PR DESCRIPTION
## Summary
- replace unsupported trust_env request parameters with sessions configured to ignore proxy environment variables
- keep thumbnail downloads and IIIF metadata resolution proxy-free using shared session helpers

## Testing
- python -m compileall genizah_app.py genizah_core.py gui_threads.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6936ec3648e08321883efbf11a229f72)