### PR TITLE
Align manuscript navigation with image viewer

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -1184,6 +1184,7 @@ class ResultDialog(QDialog):
         self.current_fl_id = None
         self.current_page_text = None
         self.current_page_uid = None
+        self.current_page_idx = None
         
         self.current_meta_request = 0
         self.extended_info_visible = False
@@ -1407,8 +1408,11 @@ class ResultDialog(QDialog):
         # Parse Meta
         ids = self.meta_mgr.parse_full_id_components(data['raw_header'])
         self.current_sys_id = ids['sys_id']
-        try: p = int(ids['p_num']) 
+        try: p = int(ids['p_num'])
         except: p = 1
+
+        # Reset page index tracker for new result
+        self.current_page_idx = None
         
         # --- Prepare Text Content ---
         # 1. Manuscript Text (Apply Pattern!)
@@ -1476,6 +1480,7 @@ class ResultDialog(QDialog):
         if not page_data: return
 
         self.current_p_num = page_data['p_num']
+        self.current_page_idx = page_data.get('current_idx')
         parsed_new = self.meta_mgr.parse_full_id_components(page_data['full_header'])
         self.current_fl_id = parsed_new['fl_id']
         self.current_full_header = page_data.get('full_header', '')
@@ -1645,8 +1650,10 @@ class ResultDialog(QDialog):
             self.txt_ext_meta.setVisible(bool(meta_html))
 
             # Load images into widget
-            try: initial_idx = int(self.current_p_num) - 1
-            except: initial_idx = 0
+            try:
+                initial_idx = int(self.current_page_idx) - 1 if self.current_page_idx else int(self.current_p_num) - 1
+            except:
+                initial_idx = 0
 
             self.ms_viewer.load_images(meta, initial_idx)
         else:
@@ -1701,8 +1708,13 @@ class ResultDialog(QDialog):
 
     def sync_external_view(self):
         # Determine index
-        try: idx = int(self.current_p_num) - 1
-        except: idx = 0
+        try:
+            if self.current_page_idx:
+                idx = int(self.current_page_idx) - 1
+            else:
+                idx = int(self.current_p_num) - 1
+        except:
+            idx = 0
         self.ms_viewer.set_page(idx)
 
     def on_metadata_loaded(self, request_id, meta):
@@ -1898,6 +1910,7 @@ class GenizahGUI(QMainWindow):
         self.is_comp_running = False
         self.current_browse_sid = None
         self.current_browse_p = None
+        self.current_browse_idx = None
         self.meta_loader = None
         self.meta_cached_count = 0
         self.meta_to_fetch_count = 0
@@ -2437,7 +2450,8 @@ class GenizahGUI(QMainWindow):
         self.browse_info_lbl.setText(label_text)
 
         # 2. Populate Image Viewer (using new logic)
-        try: idx = int(self.current_browse_p) - 1
+        try:
+            idx = int(self.current_browse_idx) - 1 if self.current_browse_idx else int(self.current_browse_p) - 1
         except: idx = 0
         self.browse_viewer.load_images(meta, idx)
 
@@ -2469,6 +2483,7 @@ class GenizahGUI(QMainWindow):
             return
 
         self.current_browse_p = page_data['p_num']
+        self.current_browse_idx = page_data.get('current_idx')
 
         # Update Nav
         self.btn_b_prev.setEnabled(page_data['current_idx'] > 1)
@@ -2481,7 +2496,8 @@ class GenizahGUI(QMainWindow):
         self.browse_text.setHtml(f"<div dir='rtl'>{html}</div>")
 
         # Sync Image Viewer
-        try: idx = int(self.current_browse_p) - 1
+        try:
+            idx = int(self.current_browse_idx) - 1 if self.current_browse_idx else int(self.current_browse_p) - 1
         except: idx = 0
         self.browse_viewer.set_page(idx)
 
@@ -4950,6 +4966,7 @@ class GenizahGUI(QMainWindow):
 
         self.current_browse_sid = sid
         self.current_browse_p = page_data['p_num'] if page_data else None
+        self.current_browse_idx = page_data.get('current_idx') if page_data else None
         
         # Disable controls until loaded
         self.btn_b_catalog.setEnabled(False)
@@ -4989,6 +5006,7 @@ class GenizahGUI(QMainWindow):
 
         if page_data:
             self.current_browse_p = page_data['p_num']
+            self.current_browse_idx = page_data.get('current_idx')
             self.browse_load_page()
 
             # --- Preload Logic (Next/Prev) ---


### PR DESCRIPTION
## Summary
- track and store current page indexes so manuscript text and image viewers stay aligned when moving between pages or results
- update browse and result navigation to use browse map ordering when selecting images and syncing viewers

## Testing
- python -m compileall genizah_app.py genizah_core.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6952a497e9e883219f9a4968e46838f8)