### PR TITLE
Add IIIF attribution display and label navigation

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -554,6 +554,10 @@ class ManuscriptViewerWidget(QWidget):
         self.combo_source.setVisible(False)
         self.combo_source.currentIndexChanged.connect(self._on_source_changed)
 
+        self.combo_img_selector = QComboBox()
+        self.combo_img_selector.setVisible(False)
+        self.combo_img_selector.currentIndexChanged.connect(self._on_label_selected)
+
         btn_zoom_out = QPushButton("-")
         btn_zoom_out.setFixedWidth(30)
         btn_zoom_out.clicked.connect(lambda: self.scroll_area.zoom_out())
@@ -567,6 +571,7 @@ class ManuscriptViewerWidget(QWidget):
         self.btn_external.clicked.connect(self.open_external)
 
         top_bar.addWidget(self.combo_source)
+        top_bar.addWidget(self.combo_img_selector)
         top_bar.addStretch()
         top_bar.addWidget(self.btn_external)
         top_bar.addWidget(btn_zoom_out)
@@ -624,6 +629,8 @@ class ManuscriptViewerWidget(QWidget):
         self.external_url = marc.get('external_iiif_link')
         self.btn_external.setVisible(bool(self.external_url))
 
+        self._populate_label_selector()
+
         # Set Page
         self.set_page(initial_idx)
 
@@ -639,6 +646,8 @@ class ManuscriptViewerWidget(QWidget):
         # Try to keep index within bounds
         if self.current_idx >= len(self.active_list):
             self.current_idx = 0
+
+        self._populate_label_selector()
         self.set_page(self.current_idx)
 
     def _resolve_url(self, base_url):
@@ -683,12 +692,56 @@ class ManuscriptViewerWidget(QWidget):
         self.loader_thread.load_failed.connect(lambda: self.scroll_area.lbl_img.setText(tr("No Image")))
         self.loader_thread.start()
 
+        self._sync_label_selector()
+
         # Preload next image
         self._preload(index + 1)
 
     def display_image(self, image):
         pix = QPixmap.fromImage(image)
         self.scroll_area.set_image(pix)
+
+    def _populate_label_selector(self):
+        self.combo_img_selector.blockSignals(True)
+        self.combo_img_selector.clear()
+
+        if not self.active_list:
+            self.combo_img_selector.setVisible(False)
+            self.combo_img_selector.blockSignals(False)
+            return
+
+        for idx, img in enumerate(self.active_list):
+            lbl = img.get('label') or tr("Image") + f" {idx + 1}"
+            fl_hint = img.get('fl_id') or img.get('fl')
+            if fl_hint:
+                lbl = f"{lbl} (FL{fl_hint})"
+            self.combo_img_selector.addItem(lbl, idx)
+
+        self.combo_img_selector.setVisible(len(self.active_list) > 1)
+        self.combo_img_selector.blockSignals(False)
+
+        self._sync_label_selector()
+
+    def _sync_label_selector(self):
+        if not self.active_list:
+            self.combo_img_selector.setVisible(False)
+            return
+
+        if self.current_idx >= len(self.active_list):
+            return
+
+        self.combo_img_selector.blockSignals(True)
+        self.combo_img_selector.setCurrentIndex(self.current_idx)
+        self.combo_img_selector.blockSignals(False)
+
+    def _on_label_selected(self, combo_idx):
+        target_idx = self.combo_img_selector.currentData()
+        if target_idx is None:
+            return
+        try:
+            self.set_page(int(target_idx))
+        except Exception:
+            pass
 
     def open_external(self):
         if self.external_url:

--- a/genizah_core.py
+++ b/genizah_core.py
@@ -1776,13 +1776,13 @@ class MetadataManager:
         return meta
 
     def fetch_iiif_manifest(self, system_id):
-        """Fetch and parse IIIF manifest for physical description and image labels."""
+        """Fetch and parse IIIF manifest for physical description, attribution, and image labels."""
         url = f"https://iiif.nli.org.il/IIIFv21/DOCID/PNX_MANUSCRIPTS{system_id}-1/manifest"
         headers = {
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/91.0.4472.124 Safari/537.36"
         }
 
-        result = {'physical_desc': '', 'canvas_map': {}}
+        result = {'physical_desc': '', 'canvas_map': {}, 'attribution': ''}
         try:
             session = self._make_session()
             resp = session.get(url, headers=headers, timeout=10, verify=False)
@@ -1791,6 +1791,13 @@ class MetadataManager:
 
                 # 1. Physical Description
                 result['physical_desc'] = data.get('attribution', '')
+                attr_val = data.get('attribution')
+                if isinstance(attr_val, str):
+                    result['attribution'] = attr_val
+                elif isinstance(attr_val, list) and attr_val:
+                    result['attribution'] = str(attr_val[0])
+                elif data.get('label'):
+                    result['attribution'] = str(data.get('label'))
 
                 # 2. Canvas Map (FL -> Label)
                 if 'sequences' in data and data['sequences']:
@@ -1954,10 +1961,16 @@ class MetadataManager:
             sorted_map = sorted(nli_iiif_data['canvas_map'].items(), key=lambda x: x[0])
             for fl_id, label in sorted_map:
                 url = f"https://iiif.nli.org.il/IIIFv21/FL{fl_id}"
-                images_nli.append({'label': label, 'url': url})
+                images_nli.append({'label': label, 'url': url, 'fl_id': fl_id})
 
         if not current_meta.get('physical_desc'):
             current_meta['physical_desc'] = nli_iiif_data.get('physical_desc', '')
+
+        if not current_meta.get('attribution'):
+            current_meta['attribution'] = nli_iiif_data.get('attribution', '')
+
+        if nli_iiif_data.get('canvas_map'):
+            current_meta['canvas_map'] = nli_iiif_data['canvas_map']
 
         # Prioritize External if available, but keep both sets
         current_meta['images'] = images_ext if images_ext else images_nli

--- a/genizah_core.py
+++ b/genizah_core.py
@@ -1839,6 +1839,7 @@ class MetadataManager:
             'date': '',
             'subjects': [],
             'physical_medium': '',
+            'attribution': '',
             'online_link': None,
             'external_iiif_link': None
         }
@@ -1917,6 +1918,10 @@ class MetadataManager:
                         val = get_sub('z')
                         if val: result['shelfmark_alt'] = val
 
+                    elif tag == '597': # Image credit / attribution
+                        val = get_sub('a')
+                        if val: result['attribution'] = val
+
             return result
         except Exception as e:
             LOGGER.warning(f"MARC fetch failed for {system_id}: {e}")
@@ -1935,6 +1940,7 @@ class MetadataManager:
         # 1. Fetch MARC (Bibliographic Data)
         marc_data = self.fetch_marc_data(system_id)
         current_meta['marc'] = marc_data
+        marc_attribution = marc_data.get('attribution')
 
         # 2. Determine Image Source (External CUDL vs Fallback NLI)
         image_list = []
@@ -1953,7 +1959,8 @@ class MetadataManager:
             if ext_data.get('canvases'):
                 images_ext = ext_data['canvases'] # Format: [{'label': '...', 'url': '...'}]
                 external_meta = ext_data.get('metadata', {})
-                current_meta['attribution'] = ext_data.get('attribution')
+                if not marc_attribution:
+                    current_meta['attribution'] = ext_data.get('attribution')
 
         # 2b. Always Fetch NLI IIIF (for fallback or toggle)
         nli_iiif_data = self.fetch_iiif_manifest(system_id)
@@ -1966,7 +1973,9 @@ class MetadataManager:
         if not current_meta.get('physical_desc'):
             current_meta['physical_desc'] = nli_iiif_data.get('physical_desc', '')
 
-        if not current_meta.get('attribution'):
+        if marc_attribution:
+            current_meta['attribution'] = marc_attribution
+        elif not current_meta.get('attribution'):
             current_meta['attribution'] = nli_iiif_data.get('attribution', '')
 
         if nli_iiif_data.get('canvas_map'):


### PR DESCRIPTION
## Summary
- surface IIIF attribution details from manifests so viewer shows credit above images
- enrich NLI image entries with FL IDs and labels for label-aware navigation
- add image label selector that allows jumping between canvases without changing existing paging

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6953a05e32b88321997a18bdfc7fc13f)