### PR TITLE
Align manuscript navigation images with text pages

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -1181,6 +1181,7 @@ class ResultDialog(QDialog):
         # State for internal browsing
         self.current_sys_id = None
         self.current_p_num = None
+        self.current_page_idx = None
         self.current_fl_id = None
         self.current_page_text = None
         self.current_page_uid = None
@@ -1476,6 +1477,7 @@ class ResultDialog(QDialog):
         if not page_data: return
 
         self.current_p_num = page_data['p_num']
+        self.current_page_idx = page_data.get('current_idx')
         parsed_new = self.meta_mgr.parse_full_id_components(page_data['full_header'])
         self.current_fl_id = parsed_new['fl_id']
         self.current_full_header = page_data.get('full_header', '')
@@ -1645,8 +1647,13 @@ class ResultDialog(QDialog):
             self.txt_ext_meta.setVisible(bool(meta_html))
 
             # Load images into widget
-            try: initial_idx = int(self.current_p_num) - 1
-            except: initial_idx = 0
+            try:
+                initial_idx = int(self.current_page_idx) - 1
+            except Exception:
+                try:
+                    initial_idx = int(self.current_p_num) - 1
+                except Exception:
+                    initial_idx = 0
 
             self.ms_viewer.load_images(meta, initial_idx)
         else:
@@ -1701,8 +1708,13 @@ class ResultDialog(QDialog):
 
     def sync_external_view(self):
         # Determine index
-        try: idx = int(self.current_p_num) - 1
-        except: idx = 0
+        try:
+            idx = int(self.current_page_idx) - 1
+        except Exception:
+            try:
+                idx = int(self.current_p_num) - 1
+            except Exception:
+                idx = 0
         self.ms_viewer.set_page(idx)
 
     def on_metadata_loaded(self, request_id, meta):
@@ -1898,6 +1910,7 @@ class GenizahGUI(QMainWindow):
         self.is_comp_running = False
         self.current_browse_sid = None
         self.current_browse_p = None
+        self.current_browse_idx = None
         self.meta_loader = None
         self.meta_cached_count = 0
         self.meta_to_fetch_count = 0
@@ -2437,8 +2450,13 @@ class GenizahGUI(QMainWindow):
         self.browse_info_lbl.setText(label_text)
 
         # 2. Populate Image Viewer (using new logic)
-        try: idx = int(self.current_browse_p) - 1
-        except: idx = 0
+        try:
+            idx = int(self.current_browse_idx) - 1
+        except Exception:
+            try:
+                idx = int(self.current_browse_p) - 1
+            except Exception:
+                idx = 0
         self.browse_viewer.load_images(meta, idx)
 
         # 3. Enable buttons
@@ -2469,6 +2487,7 @@ class GenizahGUI(QMainWindow):
             return
 
         self.current_browse_p = page_data['p_num']
+        self.current_browse_idx = page_data.get('current_idx')
 
         # Update Nav
         self.btn_b_prev.setEnabled(page_data['current_idx'] > 1)
@@ -2481,8 +2500,13 @@ class GenizahGUI(QMainWindow):
         self.browse_text.setHtml(f"<div dir='rtl'>{html}</div>")
 
         # Sync Image Viewer
-        try: idx = int(self.current_browse_p) - 1
-        except: idx = 0
+        try:
+            idx = int(self.current_browse_idx) - 1
+        except Exception:
+            try:
+                idx = int(self.current_browse_p) - 1
+            except Exception:
+                idx = 0
         self.browse_viewer.set_page(idx)
 
     def browse_load_all(self):
@@ -4950,6 +4974,7 @@ class GenizahGUI(QMainWindow):
 
         self.current_browse_sid = sid
         self.current_browse_p = page_data['p_num'] if page_data else None
+        self.current_browse_idx = page_data.get('current_idx') if page_data else None
         
         # Disable controls until loaded
         self.btn_b_catalog.setEnabled(False)
@@ -4989,6 +5014,7 @@ class GenizahGUI(QMainWindow):
 
         if page_data:
             self.current_browse_p = page_data['p_num']
+            self.current_browse_idx = page_data.get('current_idx')
             self.browse_load_page()
 
             # --- Preload Logic (Next/Prev) ---


### PR DESCRIPTION
## Summary
- track and persist page indices alongside page numbers in result and browse viewers
- use current index when setting manuscript images so next/previous navigation keeps images aligned with text
- maintain smooth navigation by updating index state on load and navigation actions

## Testing
- python -m compileall genizah_app.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6952a497e9e883219f9a4968e46838f8)