### PR TITLE
Fix browse view rendering syntax error

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -2460,9 +2460,11 @@ class GenizahGUI(QMainWindow):
     def browse_update_view(self, d):
         pd = self.searcher.get_browse_page(self.current_browse_sid, self.current_browse_p, d)
         if not pd: QMessageBox.warning(self, tr("Nav"), tr("Not found or end.")); return
-        
+
         self.current_browse_p = pd['p_num']
-        self.browse_text.setHtml(f"<div dir='rtl'>{pd['text'].replace('\n', '<br>')}</div>")
+        # Preprocess the text outside the f-string to avoid backslash parsing issues
+        browse_html_text = pd['text'].replace('\n', '<br>')
+        self.browse_text.setHtml(f"<div dir='rtl'>{browse_html_text}</div>")
         
         full_header = pd.get('full_header', '')
         _, _, shelf, title = self._get_meta_for_header(full_header)


### PR DESCRIPTION
## Summary
- preprocess browse text before formatting HTML to avoid invalid f-string escape handling

## Testing
- python -m py_compile *.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693ff0a4af748321be481aebfdf43910)