### PR TITLE
Refine lab mode search pipeline

### DIFF
--- a/gui_threads.py
+++ b/gui_threads.py
@@ -77,8 +77,10 @@ class LabSearchThread(QThread):
     def run(self):
         try:
             def cb(curr, total): self.progress_signal.emit(curr, total)
-            results = self.lab_engine.lab_search(self.query, mode=self.mode, progress_callback=cb, gap=self.gap)
-            self.results_signal.emit(results)
+            generator = self.lab_engine.lab_search(self.query, mode=self.mode, progress_callback=cb, gap=self.gap)
+            collected = list(generator)
+            deduped = self.lab_engine.deduplicate_lab_results(collected)
+            self.results_signal.emit(deduped)
         except Exception as e: self.error_signal.emit(str(e))
 
 class CompositionThread(QThread):


### PR DESCRIPTION
## Summary
- enforce a trigram tokenizer for lab indexing and rebuild with sliding-window candidate gathering
- replace lab search with a generator-based broad-net/fine-sieve pipeline that filters by minimum-should-match and reranks with sequence alignment
- surface new Lab Mode controls for recall (min-should-match) and precision (gap penalty) while deduplicating streamed results

## Testing
- python -m pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694b1dd02bd0832195bbb4a7c2f6632c)