### PR TITLE
Add rotation controls to manuscript viewer images

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -461,19 +461,19 @@ class ZoomableScrollArea(QScrollArea):
         self._pixmap = None
         self._zoom_factor = 1.0
         self._drag_start_pos = None
-        self._rotation_deg = 0
+        self._rotation = 0
 
         self.setCursor(Qt.CursorShape.OpenHandCursor)
 
     def set_image(self, pixmap):
         self._pixmap = pixmap
         self._zoom_factor = 1.0 # Reset zoom on new image
-        self._rotation_deg = 0
+        self._rotation = 0
         self._update_view()
 
-    def set_rotation(self, degrees: float):
-        """Set image rotation in degrees (clockwise)."""
-        self._rotation_deg = degrees % 360 if degrees is not None else 0
+    def rotate_view(self, degrees):
+        """Add degrees to current rotation and update."""
+        self._rotation = (self._rotation + degrees) % 360
         self._update_view()
 
     def _update_view(self):
@@ -481,10 +481,8 @@ class ZoomableScrollArea(QScrollArea):
             self.lbl_img.setText(tr("No Image"))
             return
 
-        source_pix = self._pixmap
-        if self._rotation_deg:
-            transform = QTransform().rotate(self._rotation_deg)
-            source_pix = self._pixmap.transformed(transform, Qt.TransformationMode.SmoothTransformation)
+        transform = QTransform().rotate(self._rotation)
+        source_pix = self._pixmap.transformed(transform, Qt.TransformationMode.SmoothTransformation)
 
         scaled_w = int(source_pix.width() * self._zoom_factor)
         scaled_h = int(source_pix.height() * self._zoom_factor)
@@ -575,27 +573,20 @@ class ManuscriptViewerWidget(QWidget):
         btn_zoom_in.clicked.connect(lambda: self.scroll_area.zoom_in())
 
         # Rotation controls
-        btn_rot_90 = QPushButton("90°")
-        btn_rot_90.setFixedWidth(45)
-        btn_rot_90.clicked.connect(lambda: self.apply_rotation_preset(90))
+        btn_rot_left = QPushButton("↺")
+        btn_rot_left.setToolTip(tr("Rotate Left"))
+        btn_rot_left.setFixedWidth(30)
+        btn_rot_left.clicked.connect(lambda: self.scroll_area.rotate_view(-90))
+
+        btn_rot_right = QPushButton("↻")
+        btn_rot_right.setToolTip(tr("Rotate Right"))
+        btn_rot_right.setFixedWidth(30)
+        btn_rot_right.clicked.connect(lambda: self.scroll_area.rotate_view(90))
 
         btn_rot_180 = QPushButton("180°")
-        btn_rot_180.setFixedWidth(55)
-        btn_rot_180.clicked.connect(lambda: self.apply_rotation_preset(180))
-
-        btn_rot_270 = QPushButton("270°")
-        btn_rot_270.setFixedWidth(55)
-        btn_rot_270.clicked.connect(lambda: self.apply_rotation_preset(270))
-
-        self.spin_rot_custom = QSpinBox()
-        self.spin_rot_custom.setRange(-359, 359)
-        self.spin_rot_custom.setValue(0)
-        self.spin_rot_custom.setSuffix("°")
-        self.spin_rot_custom.setFixedWidth(80)
-
-        btn_rot_apply = QPushButton(tr("Rotate"))
-        btn_rot_apply.setFixedWidth(65)
-        btn_rot_apply.clicked.connect(self.apply_custom_rotation)
+        btn_rot_180.setToolTip(tr("Rotate 180"))
+        btn_rot_180.setFixedWidth(40)
+        btn_rot_180.clicked.connect(lambda: self.scroll_area.rotate_view(180))
 
         self.btn_external = QPushButton(tr("External Site"))
         self.btn_external.setVisible(False)
@@ -604,11 +595,10 @@ class ManuscriptViewerWidget(QWidget):
         top_bar.addWidget(self.combo_source)
         top_bar.addStretch()
         top_bar.addWidget(self.btn_external)
-        top_bar.addWidget(btn_rot_90)
+        top_bar.addWidget(btn_rot_left)
+        top_bar.addWidget(btn_rot_right)
         top_bar.addWidget(btn_rot_180)
-        top_bar.addWidget(btn_rot_270)
-        top_bar.addWidget(self.spin_rot_custom)
-        top_bar.addWidget(btn_rot_apply)
+        top_bar.addSpacing(10)
         top_bar.addWidget(btn_zoom_out)
         top_bar.addWidget(btn_zoom_in)
 
@@ -666,7 +656,6 @@ class ManuscriptViewerWidget(QWidget):
 
         # Set Page
         self.set_page(initial_idx)
-        self.spin_rot_custom.setValue(0)
 
     def _on_source_changed(self):
         data = self.combo_source.currentData()
@@ -681,7 +670,6 @@ class ManuscriptViewerWidget(QWidget):
         if self.current_idx >= len(self.active_list):
             self.current_idx = 0
         self.set_page(self.current_idx)
-        self.spin_rot_custom.setValue(0)
 
     def _resolve_url(self, base_url):
         if not base_url: return None
@@ -731,18 +719,10 @@ class ManuscriptViewerWidget(QWidget):
     def display_image(self, image):
         pix = QPixmap.fromImage(image)
         self.scroll_area.set_image(pix)
-        self.spin_rot_custom.setValue(0)
 
     def open_external(self):
         if self.external_url:
              QDesktopServices.openUrl(QUrl(self.external_url))
-
-    def apply_rotation_preset(self, degrees):
-        self.spin_rot_custom.setValue(degrees)
-        self.scroll_area.set_rotation(degrees)
-
-    def apply_custom_rotation(self):
-        self.scroll_area.set_rotation(self.spin_rot_custom.value())
 
 class HiddenScrollArea(QScrollArea):
     def __init__(self, text_with_markers="", anchor_text=None, parent=None):

--- a/genizah_app.py
+++ b/genizah_app.py
@@ -24,7 +24,7 @@ from PyQt6.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout, QH
                              QGridLayout, QToolTip, QProgressDialog, QStackedLayout,
                              QScrollArea, QFrame, QSlider, QStyleOptionButton)
 from PyQt6.QtCore import Qt, QTimer, QUrl, QSize, pyqtSignal, QThread, QEventLoop, QEvent, QRect
-from PyQt6.QtGui import QFont, QIcon, QDesktopServices, QPixmap, QImage, QFontMetrics, QTextDocument
+from PyQt6.QtGui import QFont, QIcon, QDesktopServices, QPixmap, QImage, QFontMetrics, QTextDocument, QTransform
 
 from version import APP_VERSION
 
@@ -461,12 +461,19 @@ class ZoomableScrollArea(QScrollArea):
         self._pixmap = None
         self._zoom_factor = 1.0
         self._drag_start_pos = None
+        self._rotation_deg = 0
 
         self.setCursor(Qt.CursorShape.OpenHandCursor)
 
     def set_image(self, pixmap):
         self._pixmap = pixmap
         self._zoom_factor = 1.0 # Reset zoom on new image
+        self._rotation_deg = 0
+        self._update_view()
+
+    def set_rotation(self, degrees: float):
+        """Set image rotation in degrees (clockwise)."""
+        self._rotation_deg = degrees % 360 if degrees is not None else 0
         self._update_view()
 
     def _update_view(self):
@@ -474,11 +481,16 @@ class ZoomableScrollArea(QScrollArea):
             self.lbl_img.setText(tr("No Image"))
             return
 
-        scaled_w = int(self._pixmap.width() * self._zoom_factor)
-        scaled_h = int(self._pixmap.height() * self._zoom_factor)
+        source_pix = self._pixmap
+        if self._rotation_deg:
+            transform = QTransform().rotate(self._rotation_deg)
+            source_pix = self._pixmap.transformed(transform, Qt.TransformationMode.SmoothTransformation)
+
+        scaled_w = int(source_pix.width() * self._zoom_factor)
+        scaled_h = int(source_pix.height() * self._zoom_factor)
 
         # Keep aspect ratio
-        scaled_pix = self._pixmap.scaled(
+        scaled_pix = source_pix.scaled(
             scaled_w, scaled_h,
             Qt.AspectRatioMode.KeepAspectRatio,
             Qt.TransformationMode.SmoothTransformation
@@ -562,6 +574,29 @@ class ManuscriptViewerWidget(QWidget):
         btn_zoom_in.setFixedWidth(30)
         btn_zoom_in.clicked.connect(lambda: self.scroll_area.zoom_in())
 
+        # Rotation controls
+        btn_rot_90 = QPushButton("90°")
+        btn_rot_90.setFixedWidth(45)
+        btn_rot_90.clicked.connect(lambda: self.apply_rotation_preset(90))
+
+        btn_rot_180 = QPushButton("180°")
+        btn_rot_180.setFixedWidth(55)
+        btn_rot_180.clicked.connect(lambda: self.apply_rotation_preset(180))
+
+        btn_rot_270 = QPushButton("270°")
+        btn_rot_270.setFixedWidth(55)
+        btn_rot_270.clicked.connect(lambda: self.apply_rotation_preset(270))
+
+        self.spin_rot_custom = QSpinBox()
+        self.spin_rot_custom.setRange(-359, 359)
+        self.spin_rot_custom.setValue(0)
+        self.spin_rot_custom.setSuffix("°")
+        self.spin_rot_custom.setFixedWidth(80)
+
+        btn_rot_apply = QPushButton(tr("Rotate"))
+        btn_rot_apply.setFixedWidth(65)
+        btn_rot_apply.clicked.connect(self.apply_custom_rotation)
+
         self.btn_external = QPushButton(tr("External Site"))
         self.btn_external.setVisible(False)
         self.btn_external.clicked.connect(self.open_external)
@@ -569,6 +604,11 @@ class ManuscriptViewerWidget(QWidget):
         top_bar.addWidget(self.combo_source)
         top_bar.addStretch()
         top_bar.addWidget(self.btn_external)
+        top_bar.addWidget(btn_rot_90)
+        top_bar.addWidget(btn_rot_180)
+        top_bar.addWidget(btn_rot_270)
+        top_bar.addWidget(self.spin_rot_custom)
+        top_bar.addWidget(btn_rot_apply)
         top_bar.addWidget(btn_zoom_out)
         top_bar.addWidget(btn_zoom_in)
 
@@ -626,6 +666,7 @@ class ManuscriptViewerWidget(QWidget):
 
         # Set Page
         self.set_page(initial_idx)
+        self.spin_rot_custom.setValue(0)
 
     def _on_source_changed(self):
         data = self.combo_source.currentData()
@@ -640,6 +681,7 @@ class ManuscriptViewerWidget(QWidget):
         if self.current_idx >= len(self.active_list):
             self.current_idx = 0
         self.set_page(self.current_idx)
+        self.spin_rot_custom.setValue(0)
 
     def _resolve_url(self, base_url):
         if not base_url: return None
@@ -689,10 +731,18 @@ class ManuscriptViewerWidget(QWidget):
     def display_image(self, image):
         pix = QPixmap.fromImage(image)
         self.scroll_area.set_image(pix)
+        self.spin_rot_custom.setValue(0)
 
     def open_external(self):
         if self.external_url:
              QDesktopServices.openUrl(QUrl(self.external_url))
+
+    def apply_rotation_preset(self, degrees):
+        self.spin_rot_custom.setValue(degrees)
+        self.scroll_area.set_rotation(degrees)
+
+    def apply_custom_rotation(self):
+        self.scroll_area.set_rotation(self.spin_rot_custom.value())
 
 class HiddenScrollArea(QScrollArea):
     def __init__(self, text_with_markers="", anchor_text=None, parent=None):


### PR DESCRIPTION
## Summary
- add rotation controls to the manuscript image viewer with 90°, 180°, 270° presets and a custom degree field
- rotate images via QTransform while preserving zoom/drag behavior and reset rotation when switching images or sources

## Testing
- python -m compileall genizah_app.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6953ba7dad808321b85cfd2a8370ab5c)