### PR TITLE
Handle missing tantivy dependency gracefully

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -24,7 +24,22 @@ from PyQt6.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout, QH
 from PyQt6.QtCore import Qt, QTimer, QUrl, QSize, pyqtSignal, QThread, QEventLoop 
 from PyQt6.QtGui import QFont, QIcon, QDesktopServices, QPixmap, QImage
 
-from genizah_core import Config, MetadataManager, VariantManager, SearchEngine, Indexer, AIManager, tr, save_language, CURRENT_LANG, check_external_services, get_logger
+_CORE_IMPORT_ERROR = None
+try:
+    from genizah_core import Config, MetadataManager, VariantManager, SearchEngine, Indexer, AIManager, tr, save_language, CURRENT_LANG, check_external_services, get_logger
+except ImportError as import_error:
+    _CORE_IMPORT_ERROR = import_error
+
+if _CORE_IMPORT_ERROR:
+    def _show_core_import_error(err):
+        app = QApplication.instance() or QApplication(sys.argv)
+        QMessageBox.critical(None, "Missing dependency", str(err))
+
+    if __name__ == "__main__":
+        _show_core_import_error(_CORE_IMPORT_ERROR)
+        sys.exit(1)
+    else:
+        raise _CORE_IMPORT_ERROR
 from gui_threads import SearchThread, IndexerThread, ShelfmarkLoaderThread, CompositionThread, GroupingThread, AIWorkerThread, StartupThread, ConnectivityThread
 from filter_text_dialog import FilterTextDialog
 

--- a/genizah_core.py
+++ b/genizah_core.py
@@ -22,11 +22,6 @@ import json
 from genizah_translations import TRANSLATIONS
 
 try:
-    import tantivy
-except ImportError:
-    raise ImportError(tr("Tantivy library missing. Please install it."))
-
-try:
     import google.generativeai as genai
     HAS_GENAI = True
 except ImportError:
@@ -143,6 +138,11 @@ def tr(text):
     if CURRENT_LANG == 'he':
         return TRANSLATIONS.get(text, text)
     return text
+
+try:
+    import tantivy
+except ImportError:
+    raise ImportError(tr("Tantivy library missing. Please install it."))
 
 def check_external_services(extra_endpoints=None, timeout=3):
     """Check whether core external services respond within a short timeout."""

--- a/tests/test_missing_tantivy.py
+++ b/tests/test_missing_tantivy.py
@@ -1,0 +1,17 @@
+import importlib
+import sys
+from unittest import TestCase, mock
+
+
+class MissingTantivyImportTest(TestCase):
+    def test_genizah_core_reports_missing_tantivy_cleanly(self):
+        sys.modules.pop("genizah_core", None)
+
+        with mock.patch.dict(sys.modules, {"tantivy": None}):
+            with self.assertRaises(ImportError) as ctx:
+                importlib.import_module("genizah_core")
+
+        self.assertIn("Tantivy library missing", str(ctx.exception))
+        self.assertNotIsInstance(ctx.exception, NameError)
+
+        sys.modules.pop("genizah_core", None)


### PR DESCRIPTION
## Summary
- move the translation helper initialization ahead of the tantivy import to avoid NameError and keep the missing dependency message consistent
- surface a clear GUI error and exit when genizah_core cannot import due to missing tantivy
- add a unit test to ensure missing dependencies raise a clean ImportError instead of NameError

## Testing
- python -m unittest tests.test_missing_tantivy


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6942f72b8da883219cc911909a06c670)