### PR TITLE
Fix image navigation alignment

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -1612,8 +1612,16 @@ class ResultDialog(QDialog):
         has_labels = False
         if canvas_map:
             self.combo_img_labels.addItem(tr("Select Image"), -1)
-            # Sort by FL for approximate order
-            for fl, lbl in sorted(canvas_map.items()):
+
+            def _fl_sort_key(item):
+                fl_digits = re.sub(r"\\D", "", str(item[0]))
+                try:
+                    return int(fl_digits)
+                except Exception:
+                    return fl_digits or 0
+
+            # Sort numerically so dropdown order mirrors manuscript pagination
+            for fl, lbl in sorted(canvas_map.items(), key=_fl_sort_key):
                 # We need to find which P corresponds to this FL.
                 # This is tricky without full manuscript map.
                 # However, SearchEngine.get_browse_page_by_fl can find P from FL.

--- a/genizah_core.py
+++ b/genizah_core.py
@@ -1922,7 +1922,15 @@ class MetadataManager:
         # 2b. Always Fetch NLI IIIF (for fallback or toggle)
         nli_iiif_data = self.fetch_iiif_manifest(system_id)
         if nli_iiif_data.get('canvas_map'):
-            sorted_map = sorted(nli_iiif_data['canvas_map'].items(), key=lambda x: x[0])
+            # Sort numerically so image order matches manuscript pagination
+            def _fl_sort_key(item):
+                fl_digits = re.sub(r"\D", "", str(item[0]))
+                try:
+                    return int(fl_digits)
+                except Exception:
+                    return fl_digits or 0
+
+            sorted_map = sorted(nli_iiif_data['canvas_map'].items(), key=_fl_sort_key)
             for fl_id, label in sorted_map:
                 url = f"https://iiif.nli.org.il/IIIFv21/FL{fl_id}"
                 images_nli.append({'label': label, 'url': url})


### PR DESCRIPTION
## Summary
- ensure NLI image lists use numeric sorting so image order matches manuscript pagination
- display the image-label dropdown in numeric order to align navigation with pages

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6952a497e9e883219f9a4968e46838f8)