### PR TITLE
Add openpyxl dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests
 google-generativeai
 tqdm
 colorama
+openpyxl


### PR DESCRIPTION
## Summary
- add the openpyxl package to the Python requirements to support Excel handling
- attempted a clean dependency install to verify the updated requirements

## Testing
- pip install -r requirements.txt *(fails: cannot reach PyPI for openpyxl due to proxy 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6942f7298cf0832180b422b8a7e0260d)