### PR TITLE
Add manuscript context column to composition results

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -1388,7 +1388,14 @@ class GenizahGUI(QMainWindow):
         inp_w.setLayout(in_l); splitter.addWidget(inp_w)
         
         res_w = QWidget(); rl = QVBoxLayout()
-        self.comp_tree = QTreeWidget(); self.comp_tree.setHeaderLabels([tr("Score"), tr("Shelfmark"), tr("Title"), tr("System ID"), tr("Context")])
+        self.comp_tree = QTreeWidget(); self.comp_tree.setHeaderLabels([
+            tr("Score"),
+            tr("Shelfmark"),
+            tr("Title"),
+            tr("System ID"),
+            tr("Context"),
+            tr("Manuscript Context"),
+        ])
         self.comp_tree.itemChanged.connect(self.on_comp_tree_item_changed)
         self.comp_tree_updating = False
         self.comp_tree.setStyleSheet(
@@ -1401,6 +1408,7 @@ class GenizahGUI(QMainWindow):
         # Configure columns width
         header = self.comp_tree.header()
         header.setSectionResizeMode(4, QHeaderView.ResizeMode.Stretch)
+        header.setSectionResizeMode(5, QHeaderView.ResizeMode.Stretch)
         header.setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents) # Shelfmark
         header.setSectionResizeMode(3, QHeaderView.ResizeMode.ResizeToContents) # System ID
 
@@ -2710,19 +2718,19 @@ class GenizahGUI(QMainWindow):
                     # Update Shelfmark to include Image info
                     ms_node.setText(1, f"{shelf or tr('Unknown Shelfmark')} ({tr('Image')} {p_num})")
 
-                    # Show snippet in Context column
-                    lbl = make_snippet_label(p_item.get('text', ''))
-                    self.comp_tree.setItemWidget(ms_node, 4, lbl)
+                    # Show source context and manuscript snippet
+                    src_lbl = make_snippet_label(p_item.get('source_ctx', ''))
+                    ms_lbl = make_snippet_label(p_item.get('text', ''))
+                    self.comp_tree.setItemWidget(ms_node, 4, src_lbl)
+                    self.comp_tree.setItemWidget(ms_node, 5, ms_lbl)
 
                 # Case B: Multiple Pages -> Add children
                 else:
-                    # Update parent with first page image info and snippet
+                    # Update parent with first page image info (no previews on parent)
                     if pages:
                         p0 = pages[0]
                         _, p0_num, _, _ = self._get_meta_for_header(p0['raw_header'])
                         ms_node.setText(1, f"{shelf or tr('Unknown Shelfmark')} ({tr('Image')} {p0_num}...)")
-                        lbl_main = make_snippet_label(p0.get('text', ''))
-                        self.comp_tree.setItemWidget(ms_node, 4, lbl_main)
 
                     for p_item in pages:
                         _, p_num, _, _ = self._get_meta_for_header(p_item['raw_header'])
@@ -2736,9 +2744,11 @@ class GenizahGUI(QMainWindow):
 
                         page_node.setData(0, Qt.ItemDataRole.UserRole, p_item)
 
-                        # Snippet for Page
-                        lbl = make_snippet_label(p_item.get('text', ''))
-                        self.comp_tree.setItemWidget(page_node, 4, lbl)
+                        # Snippets for Page
+                        src_lbl = make_snippet_label(p_item.get('source_ctx', ''))
+                        ms_lbl = make_snippet_label(p_item.get('text', ''))
+                        self.comp_tree.setItemWidget(page_node, 4, src_lbl)
+                        self.comp_tree.setItemWidget(page_node, 5, ms_lbl)
 
             else:
                 # Fallback for raw items (should not happen with new logic, but safe to keep)
@@ -2750,8 +2760,10 @@ class GenizahGUI(QMainWindow):
                 node.setText(3, sid)
                 make_checkable(node)
                 node.setData(0, Qt.ItemDataRole.UserRole, ms_item)
-                lbl = make_snippet_label(ms_item.get('text', ''))
-                self.comp_tree.setItemWidget(node, 4, lbl)
+                src_lbl = make_snippet_label(ms_item.get('source_ctx', ''))
+                ms_lbl = make_snippet_label(ms_item.get('text', ''))
+                self.comp_tree.setItemWidget(node, 4, src_lbl)
+                self.comp_tree.setItemWidget(node, 5, ms_lbl)
 
         # ----------------------------------------
 

--- a/genizah_translations.py
+++ b/genizah_translations.py
@@ -116,6 +116,7 @@ TRANSLATIONS = {
     "Full Recursive Search": "חיפוש רקורסיבי מלא",
     "Recursive Search in Results": "חיפוש רקורסיבי בתוצאות",
     "Context": "הקשר",
+    "Manuscript Context": "הקשר כתב יד",
     "Save Report": "שמור דוח",
     "Composition Help": "עזרה בחיפוש מקבילות",
     "Scanning chunks...": "סורק...", 


### PR DESCRIPTION
### Motivation
- Add a dedicated "Manuscript Context" preview column to composition search results so the snippet from the manuscript is shown separately from the source/context column. 
- Ensure the existing `Context` column continues to show the search source context while the new column shows the manuscript snippet with highlighted matches. 
- When a manuscript node has child page nodes, suppress the parent's inline manuscript preview so previews appear only on child pages. 
- Provide a translated label for the new column (`Manuscript Context` / "הקשר כתב יד").

### Description
- Added a new column to the composition results `QTreeWidget` header and configured resizing for the new `Manuscript Context` column. 
- Populated the existing `Context` column with `source_ctx` snippets and the new column with manuscript `text` snippets (both formatted via `make_snippet_label`).
- Removed setting an inline manuscript preview on parent manuscript nodes when they contain multiple page children so only child pages show previews. 
- Added a translation entry for `Manuscript Context` in `genizah_translations.py`.

### Testing
- No automated tests were run for this change. 
- Existing automated test suites were not executed as part of this change. 
- Manual runtime/UI verification is recommended before release. 
- No regressions detected by automated checks because none were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6948e498da2083219fd1e7a14e07f7b2)