### PR TITLE
Add manuscript-context column to composition results and show previews on page rows

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -1388,7 +1388,7 @@ class GenizahGUI(QMainWindow):
         inp_w.setLayout(in_l); splitter.addWidget(inp_w)
         
         res_w = QWidget(); rl = QVBoxLayout()
-        self.comp_tree = QTreeWidget(); self.comp_tree.setHeaderLabels([tr("ציון"), tr("Shelfmark"), tr("Title"), tr("System ID"), tr("Context"), tr("הקשר כתב יד")])
+        self.comp_tree = QTreeWidget(); self.comp_tree.setHeaderLabels([tr("score"), tr("Shelfmark"), tr("Title"), tr("System ID"), tr("Context"), tr("הקשר כתב יד")])
         self.comp_tree.itemChanged.connect(self.on_comp_tree_item_changed)
         self.comp_tree.itemExpanded.connect(self.on_comp_tree_item_expanded)
         self.comp_tree.itemCollapsed.connect(self.on_comp_tree_item_collapsed)

--- a/genizah_app.py
+++ b/genizah_app.py
@@ -1388,7 +1388,7 @@ class GenizahGUI(QMainWindow):
         inp_w.setLayout(in_l); splitter.addWidget(inp_w)
         
         res_w = QWidget(); rl = QVBoxLayout()
-        self.comp_tree = QTreeWidget(); self.comp_tree.setHeaderLabels([tr("Score"), tr("Shelfmark"), tr("Title"), tr("System ID"), tr("Context")])
+        self.comp_tree = QTreeWidget(); self.comp_tree.setHeaderLabels([tr("Score"), tr("Shelfmark"), tr("Title"), tr("System ID"), tr("Context"), tr("הקשר כתב יד")])
         self.comp_tree.itemChanged.connect(self.on_comp_tree_item_changed)
         self.comp_tree_updating = False
         self.comp_tree.setStyleSheet(
@@ -1401,6 +1401,7 @@ class GenizahGUI(QMainWindow):
         # Configure columns width
         header = self.comp_tree.header()
         header.setSectionResizeMode(4, QHeaderView.ResizeMode.Stretch)
+        header.setSectionResizeMode(5, QHeaderView.ResizeMode.Stretch)
         header.setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents) # Shelfmark
         header.setSectionResizeMode(3, QHeaderView.ResizeMode.ResizeToContents) # System ID
 
@@ -2672,6 +2673,10 @@ class GenizahGUI(QMainWindow):
             lbl.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
             return lbl
 
+        def set_context_widgets(node, source_ctx, manuscript_ctx):
+            self.comp_tree.setItemWidget(node, 4, make_snippet_label(source_ctx))
+            self.comp_tree.setItemWidget(node, 5, make_snippet_label(manuscript_ctx))
+
         def make_checkable(node):
             node.setFlags(node.flags() | Qt.ItemFlag.ItemIsUserCheckable | Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable)
             node.setCheckState(0, Qt.CheckState.Unchecked)
@@ -2710,19 +2715,16 @@ class GenizahGUI(QMainWindow):
                     # Update Shelfmark to include Image info
                     ms_node.setText(1, f"{shelf or tr('Unknown Shelfmark')} ({tr('Image')} {p_num})")
 
-                    # Show snippet in Context column
-                    lbl = make_snippet_label(p_item.get('text', ''))
-                    self.comp_tree.setItemWidget(ms_node, 4, lbl)
+                    # Show source context + manuscript snippet for single page
+                    set_context_widgets(ms_node, p_item.get('source_ctx', ''), p_item.get('text', ''))
 
                 # Case B: Multiple Pages -> Add children
                 else:
-                    # Update parent with first page image info and snippet
+                    # Update parent with first page image info only (no preview when children exist)
                     if pages:
                         p0 = pages[0]
                         _, p0_num, _, _ = self._get_meta_for_header(p0['raw_header'])
                         ms_node.setText(1, f"{shelf or tr('Unknown Shelfmark')} ({tr('Image')} {p0_num}...)")
-                        lbl_main = make_snippet_label(p0.get('text', ''))
-                        self.comp_tree.setItemWidget(ms_node, 4, lbl_main)
 
                     for p_item in pages:
                         _, p_num, _, _ = self._get_meta_for_header(p_item['raw_header'])
@@ -2736,9 +2738,8 @@ class GenizahGUI(QMainWindow):
 
                         page_node.setData(0, Qt.ItemDataRole.UserRole, p_item)
 
-                        # Snippet for Page
-                        lbl = make_snippet_label(p_item.get('text', ''))
-                        self.comp_tree.setItemWidget(page_node, 4, lbl)
+                        # Contexts for Page
+                        set_context_widgets(page_node, p_item.get('source_ctx', ''), p_item.get('text', ''))
 
             else:
                 # Fallback for raw items (should not happen with new logic, but safe to keep)
@@ -2750,8 +2751,7 @@ class GenizahGUI(QMainWindow):
                 node.setText(3, sid)
                 make_checkable(node)
                 node.setData(0, Qt.ItemDataRole.UserRole, ms_item)
-                lbl = make_snippet_label(ms_item.get('text', ''))
-                self.comp_tree.setItemWidget(node, 4, lbl)
+                set_context_widgets(node, ms_item.get('source_ctx', ''), ms_item.get('text', ''))
 
         # ----------------------------------------
 

--- a/genizah_app.py
+++ b/genizah_app.py
@@ -1393,6 +1393,7 @@ class GenizahGUI(QMainWindow):
         self.comp_tree.itemExpanded.connect(self.on_comp_tree_item_expanded)
         self.comp_tree.itemCollapsed.connect(self.on_comp_tree_item_collapsed)
         self.comp_tree_updating = False
+        self.comp_context_default_widths_set = False
         self.comp_tree.setStyleSheet(
             "QTreeWidget::indicator { width: 16px; height: 16px; }"
             "QTreeWidget::indicator:unchecked { border: 1px solid #9b9b9b; background: transparent; }"
@@ -1406,6 +1407,9 @@ class GenizahGUI(QMainWindow):
         header.setSectionResizeMode(5, QHeaderView.ResizeMode.Interactive)
         header.setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents) # Shelfmark
         header.setSectionResizeMode(3, QHeaderView.ResizeMode.ResizeToContents) # System ID
+        header.setSortIndicatorShown(True)
+        header.sortIndicatorChanged.connect(self.on_comp_tree_sort_changed)
+        header.sectionResized.connect(self._update_comp_tree_tooltips)
 
         self.comp_tree.setColumnWidth(0, 160) # Score - widened
 
@@ -1413,9 +1417,11 @@ class GenizahGUI(QMainWindow):
         title_width = self.comp_tree.fontMetrics().averageCharWidth() * 25
         self.comp_tree.setColumnWidth(2, int(title_width))
 
-        self.comp_tree.setSortingEnabled(True)
+        self.comp_tree.setSortingEnabled(False)
+        self.comp_tree.setSortRole(Qt.ItemDataRole.EditRole)
         self.comp_tree.itemDoubleClicked.connect(self.show_comp_detail)
         rl.addWidget(self.comp_tree)
+        QTimer.singleShot(0, self._set_comp_context_column_widths)
         
         exp_layout = QHBoxLayout()
         exp_layout.addWidget(QLabel(tr("Save Report")))
@@ -2682,7 +2688,11 @@ class GenizahGUI(QMainWindow):
             for col in range(4):
                 text = node.text(col)
                 if text:
-                    node.setToolTip(col, text)
+                    node.setToolTip(col, "")
+
+        def set_text(node, col, text):
+            node.setText(col, text)
+            node.setData(col, Qt.ItemDataRole.EditRole, text)
 
         def set_score(node, score):
             node.setText(0, str(score))
@@ -2711,9 +2721,9 @@ class GenizahGUI(QMainWindow):
                 # Manuscript Node
                 ms_node = QTreeWidgetItem(parent)
                 set_score(ms_node, ms_item.get('score', 0))
-                ms_node.setText(1, shelf or tr("Unknown Shelfmark"))
-                ms_node.setText(2, t or "")
-                ms_node.setText(3, sid)
+                set_text(ms_node, 1, shelf or tr("Unknown Shelfmark"))
+                set_text(ms_node, 2, t or "")
+                set_text(ms_node, 3, sid)
                 set_node_tooltips(ms_node)
                 make_checkable(ms_node)
 
@@ -2739,7 +2749,7 @@ class GenizahGUI(QMainWindow):
                     if pages:
                         p0 = pages[0]
                         _, p0_num, _, _ = self._get_meta_for_header(p0['raw_header'])
-                        ms_node.setText(1, f"{shelf or tr('Unknown Shelfmark')} ({tr('Image')} {p0_num}...)")
+                        set_text(ms_node, 1, f"{shelf or tr('Unknown Shelfmark')} ({tr('Image')} {p0_num}...)")
                         set_node_tooltips(ms_node)
                         set_context_widgets(ms_node, p0.get('source_ctx', ''), p0.get('text', ''))
 
@@ -2748,9 +2758,9 @@ class GenizahGUI(QMainWindow):
 
                         page_node = QTreeWidgetItem(ms_node)
                         set_score(page_node, p_item.get('score', ''))
-                        page_node.setText(1, f"{tr('Image')} {p_num}")
-                        page_node.setText(2, "") # No Title needed for page
-                        page_node.setText(3, "") # No SysID needed for page
+                        set_text(page_node, 1, f"{tr('Image')} {p_num}")
+                        set_text(page_node, 2, "") # No Title needed for page
+                        set_text(page_node, 3, "") # No SysID needed for page
                         set_node_tooltips(page_node)
                         make_checkable(page_node)
 
@@ -2764,9 +2774,9 @@ class GenizahGUI(QMainWindow):
                 sid, _, shelf, title = self._get_meta_for_header(ms_item.get('raw_header', ''))
                 node = QTreeWidgetItem(parent)
                 set_score(node, ms_item.get('score', ''))
-                node.setText(1, shelf)
-                node.setText(2, title)
-                node.setText(3, sid)
+                set_text(node, 1, shelf)
+                set_text(node, 2, title)
+                set_text(node, 3, sid)
                 set_node_tooltips(node)
                 make_checkable(node)
                 node.setData(0, Qt.ItemDataRole.UserRole, ms_item)
@@ -2831,8 +2841,9 @@ class GenizahGUI(QMainWindow):
                     add_manuscript_node(root_k, item)
 
         self.comp_tree.setUpdatesEnabled(True)
-        self.comp_tree.setSortingEnabled(True)
+        self.comp_tree.setSortingEnabled(False)
         self.comp_tree_updating = False
+        self._update_comp_tree_tooltips()
         self._update_recursive_button_state()
         if self.pending_recursive_search:
             self.pending_recursive_search = False
@@ -2865,13 +2876,29 @@ class GenizahGUI(QMainWindow):
         if snippet_html:
             lbl.setText(f"<div dir='rtl' style='margin:2px;'>{snippet_html}</div>")
         lbl.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
-        if full_html:
-            lbl.setToolTip(f"<div dir='rtl'>{full_html}</div>")
+        lbl.setProperty("full_html", full_html)
         return lbl
 
     def _set_comp_preview_widgets(self, node, source_ctx, manuscript_ctx):
         self.comp_tree.setItemWidget(node, 4, self._make_comp_preview_label(source_ctx))
         self.comp_tree.setItemWidget(node, 5, self._make_comp_preview_label(manuscript_ctx))
+
+    def _set_comp_context_column_widths(self):
+        if self.comp_context_default_widths_set:
+            return
+        if not hasattr(self, "comp_tree"):
+            return
+        viewport_width = self.comp_tree.viewport().width()
+        if viewport_width <= 0:
+            return
+        fixed_width = sum(self.comp_tree.columnWidth(i) for i in range(4))
+        remaining = max(0, viewport_width - fixed_width)
+        if remaining <= 0:
+            return
+        width = max(120, remaining // 2)
+        self.comp_tree.setColumnWidth(4, width)
+        self.comp_tree.setColumnWidth(5, width)
+        self.comp_context_default_widths_set = True
 
     def on_comp_tree_item_expanded(self, item):
         self._toggle_comp_parent_preview(item, hide=True)
@@ -2890,6 +2917,64 @@ class GenizahGUI(QMainWindow):
             self.comp_tree.setItemWidget(item, 5, QLabel(""))
         else:
             self._set_comp_preview_widgets(item, ctx.get("source_ctx", ""), ctx.get("manuscript_ctx", ""))
+        self._update_comp_tree_tooltips()
+
+    def on_comp_tree_sort_changed(self, column, order):
+        if column > 3:
+            return
+        root = self.comp_tree.invisibleRootItem()
+        for i in range(root.childCount()):
+            self._sort_comp_tree_node(root.child(i), column, order)
+
+    def _sort_comp_tree_node(self, node, column, order):
+        if not node or node.childCount() == 0:
+            return
+        children_have_data = False
+        for i in range(node.childCount()):
+            if node.child(i).data(0, Qt.ItemDataRole.UserRole):
+                children_have_data = True
+                break
+        if children_have_data:
+            node.sortChildren(column, order)
+        else:
+            for i in range(node.childCount()):
+                self._sort_comp_tree_node(node.child(i), column, order)
+
+    def _update_comp_tree_tooltips(self, *_):
+        if not hasattr(self, "comp_tree"):
+            return
+        fm = self.comp_tree.fontMetrics()
+
+        def update_node_tooltip(node):
+            for col in range(4):
+                text = node.text(col)
+                if not text:
+                    node.setToolTip(col, "")
+                    continue
+                col_width = self.comp_tree.columnWidth(col)
+                if fm.horizontalAdvance(text) > max(0, col_width - 8):
+                    node.setToolTip(col, text)
+                else:
+                    node.setToolTip(col, "")
+
+            for col in (4, 5):
+                lbl = self.comp_tree.itemWidget(node, col)
+                if not lbl:
+                    continue
+                full_html = lbl.property("full_html") or ""
+                col_width = self.comp_tree.columnWidth(col)
+                if full_html and lbl.sizeHint().width() > max(0, col_width - 8):
+                    lbl.setToolTip(f"<div dir='rtl'>{full_html}</div>")
+                else:
+                    lbl.setToolTip("")
+
+        root = self.comp_tree.invisibleRootItem()
+        stack = [root.child(i) for i in range(root.childCount())]
+        while stack:
+            node = stack.pop()
+            update_node_tooltip(node)
+            for i in range(node.childCount()):
+                stack.append(node.child(i))
 
     def on_comp_tree_item_changed(self, item, column):
         if self.comp_tree_updating or column != 0:
@@ -3106,12 +3191,11 @@ class GenizahGUI(QMainWindow):
             sys_id, _, shelf, title = self._get_meta_for_header(node_data.get('raw_header', ''))
 
             node.setText(1, shelf)
+            node.setData(1, Qt.ItemDataRole.EditRole, shelf)
             node.setText(2, title)
+            node.setData(2, Qt.ItemDataRole.EditRole, title)
             node.setText(3, sys_id or '')
-            for col in range(4):
-                text = node.text(col)
-                if text:
-                    node.setToolTip(col, text)
+            node.setData(3, Qt.ItemDataRole.EditRole, sys_id or '')
 
         root = self.comp_tree.invisibleRootItem()
         for i in range(root.childCount()):
@@ -3123,6 +3207,7 @@ class GenizahGUI(QMainWindow):
                         update_node(child.child(k))
                 else:
                     update_node(child)
+        self._update_comp_tree_tooltips()
 
     def export_comp_report(self, fmt='xlsx'):
         # 1. Collect composition results


### PR DESCRIPTION
### Motivation
- Provide a distinct preview of the matching text inside the manuscript separate from the source/context preview.  
- Allow seeing both the quoting source context and the manuscript snippet side-by-side for each result.  
- Avoid duplicating previews on parent manuscript nodes when that manuscript is expanded into page children.  

### Description
- Add a new tree column header `tr("הקשר כתב יד")` (Manuscript Context) and enable resize mode for the new column.  
- Introduce a helper `set_context_widgets(node, source_ctx, manuscript_ctx)` to render both the source context (column 4) and manuscript snippet (column 5) with highlighted matches.  
- Update `add_manuscript_node` so single-page manuscript nodes show both contexts, multi-page manuscript parent nodes show only image info (no preview), and child page nodes show both contexts.  
- Update fallback/raw items to populate both source and manuscript context widgets.  

### Testing
- No automated tests were executed for this change.  
- The change is limited to UI tree column layout and widget population logic and was committed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6948e498da2083219fd1e7a14e07f7b2)