### PR TITLE
Refine composition results UI and fix startup crash

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -1408,6 +1408,7 @@ class GenizahGUI(QMainWindow):
         header.setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents) # Shelfmark
         header.setSectionResizeMode(3, QHeaderView.ResizeMode.ResizeToContents) # System ID
         header.setSortIndicatorShown(True)
+        header.setSectionsClickable(True)
         header.sortIndicatorChanged.connect(self.on_comp_tree_sort_changed)
         header.sectionClicked.connect(self.on_comp_tree_section_clicked)
         header.sectionResized.connect(self._update_comp_tree_tooltips)


### PR DESCRIPTION
### Motivation
- Show a separate manuscript snippet column so the manuscript excerpt is distinct from the quoting/source context and is centered on the highlighted match.  
- Keep the parent-row preview visible by default but hide it while the manuscript node is expanded and restore it on collapse.  
- Make the two context columns resizable and provide tooltips only when a preview is truncated, and allow sorting by columns within manuscript groups while preserving top-level category order.  
- Fix the startup crash caused by an unsupported API and ensure numeric sorting for `Score` works correctly.  

### Description
- Added a new tree column header `tr("הקשר כתב יד")`, kept the `Score` header label, made context columns interactive, and set default balanced widths for the two context columns via `_set_comp_context_column_widths`.  
- Implemented preview helpers `
  _format_comp_preview_html`, `_make_comp_preview_label`, and `_set_comp_preview_widgets` to center displayed snippets around the `*highlighted*` span and attach full HTML for tooltips.  
- Added expand/collapse handlers `on_comp_tree_item_expanded` and `on_comp_tree_item_collapsed`, stored preview data on each item (`UserRole + 1`), and toggle parent previews with `_toggle_comp_parent_preview` so parents hide previews only while expanded.  
- Implemented intra-group sorting via `on_comp_tree_sort_changed` and `_sort_comp_tree_node`, set numeric `EditRole` for the score through `set_score`, removed the unsupported `QTreeWidget.setSortRole` call to fix the startup error, and added `_update_comp_tree_tooltips` to attach tooltips only when text/widgets do not fully fit.  

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6948e498da2083219fd1e7a14e07f7b2)