### PR TITLE
Respect environment proxies for requests

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -1577,16 +1577,9 @@ def load_thumbnail_to_label(label, thumb_url):
     label.setProperty("thumb_url", thumb_url)
     label.setText("Loading preview…")
 
-    def _make_proxy_free_session():
-        session = requests.Session()
-        if hasattr(session, "trust_env"):
-            session.trust_env = False
-        session.proxies = {}
-        return session
-
     def worker():
         try:
-            session = _make_proxy_free_session()
+            session = requests.Session()
             resp = session.get(thumb_url, timeout=10, allow_redirects=True)
             if resp.status_code != 200:
                 raise ValueError(f"Unexpected status: {resp.status_code}")

--- a/genizah_core.py
+++ b/genizah_core.py
@@ -237,11 +237,7 @@ class MetadataManager:
         threading.Thread(target=self._build_file_map_background, daemon=True).start()
 
     def _make_session(self):
-        session = requests.Session()
-        if hasattr(session, "trust_env"):
-            session.trust_env = False
-        session.proxies = {}
-        return session
+        return requests.Session()
 
     def _load_caches(self):
         self._load_metadata_bank()


### PR DESCRIPTION
## Summary
- allow thumbnail fetches to use default network configuration instead of forcing proxies off
- update metadata session creation to respect environment proxy settings

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693701fe16f083219a17fd7aa28401d1)