### PR TITLE
Standardize concise English comments

### DIFF
--- a/debug_full_gui.py
+++ b/debug_full_gui.py
@@ -5,10 +5,10 @@ from PyQt6.QtWidgets import QApplication, QMainWindow, QPushButton, QLabel, QVBo
 from PyQt6.QtCore import QThread, pyqtSignal, Qt
 from PyQt6.QtGui import QImage, QPixmap, QImageReader
 
-# השתקת אזהרות SSL כפי שעשינו בתוכנה
+# Silence SSL warnings for test run
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-# כתובת שידועה כעובדת מהבדיקה הקודמת שלך
+# Known-good test URL
 TEST_URL = "https://iiif.nli.org.il/IIIFv21/FL160999962/full/400,/0/default.jpg"
 
 class DebugThread(QThread):
@@ -39,7 +39,7 @@ class DebugThread(QThread):
                 self.load_failed.emit("Empty response body")
                 return
 
-            # הדפסת התחלת הקובץ כדי לראות אם זה באמת תמונה או HTML שגיאה
+            # Print first bytes to confirm image vs. HTML error page
             first_bytes = data[:20]
             print(f"[THREAD] First 20 bytes: {first_bytes}")
 
@@ -82,7 +82,7 @@ class DebugWindow(QMainWindow):
         container.setLayout(layout)
         self.setCentralWidget(container)
         
-        # בדיקת תמיכה בפורמטים
+        # Report supported image formats
         formats = [fmt.data().decode("ascii") for fmt in QImageReader.supportedImageFormats()]
         print(f"[MAIN] Supported Image Formats on this system: {formats}")
 
@@ -90,7 +90,7 @@ class DebugWindow(QMainWindow):
         self.lbl_status.setText("Downloading...")
         self.btn_start.setEnabled(False)
         
-        # שמירה כמשתנה מחלקה כדי למנוע Garbage Collection
+        # Keep reference to avoid premature garbage collection
         self.worker = DebugThread()
         self.worker.image_loaded.connect(self.on_success)
         self.worker.load_failed.connect(self.on_fail)

--- a/genizah_core.py
+++ b/genizah_core.py
@@ -879,7 +879,7 @@ class SearchEngine:
                     
                     # CRITICAL FIX: Filter out 1-letter noise variants
                     # If original was >1 char, variant must be >1 char.
-                    # This prevents "דא" becoming "ר" and matching everything in the universe.
+                    # Prevents single-letter fallbacks that over-match
                     if len(term) > 1 and len(v) < 2:
                         continue
                         
@@ -910,14 +910,14 @@ class SearchEngine:
             
             # 3. Sort by LENGTH (Descending)
             # This is the correct fix for the visual glitch. 
-            # It ensures "וידא" matches before "דא".
+            # Favor longer matches before short variants
             unique_vars = sorted(list(set(vars_list)), key=len, reverse=True)
             
             # 4. Escape special chars
             escaped = [re.escape(v) for v in unique_vars]
             
             # 5. Simple Group (Removed strict Lookbehind/Lookahead)
-            # This allows finding "והמילה" even if searching "מילה"
+            # Allow prefix matches when search term appears inside a word
             parts.append(f"({'|'.join(escaped)})")
 
         if max_gap == 0:


### PR DESCRIPTION
## Summary
- replace Hebrew comments with concise English descriptions in the debug helper and main UI
- clarify export workflows with focused notes on highlight handling and column sizing
- simplify search engine comment examples to concise guidance

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693fc13695e48321bd02ee13d6628c73)