### PR TITLE
Add rotation slider with synced toolbar buttons

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -24,7 +24,7 @@ from PyQt6.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout, QH
                              QGridLayout, QToolTip, QProgressDialog, QStackedLayout,
                              QScrollArea, QFrame, QSlider, QStyleOptionButton)
 from PyQt6.QtCore import Qt, QTimer, QUrl, QSize, pyqtSignal, QThread, QEventLoop, QEvent, QRect
-from PyQt6.QtGui import QFont, QIcon, QDesktopServices, QPixmap, QImage, QFontMetrics, QTextDocument
+from PyQt6.QtGui import QFont, QIcon, QDesktopServices, QPixmap, QImage, QFontMetrics, QTextDocument, QTransform
 
 from version import APP_VERSION
 
@@ -461,12 +461,19 @@ class ZoomableScrollArea(QScrollArea):
         self._pixmap = None
         self._zoom_factor = 1.0
         self._drag_start_pos = None
+        self._rotation = 0
 
         self.setCursor(Qt.CursorShape.OpenHandCursor)
 
     def set_image(self, pixmap):
         self._pixmap = pixmap
         self._zoom_factor = 1.0 # Reset zoom on new image
+        self._rotation = 0
+        self._update_view()
+
+    def set_rotation(self, angle):
+        """Set absolute rotation in degrees and refresh."""
+        self._rotation = (angle or 0) % 360
         self._update_view()
 
     def _update_view(self):
@@ -474,11 +481,14 @@ class ZoomableScrollArea(QScrollArea):
             self.lbl_img.setText(tr("No Image"))
             return
 
-        scaled_w = int(self._pixmap.width() * self._zoom_factor)
-        scaled_h = int(self._pixmap.height() * self._zoom_factor)
+        transform = QTransform().rotate(self._rotation)
+        source_pix = self._pixmap.transformed(transform, Qt.TransformationMode.SmoothTransformation)
+
+        scaled_w = int(source_pix.width() * self._zoom_factor)
+        scaled_h = int(source_pix.height() * self._zoom_factor)
 
         # Keep aspect ratio
-        scaled_pix = self._pixmap.scaled(
+        scaled_pix = source_pix.scaled(
             scaled_w, scaled_h,
             Qt.AspectRatioMode.KeepAspectRatio,
             Qt.TransformationMode.SmoothTransformation
@@ -562,6 +572,34 @@ class ManuscriptViewerWidget(QWidget):
         btn_zoom_in.setFixedWidth(30)
         btn_zoom_in.clicked.connect(lambda: self.scroll_area.zoom_in())
 
+        # Rotation controls
+        btn_rot_left = QPushButton("↺")
+        btn_rot_left.setToolTip(tr("Rotate Left"))
+        btn_rot_left.setFixedWidth(30)
+
+        btn_rot_right = QPushButton("↻")
+        btn_rot_right.setToolTip(tr("Rotate Right"))
+        btn_rot_right.setFixedWidth(30)
+
+        btn_rot_reset = QPushButton(tr("Reset"))
+        btn_rot_reset.setToolTip(tr("Reset Rotation"))
+        btn_rot_reset.setFixedWidth(50)
+
+        self.slider_rotation = QSlider(Qt.Orientation.Horizontal)
+        self.slider_rotation.setRange(0, 360)
+        self.slider_rotation.setValue(0)
+        self.slider_rotation.setFixedWidth(140)
+        self.slider_rotation.setToolTip(tr("Rotate Image"))
+        self.slider_rotation.valueChanged.connect(self.scroll_area.set_rotation)
+
+        def adjust_rotation(delta):
+            new_val = (self.slider_rotation.value() + delta) % 360
+            self.slider_rotation.setValue(new_val)
+
+        btn_rot_left.clicked.connect(lambda: adjust_rotation(-90))
+        btn_rot_right.clicked.connect(lambda: adjust_rotation(90))
+        btn_rot_reset.clicked.connect(lambda: self.slider_rotation.setValue(0))
+
         self.btn_external = QPushButton(tr("External Site"))
         self.btn_external.setVisible(False)
         self.btn_external.clicked.connect(self.open_external)
@@ -569,6 +607,11 @@ class ManuscriptViewerWidget(QWidget):
         top_bar.addWidget(self.combo_source)
         top_bar.addStretch()
         top_bar.addWidget(self.btn_external)
+        top_bar.addWidget(btn_rot_left)
+        top_bar.addWidget(self.slider_rotation, 1)
+        top_bar.addWidget(btn_rot_right)
+        top_bar.addWidget(btn_rot_reset)
+        top_bar.addSpacing(5)
         top_bar.addWidget(btn_zoom_out)
         top_bar.addWidget(btn_zoom_in)
 
@@ -660,6 +703,8 @@ class ManuscriptViewerWidget(QWidget):
         if not self.active_list:
             self.scroll_area.set_image(None)
             self.scroll_area.lbl_img.setText(tr("No images available"))
+            if hasattr(self, "slider_rotation"):
+                self.slider_rotation.setValue(0)
             return
 
         # Bounds check
@@ -689,6 +734,8 @@ class ManuscriptViewerWidget(QWidget):
     def display_image(self, image):
         pix = QPixmap.fromImage(image)
         self.scroll_area.set_image(pix)
+        if hasattr(self, "slider_rotation"):
+            self.slider_rotation.setValue(0)
 
     def open_external(self):
         if self.external_url:


### PR DESCRIPTION
## Summary
- add absolute rotation handling to the zoomable viewer and apply transforms before scaling
- introduce a rotation toolbar with slider plus left/right/reset buttons that keep UI and image in sync via the slider
- reset rotation state when images or sources change to avoid stale angles

## Testing
- python -m compileall genizah_app.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6953ba7dad808321b85cfd2a8370ab5c)