### PR TITLE
Add shelfmark lookup to browse tab

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -2596,12 +2596,15 @@ class GenizahGUI(QMainWindow):
         self.browse_sys_input = QLineEdit(); self.browse_sys_input.setPlaceholderText(tr("Enter System ID..."))
         self.browse_fl_input = QLineEdit(); self.browse_fl_input.setPlaceholderText(tr("Enter FL ID..."))
         self.browse_fl_input.setFixedWidth(140)
+        self.browse_shelf_input = QLineEdit(); self.browse_shelf_input.setPlaceholderText(tr("Enter shelfmark..."))
+        self.browse_shelf_input.setFixedWidth(200)
 
         self.btn_browse_go = QPushButton(tr("Go")); self.btn_browse_go.setFixedWidth(50)
         self.btn_browse_go.clicked.connect(self.browse_load)
         self.btn_browse_go.setEnabled(False)
         self.browse_sys_input.returnPressed.connect(self.browse_load)
         self.browse_fl_input.returnPressed.connect(self.browse_load)
+        self.browse_shelf_input.returnPressed.connect(self.browse_load)
         
         self.btn_b_catalog = QPushButton(tr("Ktiv")); self.btn_b_catalog.setToolTip(tr("Open in Ktiv Website"))
         self.btn_b_catalog.clicked.connect(self.browse_open_catalog); self.btn_b_catalog.setEnabled(False)
@@ -2617,6 +2620,7 @@ class GenizahGUI(QMainWindow):
 
         row1.addWidget(QLabel(tr("System ID:"))); row1.addWidget(self.browse_sys_input)
         row1.addWidget(QLabel(tr("FL:"))); row1.addWidget(self.browse_fl_input)
+        row1.addWidget(QLabel(tr("Shelfmark:"))); row1.addWidget(self.browse_shelf_input)
         row1.addWidget(self.btn_browse_go)
         row1.addSpacing(20)
         row1.addWidget(self.btn_b_all)
@@ -3013,7 +3017,7 @@ class GenizahGUI(QMainWindow):
 
     def get_browse_help_text(self):
         if CURRENT_LANG == 'he': return tr("BROWSE_HELP_HTML")
-        return """<h3>Browse Manuscripts</h3><ul><li><b>System ID:</b> Enter an ID to load a manuscript.</li><li><b>View All:</b> Switch to continuous view of the full text.</li><li><b>Save:</b> Export the manuscript text to a file.</li></ul>"""
+        return """<h3>Browse Manuscripts</h3><ul><li><b>System ID:</b> Enter an ID to load a manuscript.</li><li><b>Shelfmark:</b> You can load by shelfmark even if it includes dots/slashes/spaces. If the match is ambiguous, the closest options (up to 10) will be suggested.</li><li><b>View All:</b> Switch to continuous view of the full text.</li><li><b>Save:</b> Export the manuscript text to a file.</li></ul>"""
 
     def get_settings_help_text(self):
         if CURRENT_LANG == 'he': return tr("SETTINGS_HELP_HTML")
@@ -5479,11 +5483,33 @@ class GenizahGUI(QMainWindow):
         if not self.searcher: return
         sid = self.browse_sys_input.text().strip()
         fl_id = self.browse_fl_input.text().strip()
-        if not sid and not fl_id: return
+        shelf_query = self.browse_shelf_input.text().strip()
+        if not sid and not fl_id and not shelf_query: return
 
         # Reset UI
         self.browse_text.setText(tr("Loading metadata..."))
         self.browse_viewer.load_images({}) # Clear viewer
+
+        # Attempt shelfmark resolution first (ignores punctuation)
+        if shelf_query and not sid and self.meta_mgr:
+            matches = self.meta_mgr.find_shelfmark_matches(shelf_query, limit=10)
+            if len(matches) == 1:
+                sid = matches[0]['sys_id']
+                self.browse_sys_input.setText(sid or "")
+                # Show canonical shelfmark formatting if available
+                if matches[0]['shelfmark']:
+                    self.browse_shelf_input.setText(matches[0]['shelfmark'])
+            elif len(matches) == 0:
+                QMessageBox.warning(self, tr("Error"), tr("Shelfmark not found."))
+                return
+            else:
+                opts = "\n".join([f"- {m['shelfmark']} ({tr('System ID')}: {m['sys_id']})" for m in matches])
+                QMessageBox.information(
+                    self,
+                    tr("Multiple shelfmarks found"),
+                    tr("Multiple shelfmarks matched your input:\n{}\n\n(Showing up to 10 closest options.)").format(opts)
+                )
+                return
 
         page_data = None
         if fl_id:

--- a/genizah_core.py
+++ b/genizah_core.py
@@ -1538,6 +1538,7 @@ class MetadataManager:
         self.meta_map = {}
         self.nli_cache = {}
         self.csv_bank = {}
+        self._shelfmark_index = None
         self.nli_executor = ThreadPoolExecutor(max_workers=2)
         self.ns = {'marc': 'http://www.loc.gov/MARC21/slim'}
 
@@ -1610,8 +1611,93 @@ class MetadataManager:
 
                     self.csv_bank[sys_id] = {'shelfmark': shelf, 'title': title}
             LOGGER.info("Loaded %d records into csv_bank from libraries.csv", len(self.csv_bank))
+            self._invalidate_shelfmark_index()
         except Exception as e:
             LOGGER.error("Failed to load CSV library bank from %s: %s", Config.LIBRARIES_CSV, e)
+
+    def _invalidate_shelfmark_index(self):
+        """Reset cached shelfmark index after metadata changes."""
+        self._shelfmark_index = None
+
+    def normalize_shelfmark(self, shelf):
+        """
+        Normalize shelfmark strings by removing Ms. prefixes, dots, slashes, and spaces.
+        Lowercases for consistent matching.
+        """
+        if not shelf:
+            return ""
+        shelf = re.sub(r"^\s*m[\.\s]*s[\.\s]*\.?\s*", "", str(shelf), flags=re.IGNORECASE)
+        shelf = re.sub(r"[./\\\s]", "", shelf)
+        shelf = re.sub(r"[^\w]", "", shelf)
+        return shelf.lower()
+
+    def _ensure_shelfmark_index(self):
+        """Build a normalized shelfmark -> {(sys_id, display_shelfmark)} index."""
+        if self._shelfmark_index is not None:
+            return self._shelfmark_index
+
+        index = defaultdict(set)
+
+        def add_entry(sys_id, shelf):
+            norm = self.normalize_shelfmark(shelf)
+            if norm:
+                index[norm].add((sys_id, shelf))
+
+        for sys_id, data in self.csv_bank.items():
+            add_entry(sys_id, data.get('shelfmark'))
+
+        for sys_id, data in self.nli_cache.items():
+            add_entry(sys_id, data.get('shelfmark'))
+            add_entry(sys_id, data.get('shelfmark_alt'))
+
+        self._shelfmark_index = index
+        return index
+
+    def find_shelfmark_matches(self, query, limit=10):
+        """
+        Find system IDs whose shelfmarks match the query, ignoring dots, slashes, and spaces.
+        Returns exact matches first, followed by partial matches, capped at `limit`.
+        """
+        norm_query = self.normalize_shelfmark(query)
+        if not norm_query:
+            return []
+
+        index = self._ensure_shelfmark_index()
+        candidates = []
+
+        for norm_value, pairs in index.items():
+            match_rank = None
+            if norm_value == norm_query:
+                match_rank = 0  # Exact match
+            elif norm_query in norm_value:
+                match_rank = 1  # Partial match
+
+            if match_rank is None:
+                continue
+
+            for sys_id, shelf in pairs:
+                candidates.append({
+                    'sys_id': sys_id,
+                    'shelfmark': shelf,
+                    'exact': match_rank == 0
+                })
+
+        # Sort exact matches first, then natural shelfmark ordering
+        candidates.sort(key=lambda c: (0 if c['exact'] else 1, natural_sort_key(str(c['shelfmark'] or "")), c['sys_id']))
+
+        # Deduplicate by (sys_id, shelfmark) and trim
+        final = []
+        seen = set()
+        for c in candidates:
+            key = (c['sys_id'], c['shelfmark'])
+            if key in seen:
+                continue
+            seen.add(key)
+            final.append(c)
+            if len(final) >= limit:
+                break
+
+        return final
 
     def get_meta_for_id(self, sys_id):
         # Normalize sys_id to digits only (handles BOM/RTL marks/stray chars)
@@ -1768,11 +1854,13 @@ class MetadataManager:
                 'thumb_checked': True # Mark as checked to prevent repeated image download attempts
             }
             self.nli_cache[system_id] = meta
+            self._invalidate_shelfmark_index()
             return meta
 
         # 3. Only if necessary (not in cache/CSV) - Network request
         _, meta = self._fetch_single_worker(system_id)
         self.nli_cache[system_id] = meta
+        self._invalidate_shelfmark_index()
         return meta
 
     def fetch_iiif_manifest(self, system_id):
@@ -1995,6 +2083,7 @@ class MetadataManager:
             current_meta['shelfmark'] = marc_data['shelfmark_alt']
 
         self.nli_cache[system_id] = current_meta
+        self._invalidate_shelfmark_index()
         return current_meta
 
     def fetch_external_iiif_data(self, view_url):

--- a/genizah_translations.py
+++ b/genizah_translations.py
@@ -56,6 +56,8 @@ TRANSLATIONS = {
     "FL": "מס' קובץ",
     "FL:": "מס' קובץ:",
     "Enter FL ID...": "הכנס מספר קובץ...",
+    "Enter shelfmark...": "הכנס מספר מדף...",
+    "Shelfmark:": "מספר מדף:",
     "Shelfmark": "מספר מדף",
     "Title": "כותרת",
     "Snippet": "קטע",
@@ -170,6 +172,9 @@ TRANSLATIONS = {
     "Show full text continuously (Infinite Scroll)": "הצג טקסט מלא ברצף (גלילה אינסופית)",
     "Save": "שמור",
     "Save full manuscript to file": "שמור כתב יד מלא לקובץ",
+    "Shelfmark not found.": "מספר המדף לא נמצא.",
+    "Multiple shelfmarks found": "נמצאו מספר מספרי מדף",
+    "Multiple shelfmarks matched your input:\n{}\n\n(Showing up to 10 closest options.)": "מספר המדף שהוקלד אינו חד משמעי. האפשרויות הקרובות (עד עשר):\n{}",
     "No Preview": "אין תצוגה",
     "Loading Meta...": "טוען מידע...",
     "No Image": "אין תמונה",
@@ -367,6 +372,7 @@ TRANSLATIONS = {
     "BROWSE_HELP_HTML": """<div dir='rtl'><h3>עיון בכתב יד</h3>
     <ul>
     <li><b>מספר מערכת:</b> הזן מזהה מערכת כדי לטעון כתב יד.</li>
+    <li><b>מספר מדף:</b> ניתן להזין מספר מדף גם אם כולל נקודות/לוכסנים או רווחים. אם אין התאמה חד משמעית, יוצגו האפשרויות הקרובות (עד 10).</li>
     <li><b>תצוגה:</b> דפדוף עמוד-עמוד או צפייה רציפה בכל הטקסט.</li>
     <li><b>שמור:</b> ייצוא כתב היד לקובץ טקסט.</li>
     </ul></div>""",


### PR DESCRIPTION
## Summary
- add normalized shelfmark index to resolve shelfmark queries and suggest close matches
- allow browsing manuscripts by shelfmark from the Browse tab with translated messaging
- update browse help copy to describe shelfmark-based navigation

## Testing
- python -m compileall genizah_core.py genizah_app.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6953d7c620a88321b418d712be8e584c)