### PR TITLE
Bump version to 3.2.1 and stabilize test imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 **עברית למטה**
 
-# 📜 Genizah Search Pro 3.2
+# 📜 Genizah Search Pro 3.2.1
 
 **The Ultimate Search & Analysis Tool for the Cairo Genizah Corpus**
 
@@ -13,6 +13,10 @@ Genizah Search Pro is a powerful desktop application designed for researchers wo
 > This is required to support the new line-by-line display and metadata search features.
 
 ---
+
+## 🚀 What's New in Version 3.2.1?
+* **🧪 More reliable packaging checks:** Test runs now locate the app modules even when using pytest's importlib mode, ensuring missing dependencies like Tantivy surface with clear messaging before creating the EXE.
+* **🏷️ Version sync:** The app title, About panel, and Windows App ID now pull from a single version constant for consistent EXE metadata.
 
 ## 🚀 What's New in Version 3.2?
 * **📊 Expanded Export Options:** You can now export search results and composition reports directly to **Excel (.xlsx)** and **CSV** formats, in addition to standard Text files.
@@ -63,7 +67,7 @@ Genizah Search Pro is a powerful desktop application designed for researchers wo
 
 ## 🛠 Installation
 
-1.  **Download:** Get the latest `GenizahSearchPro_v3.2.zip` from the releases page.
+1.  **Download:** Get the latest `GenizahSearchPro_v3.2.1.zip` from the releases page.
 2.  **Extract:** Unzip to the folder where the Transcriptions.txt file exists (see below).
 3.  **Required Data Files:**
     Ensure the following files are inside the folder next to `GenizahPro.exe`:
@@ -127,7 +131,7 @@ This tool relies on the **MiDRASH** project dataset:
 This project is licensed under the **MIT License** - see the [LICENSE](LICENSE) file for details.
 
 ---
-# 📜 Genizah Search Pro 3.2
+# 📜 Genizah Search Pro 3.2.1
 
 **כלי החיפוש והניתוח האולטימטיבי לקורפוס הגניזה הקהירית**
 
@@ -140,6 +144,10 @@ Genizah Search Pro היא אפליקציית שולחן עבודה עוצמתי�
 > פעולה זו נדרשת כדי לתמוך בתצוגה החדשה שורה-אחר-שורה ובאפשרויות החיפוש במטא-דאטה.
 
 ---
+
+## 🚀 מה חדש בגרסה 3.2.1?
+* **🧪 אמינות בדיקות:** הרצת הבדיקות מאתרת את מודולי האפליקציה גם במצב ה-importlib של pytest, כך שהודעות חסר (למשל Tantivy) יופיעו בבירור לפני יצירת ה-EXE.
+* **🏷️ סנכרון גרסה:** כותרת האפליקציה, מסך האודות ו-App ID ב-Windows משתמשים כעת בערך גרסה אחד כדי לשמור על עקביות באריזה.
 
 ## 🚀 מה חדש בגרסה 3.2?
 * **📊 אפשרויות ייצוא מורחבות:** כעת ניתן לייצא את תוצאות החיפוש ודוחות חיפוש החיבורים ישירות לפורמטים **Excel (.xlsx)** ו-**CSV**, בנוסף לקבצי טקסט רגילים.
@@ -190,7 +198,7 @@ Genizah Search Pro היא אפליקציית שולחן עבודה עוצמתי�
 
 ## 🛠 התקנה
 
-1.  **הורדה:** הורידו את `GenizahSearchPro_v3.2.zip` העדכני מדף השחרורים (Releases).
+1.  **הורדה:** הורידו את `GenizahSearchPro_v3.2.1.zip` העדכני מדף השחרורים (Releases).
 2.  **חילוץ:** חלצו את ה-zip לתיקייה שבה נמצא הקובץ Transcriptions.txt (ראו למטה).
 3.  **קבצי נתונים נדרשים:**
     ודאו שהקבצים הבאים נמצאים בתיקייה לצד `GenizahPro.exe`:

--- a/genizah_app.py
+++ b/genizah_app.py
@@ -24,6 +24,8 @@ from PyQt6.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout, QH
 from PyQt6.QtCore import Qt, QTimer, QUrl, QSize, pyqtSignal, QThread, QEventLoop 
 from PyQt6.QtGui import QFont, QIcon, QDesktopServices, QPixmap, QImage
 
+from version import APP_VERSION
+
 _CORE_IMPORT_ERROR = None
 try:
     from genizah_core import Config, MetadataManager, VariantManager, SearchEngine, Indexer, AIManager, tr, save_language, CURRENT_LANG, check_external_services, get_logger
@@ -688,7 +690,7 @@ class GenizahGUI(QMainWindow):
     
     def __init__(self):
         super().__init__()
-        self.setWindowTitle("Genizah Search Pro V3.2")
+        self.setWindowTitle(tr(f"Genizah Search Pro V{APP_VERSION}"))
         self.resize(1300, 850)
         log_tls_relaxation_notice()
 
@@ -1341,7 +1343,7 @@ class GenizahGUI(QMainWindow):
         </style>
         <div style='font-family: Arial; font-size: 13px;'>
             <div style='text-align:center;'>
-                <h2 style='margin-bottom:5px;'>Genizah Search Pro 3.2</h2>
+                <h2 style='margin-bottom:5px;'>Genizah Search Pro {APP_VERSION}</h2>
                 <p style='color: #7f8c8d;'>Developed by Hillel Gershuni (<a href='mailto:gershuni@gmail.com'>gershuni@gmail.com</a>)</p>
             </div>
             <hr>
@@ -2801,7 +2803,7 @@ if __name__ == "__main__":
     try:
         import ctypes
         if hasattr(ctypes, 'windll'):
-            myappid = 'genizah.search.pro.3.2'
+            myappid = f'genizah.search.pro.{APP_VERSION}'
             ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(myappid)
     except (ImportError, AttributeError):
         pass

--- a/genizah_translations.py
+++ b/genizah_translations.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
+from version import APP_VERSION
 
 TRANSLATIONS = {
     # --- General ---
-    "Genizah Search Pro V3.2": "Genizah Search Pro V3.2",
+    f"Genizah Search Pro V{APP_VERSION}": f"Genizah Search Pro V{APP_VERSION}",
     "Initializing components... Please wait.": "מאתחל רכיבים... אנא המתן.",
     "Fatal Error": "שגיאה קריטית",
     "Failed to initialize:\n{}": "אתחול נכשל:\n{}",
@@ -265,20 +266,20 @@ TRANSLATIONS = {
     </ul></div>""",
 
     # --- HTML About ---
-    "ABOUT_HTML": """
+    "ABOUT_HTML": f"""
         <style>
-            h3 { margin-bottom: 0px; margin-top: 10px; }
-            p { margin-top: 5px; margin-bottom: 5px; line-height: 1.4; }
-            a { color: #2980b9; text-decoration: none; }
+            h3 {{ margin-bottom: 0px; margin-top: 10px; }}
+            p {{ margin-top: 5px; margin-bottom: 5px; line-height: 1.4; }}
+            a {{ color: #2980b9; text-decoration: none; }}
         </style>
         <div style='font-family: Arial; font-size: 13px;' dir='rtl'>
             <div style='text-align:center;'>
-                <h2 s1yle='margin-bottom:5px;'>Genizah Search Pro 3.2</h2>
+                <h2 style='margin-bottom:5px;'>Genizah Search Pro {APP_VERSION}</h2>
                 <p style='color: #7f8c8d;'>פותח על ידי הלל גרשוני (<a href='mailto:gershuni@gmail.com'>gershuni@gmail.com</a>)</p>
             </div>
             <hr>
 
-            <h3>מוקדש לזכרו של מורנו האהוב, פרופ' מנחם כהנא ז"ל</h3>
+            <h3>מוקדש לזכרו של מורנו האהוב, פרופ' מנחם כהנא ז\"ל</h3>
             <h3>קרדיטים</h3>
             <p>כלי זה פותח בסיוע <b>Gemini 3.0</b> ו-<b>GPT 5.1</b>. תודתי נתונה לאבי שמידמן, אלישע רוזנצוייג, אפרים מאירי, אלעזר גרשוני, איתי קגן ואלנתן חן על עצותיהם ותמיכתם.</p>
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Test configuration for ensuring project modules are importable."""
+
+import sys
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+ROOT_PATH = str(ROOT_DIR)
+
+if ROOT_PATH not in sys.path:
+    sys.path.insert(0, ROOT_PATH)

--- a/version.py
+++ b/version.py
@@ -1,0 +1,3 @@
+"""Centralized version definition for the Genizah Search Pro application."""
+
+APP_VERSION = "3.2.1"


### PR DESCRIPTION
## Summary
- update the app to version 3.2.1 and centralize the version string for the UI and Windows App ID
- refresh the README and About content to reflect the new release and ensure formatting is correct
- add pytest configuration so core modules import correctly when Tantivy is missing

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69438d86b6d88321aa66e479f1eb60e5)