### PR TITLE
Fix browse navigation syncing images by FL

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -573,6 +573,29 @@ class ManuscriptViewerWidget(QWidget):
         self.preload_worker = ImageLoaderThread(final)
         self.preload_worker.start()
 
+    def set_page_by_fl(self, fl_digits):
+        """Switch to the image whose FL matches the provided digits."""
+        if not fl_digits:
+            return self.set_page(self.current_idx)
+
+        idx = self._find_index_by_fl(fl_digits)
+        if idx is None:
+            return self.set_page(self.current_idx)
+
+        return self.set_page(idx)
+
+    def _find_index_by_fl(self, fl_digits):
+        """Find image index matching the FL digits (string)."""
+        clean = re.sub(r"\D", "", str(fl_digits))
+        if not clean or not self.active_list:
+            return None
+
+        for i, img in enumerate(self.active_list):
+            img_fl = re.sub(r"\D", "", str(img.get('fl_id', '')))
+            if img_fl and img_fl == clean:
+                return i
+        return None
+
     def set_page(self, index):
         if not self.active_list:
             self.scroll_area.set_image(None)
@@ -2480,10 +2503,14 @@ class GenizahGUI(QMainWindow):
         html = raw_text.replace("\n", "<br>")
         self.browse_text.setHtml(f"<div dir='rtl'>{html}</div>")
 
-        # Sync Image Viewer
-        try: idx = int(self.current_browse_p) - 1
-        except: idx = 0
-        self.browse_viewer.set_page(idx)
+        # Sync Image Viewer (prefer FL ID when available)
+        fl_digits = re.sub(r"\D", "", str(page_data.get('fl_id') or ""))
+        if fl_digits:
+            self.browse_viewer.set_page_by_fl(fl_digits)
+        else:
+            try: idx = int(self.current_browse_p) - 1
+            except: idx = 0
+            self.browse_viewer.set_page(idx)
 
     def browse_load_all(self):
         """Load all pages into the text browser for continuous scrolling."""

--- a/genizah_core.py
+++ b/genizah_core.py
@@ -1925,7 +1925,7 @@ class MetadataManager:
             sorted_map = sorted(nli_iiif_data['canvas_map'].items(), key=lambda x: x[0])
             for fl_id, label in sorted_map:
                 url = f"https://iiif.nli.org.il/IIIFv21/FL{fl_id}"
-                images_nli.append({'label': label, 'url': url})
+                images_nli.append({'label': label, 'url': url, 'fl_id': fl_id})
 
         if not current_meta.get('physical_desc'):
             current_meta['physical_desc'] = nli_iiif_data.get('physical_desc', '')
@@ -2933,10 +2933,12 @@ class SearchEngine:
         
         target_page = pages[new_idx]
         text = self.get_full_text_by_id(target_page['uid'])
+        parsed = self.meta_mgr.parse_full_id_components(target_page.get('full_header', ''))
         return {
             'uid': target_page['uid'], 'p_num': target_page['p_num'],
             'full_header': target_page['full_header'], 'text': text,
-            'total_pages': len(pages), 'current_idx': new_idx + 1
+            'total_pages': len(pages), 'current_idx': new_idx + 1,
+            'fl_id': parsed.get('fl_id')
         }
 
     def get_browse_page_by_fl(self, fl_id, sys_id=None):


### PR DESCRIPTION
## Summary
- include FL identifiers in NLI image metadata and browse page responses
- add viewer support to select images by FL ID and sync browse navigation
- update browse navigation to align images with text when moving between pages

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6952a1642c0083219dabcd49438ebf9b)