### PR TITLE
Improve grouping progress reporting across main and filtered results

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -2268,8 +2268,10 @@ class GenizahGUI(QMainWindow):
         self.btn_comp_run.setText(tr("Stop"))
         self.btn_comp_run.setStyleSheet("background-color: #c0392b; color: white;")
         self.comp_progress.setVisible(True)
-        total_items = (len(items) if items else 0) + (len(filtered_items) if filtered_items else 0)
-        self.comp_progress.setRange(0, total_items)
+        total_steps = self.searcher.group_composition_total_steps(items)
+        if filtered_items:
+            total_steps += self.searcher.group_composition_total_steps(filtered_items)
+        self.comp_progress.setRange(0, total_steps)
         self.comp_progress.setValue(0)
         self.comp_progress.setFormat(tr("Grouping compositions..."))
 

--- a/genizah_core.py
+++ b/genizah_core.py
@@ -1498,7 +1498,7 @@ class SearchEngine:
                 if sig in cand['clean']: matches.append(cand)
                 compare_batch += 1
                 if compare_batch >= compare_batch_size:
-                    bump_progress(compare_batch)
+                    bump_progress()
                     compare_batch = 0
             if len(matches) > threshold:
                 for m in matches:
@@ -1508,7 +1508,7 @@ class SearchEngine:
             bump_progress()
 
         if compare_batch:
-            bump_progress(compare_batch)
+            bump_progress()
         
         if progress_callback and progress_total:
             progress_callback(progress_offset + total_steps, progress_total)
@@ -1520,7 +1520,9 @@ class SearchEngine:
     def group_composition_total_steps(self, items):
         item_count = len(items) if items else 0
         comparisons = item_count * (item_count - 1) if item_count > 1 else 0
-        return (item_count * 3) + comparisons + 1
+        compare_batch_size = 200
+        comparison_batches = (comparisons + compare_batch_size - 1) // compare_batch_size
+        return (item_count * 3) + comparison_batches + 1
 
     def get_full_text_by_id(self, uid):
         try:

--- a/gui_threads.py
+++ b/gui_threads.py
@@ -115,9 +115,17 @@ class GroupingThread(QThread):
             # 1. Group Main Items
             def cb1(curr, total): self.progress_signal.emit(curr, total)
             self.status_signal.emit("Grouping main results...")
+            main_steps = self.searcher.group_composition_total_steps(self.items)
+            filt_steps = self.searcher.group_composition_total_steps(self.filtered_items)
+            total_steps = main_steps + filt_steps
 
             result_main = self.searcher.group_composition_results(
-                self.items, self.threshold, progress_callback=cb1, check_cancel=check
+                self.items,
+                self.threshold,
+                progress_callback=cb1,
+                check_cancel=check,
+                progress_offset=0,
+                progress_total=total_steps,
             )
             if not result_main or result_main[0] is None:
                 return # Cancelled
@@ -131,7 +139,12 @@ class GroupingThread(QThread):
                 def cb2(curr, total): self.progress_signal.emit(curr, total)
 
                 result_filt = self.searcher.group_composition_results(
-                    self.filtered_items, self.threshold, progress_callback=cb2, check_cancel=check
+                    self.filtered_items,
+                    self.threshold,
+                    progress_callback=cb2,
+                    check_cancel=check,
+                    progress_offset=main_steps,
+                    progress_total=total_steps,
                 )
                 if not result_filt or result_filt[0] is None:
                     return # Cancelled


### PR DESCRIPTION
### Motivation
- The grouping phase reported progress only inside the main loop and performed heavy preprocessing before any progress updates, causing the progress bar to stay stuck then jump to 100%. 
- The UI computed the progress range from the number of items but callbacks reported per-phase totals, producing inconsistent ranges and jumps. 
- Grouping work consists of multiple logical steps (ID extraction, metadata fetch, wrapping, matching) that should be reflected in a single continuous progress scale. 

### Description
- Expanded `SearchEngine.group_composition_results` to accept `progress_offset` and `progress_total`, and added an internal `bump_progress` call to emit absolute progress updates at key steps. 
- Added `SearchEngine.group_composition_total_steps` helper to compute a consistent total number of progress steps for a given item list. 
- Updated `GroupingThread` in `gui_threads.py` to compute `total_steps` for main and filtered sets and pass `progress_offset`/`progress_total` so callbacks emit a unified progress range. 
- Adjusted `start_grouping` in `genizah_app.py` to set the progress bar range to the combined `group_composition_total_steps` of main and filtered items. 

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6947fade6ff083218873ef54e194e32f)