### PR TITLE
Revamp lab mode search pipeline

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -108,7 +108,7 @@ class LabSettingsDialog(QDialog):
         self.spin_candidate_limit.setRange(500, 50000)
         self.spin_candidate_limit.setSingleStep(500)
         self.spin_candidate_limit.setValue(self.settings.candidate_limit)
-        self.spin_candidate_limit.setToolTip(tr("Max Stage 1 candidates (default 2000, max 50000)."))
+        self.spin_candidate_limit.setToolTip(tr("Max Stage 1 candidates (default 50000, max 50000)."))
 
         sens_layout.addWidget(QLabel(tr("Minimum Match %:")), 0, 0)
         sens_layout.addWidget(self.slider_min_match, 0, 1)


### PR DESCRIPTION
## Summary
- configure the Lab Mode index with a trigram tokenizer and fix query parsing to use schema field handles
- rebuild Lab Mode search as a generator-based broad-net/fine-sieve pipeline with sliding windows, OR trigram queries, and sequence-alignment reranking with minimum-should-match filtering
- raise Lab Mode candidate defaults and update settings UI help text to reflect the broader retrieval stage

## Testing
- python -m py_compile genizah_core.py genizah_app.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694b1dd02bd0832195bbb4a7c2f6632c)