### PR TITLE
Fix system ID lookup for composition search results

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -1869,7 +1869,17 @@ class GenizahGUI(QMainWindow):
         ResultDialog(self, sorted_results, row, self.meta_mgr, self.searcher).exec()
 
     def open_result_in_browse(self, res, shelfmark=None, title=None, fl_id=None):
-        sid = res['display'].get('id')
+        sid = None
+        if isinstance(res, dict):
+            display = res.get('display')
+            if isinstance(display, dict):
+                sid = display.get('id')
+            if not sid:
+                sid = res.get('sys_id')
+            if not sid:
+                raw_header = res.get('raw_header') or res.get('full_header')
+                if raw_header:
+                    sid, _ = self.meta_mgr.parse_header_smart(raw_header)
         if not sid:
             QMessageBox.warning(self, tr("Error"), tr("No System ID found for this result."))
             return


### PR DESCRIPTION
### Motivation
- The "View full transcription" action could fail for composition/grouping results because the code only checked `res['display']['id']` and raised a "No System ID" warning even when an ID was available elsewhere.
- Composition/manuscript items sometimes carry their identifier as `sys_id` or only expose it in a `raw_header` that requires parsing with metadata utilities.

### Description
- Updated `open_result_in_browse` in `genizah_app.py` to safely resolve `sid` from multiple sources: `res['display']['id']`, `res['sys_id']`, and by parsing `raw_header`/`full_header` with `meta_mgr.parse_header_smart`.
- Added type checks and fallbacks so non-dict or partially populated result objects will not trigger a false "No System ID" warning.
- Preserved existing behavior for setting `browse_fl_input`, `browse_sys_input`, and loading the browse tab once `sid` is found.

### Testing
- No automated tests were run for this change.
- Local runtime behavior was validated during development (no CI run requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6948134a7894832180844eaea13b6221)