### PR TITLE
Add full recursive composition search with selectable result checkboxes

### DIFF
--- a/genizah_translations.py
+++ b/genizah_translations.py
@@ -107,6 +107,8 @@ TRANSLATIONS = {
     "Move titles appearing > X times to Appendix": "העבר כותרות המופיעות מעל X פעמים לנספח",
     "Analyze Composition": "נתח חיבור",
     "Analyze": "נתח",
+    "Full Recursive Search": "חיפוש רקורסיבי מלא",
+    "Recursive Search in Results": "חיפוש רקורסיבי בתוצאות",
     "Context": "הקשר",
     "Save Report": "שמור דוח",
     "Composition Help": "עזרה בחיפוש מקבילות",
@@ -132,6 +134,8 @@ TRANSLATIONS = {
     "Fetching metadata before export...": "טוען נתונים לפני ייצוא...",
     "Loading missing metadata...": "טוען נתונים חסרים...",
     "No items.": "אין פריטים.",
+    "No Data": "אין נתונים",
+    "Could not load full text for selected results.": "לא ניתן לטעון טקסט מלא עבור התוצאות שנבחרו.",
 
     # --- Browse Tab ---
     "Enter System ID...": "הכנס מספר מערכת...",


### PR DESCRIPTION
### Motivation
- Provide a “Full Recursive Search” mode that can re-run a composition search using the original text plus full texts of result pages. 
- Allow users to restrict recursive searches to a selected subset of results by choosing items in the composition results tree. 
- Make it easy to select all results or subgroups via root/group checkboxes and improve checkbox visibility (including dark mode). 

### Description
- Added a new `Full Recursive Search` button which becomes `Recursive Search in Results` when any items are checked, and wired `run_recursive_composition` to collect either selected UIDs or all result UIDs and fetch their full texts via `searcher.get_full_text_by_id(uid)` before calling `run_composition(custom_text=...)`.
- Made composition tree nodes checkable (including root and group nodes) and implemented check propagation and sync with `on_comp_tree_item_changed`, `_set_child_check_state`, `_sync_parent_check_state`, `_collect_checked_comp_page_uids`, and `_collect_all_comp_page_uids`.
- Updated `run_composition` to accept an optional `custom_text` argument and to disable the recursive button during runs, and added a QTreeWidget stylesheet to improve checkbox indicator visibility and dark-mode contrast.
- Updated translations in `genizah_translations.py` for the new button labels and user messages.

### Testing
- No automated tests were executed for this change."}

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6947f0b8d3d88321868e05339a9d3cbc)