### PR TITLE
Add FL-targeted browsing and page-aware actions from manuscript viewer

### DIFF
--- a/genizah_core.py
+++ b/genizah_core.py
@@ -1538,3 +1538,21 @@ class SearchEngine:
             'full_header': target_page['full_header'], 'text': text,
             'total_pages': len(pages), 'current_idx': new_idx + 1
         }
+
+    def get_browse_page_by_fl(self, sys_id, fl_id):
+        if not os.path.exists(Config.BROWSE_MAP): return None
+        with open(Config.BROWSE_MAP, 'rb') as f: browse_map = pickle.load(f)
+        if sys_id not in browse_map: return None
+        pages = browse_map[sys_id]
+        if not pages: return None
+
+        for i, p in enumerate(pages):
+            parsed = self.parse_full_id_components(p.get('full_header', ''))
+            if parsed.get('fl_id') and str(parsed['fl_id']) == str(fl_id):
+                text = self.get_full_text_by_id(p['uid'])
+                return {
+                    'uid': p['uid'], 'p_num': p['p_num'],
+                    'full_header': p['full_header'], 'text': text,
+                    'total_pages': len(pages), 'current_idx': i + 1
+                }
+        return None

--- a/genizah_translations.py
+++ b/genizah_translations.py
@@ -53,6 +53,8 @@ TRANSLATIONS = {
     "Search Help": "עזרה בחיפוש",
     "System ID": "מספר מערכת",
     "System ID:": "מספר מערכת:",
+    "FL:": "FL:",
+    "Enter FL...": "הכנס FL...",
     "Shelfmark": "מספר מדף",
     "Title": "כותרת",
     "Snippet": "קטע",
@@ -69,6 +71,9 @@ TRANSLATIONS = {
     "Metadata Error": "שגיאת נתונים",
     "Metadata load cancelled. Loaded {}/{}.": "טעינת נתונים בוטלה. נטענו {}/{}.",
     "Loaded {} items.": "נטענו {} פריטים.",
+    "View full transcription": "צפה בתעתיק מלא",
+    "Search for parallels": "חפש מקבילות",
+    "No System ID found for this result.": "לא נמצא מספר מערכת עבור תוצאה זו.",
 
     # --- Search Modes & Tooltips ---
     "Exact": "מדויק",
@@ -143,6 +148,8 @@ TRANSLATIONS = {
     "Waiting...": "ממתין...",
     "Not found or end.": "לא נמצא או סוף הקובץ.",
     "Nav": "ניווט",
+    "Please enter a System ID.": "אנא הכנס מספר מערכת.",
+    "FL not found for this manuscript.": "לא נמצא מספר קובץ לכתב יד זה.",
     "Loading full manuscript...": "טוען כתב יד מלא...",
     "Could not load full text.": "לא ניתן לטעון טקסט מלא.",
     "Continuous View": "תצוגה רציפה",


### PR DESCRIPTION
### Motivation
- Enable jumping from a search `ResultDialog` directly to a specific page (FL) inside the Browse tab rather than always to the start of the manuscript. 
- Make the two action buttons (`View full transcription`, `Search for parallels`) operate from the contextual manuscript viewer and respect the currently displayed page. 
- Ensure composition-search handoff uses the exact page text currently shown in the viewer. 
- Provide minimal UI support and translations for FL input and related messages.

### Description
- Moved the action buttons into the `ResultDialog` header and wired them to call the main-window handlers and then close the viewer, so both actions now close the dialog after navigating. 
- Added a new core API `get_browse_page_by_fl` in `genizah_core.py` and a `browse_fl_input` field in the Browse tab so `open_result_in_browse` can target an FL page (sets `browse_fl_input` and calls `browse_load`). 
- Updated `open_result_in_browse` to accept an optional `fl_id` and set the Browse UI to that FL, and updated `send_result_to_composition` to accept a provided `source_text` (the viewer passes `current_page_text`) so parallel search is based on the currently displayed page. 
- Added `browse_render_page` helper to render a single page in the Browse tab, populate the FL input from the page header, and added translations for the new FL-related labels/messages and the two action strings.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6947debcdb6c83219e860971d613cdd8)