### PR TITLE
Add shelfmark-based browsing to manuscript view

### DIFF
--- a/Help.html
+++ b/Help.html
@@ -165,7 +165,7 @@
 <div class="box lang-en">
 <p>The <b>Browse Manuscript</b> tab is used for reading full manuscripts.</p>
 <ul>
-<li>Enter a <b>System ID</b> to load a manuscript.</li>
+<li>Enter a <b>System ID</b> or <b>Shelfmark</b> (dots/slashes are ignored) to load a manuscript.</li>
 <li>View page images and transcribed text.</li>
 <li><b>View All</b> shows the manuscript as one continuous text.</li>
 <li><b>Save</b> exports the full manuscript to a text file.</li>
@@ -175,7 +175,7 @@
 <div class="box rtl lang-he">
 <p>לשונית <b>עיון בכתב יד</b> מאפשרת קריאה רציפה של כתבי יד.</p>
 <ul>
-<li>הזנת <b>מספר מערכת</b> לטעינת כתב יד.</li>
+<li>הזנת <b>מספר מערכת</b> או <b>מספר מדף</b> (מתעלמים מנקודות/לוכסנים) לטעינת כתב יד.</li>
 <li>צפייה בתמונות ובטקסט המתועתק.</li>
 <li><b>הכל</b> מציג את כתב היד כולו ברצף.</li>
 <li><b>שמור</b> מייצא את כתב היד לקובץ טקסט.</li>

--- a/genizah_app.py
+++ b/genizah_app.py
@@ -22,7 +22,7 @@ from PyQt6.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout, QH
                              QTextBrowser, QFileDialog, QMenu, QGroupBox, QSpinBox, QDoubleSpinBox,
                              QTreeWidget, QTreeWidgetItem, QPlainTextEdit, QStyle,
                              QGridLayout, QToolTip, QProgressDialog, QStackedLayout,
-                             QScrollArea, QFrame, QSlider, QStyleOptionButton, QSizePolicy)
+                             QScrollArea, QFrame, QSlider, QStyleOptionButton, QSizePolicy, QInputDialog)
 from PyQt6.QtCore import Qt, QTimer, QUrl, QSize, pyqtSignal, QThread, QEventLoop, QEvent, QRect
 from PyQt6.QtGui import QFont, QIcon, QDesktopServices, QPixmap, QImage, QFontMetrics, QTextDocument, QTransform
 
@@ -2594,6 +2594,8 @@ class GenizahGUI(QMainWindow):
         # Row 1: Search Inputs
         row1 = QHBoxLayout()
         self.browse_sys_input = QLineEdit(); self.browse_sys_input.setPlaceholderText(tr("Enter System ID..."))
+        self.browse_shelf_input = QLineEdit(); self.browse_shelf_input.setPlaceholderText(tr("Enter shelfmark..."))
+        self.browse_shelf_input.setFixedWidth(220)
         self.browse_fl_input = QLineEdit(); self.browse_fl_input.setPlaceholderText(tr("Enter FL ID..."))
         self.browse_fl_input.setFixedWidth(140)
 
@@ -2601,6 +2603,7 @@ class GenizahGUI(QMainWindow):
         self.btn_browse_go.clicked.connect(self.browse_load)
         self.btn_browse_go.setEnabled(False)
         self.browse_sys_input.returnPressed.connect(self.browse_load)
+        self.browse_shelf_input.returnPressed.connect(self.browse_load)
         self.browse_fl_input.returnPressed.connect(self.browse_load)
         
         self.btn_b_catalog = QPushButton(tr("Ktiv")); self.btn_b_catalog.setToolTip(tr("Open in Ktiv Website"))
@@ -2616,6 +2619,7 @@ class GenizahGUI(QMainWindow):
         self.btn_b_all.setEnabled(False)
 
         row1.addWidget(QLabel(tr("System ID:"))); row1.addWidget(self.browse_sys_input)
+        row1.addWidget(QLabel(tr("Shelfmark:"))); row1.addWidget(self.browse_shelf_input)
         row1.addWidget(QLabel(tr("FL:"))); row1.addWidget(self.browse_fl_input)
         row1.addWidget(self.btn_browse_go)
         row1.addSpacing(20)
@@ -3521,6 +3525,9 @@ class GenizahGUI(QMainWindow):
             if title:
                 info_text += f"<br>{title}"
             self.browse_info_lbl.setText(info_text)
+            self.browse_shelf_input.setText(shelfmark)
+        else:
+            self.browse_shelf_input.setText("")
         if fl_id:
             self.browse_fl_input.setText(fl_id)
         else:
@@ -5475,11 +5482,58 @@ class GenizahGUI(QMainWindow):
 
         return sys_id, page, shelf_lbl, title_lbl
 
+    def _choose_shelfmark_match(self, matches):
+        display_items = []
+        for m in matches:
+            shelf = m.get('shelfmark') or tr("Unknown Shelfmark")
+            title = m.get('title') or tr("Untitled")
+            display_items.append(f"{shelf} — {title} (ID: {m.get('sys_id', '')})")
+
+        choice, ok = QInputDialog.getItem(
+            self,
+            tr("Select shelfmark"),
+            tr("Multiple matches found. Please choose a manuscript to open:"),
+            display_items,
+            0,
+            False
+        )
+        if ok and choice in display_items:
+            idx = display_items.index(choice)
+            return matches[idx]
+        return None
+
+    def _resolve_browse_shelfmark(self, shelf_text):
+        matches = self.meta_mgr.find_shelfmark_matches(shelf_text, max_results=10)
+        if not matches:
+            QMessageBox.warning(self, tr("Shelfmark"), tr("No shelfmark matches found. Try a different format."))
+            return None
+
+        unique_sys_ids = {m['sys_id'] for m in matches}
+        if len(unique_sys_ids) == 1:
+            return matches[0]
+
+        chosen = self._choose_shelfmark_match(matches)
+        if not chosen:
+            # Offer the suggestions as information
+            suggestions = "\n".join([m.get('shelfmark') or tr("Unknown Shelfmark") for m in matches])
+            QMessageBox.information(self, tr("Shelfmark"), tr("No single match. Close options:") + f"\n{suggestions}")
+        return chosen
+
     def browse_load(self):
         if not self.searcher: return
         sid = self.browse_sys_input.text().strip()
+        shelf_text = self.browse_shelf_input.text().strip()
         fl_id = self.browse_fl_input.text().strip()
-        if not sid and not fl_id: return
+        if not sid and not fl_id and not shelf_text: return
+
+        shelf_match = None
+        if shelf_text:
+            shelf_match = self._resolve_browse_shelfmark(shelf_text)
+            if not shelf_match:
+                return
+            sid = shelf_match.get('sys_id', sid)
+            self.browse_sys_input.setText(sid or "")
+            self.browse_shelf_input.setText(shelf_match.get('shelfmark', shelf_text))
 
         # Reset UI
         self.browse_text.setText(tr("Loading metadata..."))
@@ -5491,13 +5545,15 @@ class GenizahGUI(QMainWindow):
             if not page_data and not sid:
                 QMessageBox.warning(self, tr("Error"), tr("FL not found."))
                 return
+            elif not page_data and sid:
+                QMessageBox.information(self, tr("Info"), tr("FL not found. Opening the manuscript by shelfmark/system ID."))
             if page_data:
                 sid = page_data.get('sys_id', sid)
                 self.browse_sys_input.setText(sid or "")
                 self.browse_fl_input.setText(page_data.get('fl_id', fl_id))
 
         if not sid:
-            QMessageBox.warning(self, tr("Error"), tr("FL not found."))
+            QMessageBox.warning(self, tr("Error"), tr("Shelfmark or ID not found."))
             return
 
         self.current_browse_sid = sid

--- a/genizah_core.py
+++ b/genizah_core.py
@@ -1540,6 +1540,7 @@ class MetadataManager:
         self.csv_bank = {}
         self.nli_executor = ThreadPoolExecutor(max_workers=2)
         self.ns = {'marc': 'http://www.loc.gov/MARC21/slim'}
+        self._shelf_index = None
 
         # Ensure index dir exists for caches
         if not os.path.exists(Config.INDEX_DIR):
@@ -1567,6 +1568,7 @@ class MetadataManager:
                 with open(Config.CACHE_META, 'rb') as f: self.meta_map = pickle.load(f)
             except Exception as e:
                 LOGGER.warning("Failed to load metadata cache from %s: %s", Config.CACHE_META, e)
+        # Shelf index will be lazily built when needed
 
     def _load_heavy_caches_bg(self):
         self._load_csv_bank()
@@ -1612,6 +1614,93 @@ class MetadataManager:
             LOGGER.info("Loaded %d records into csv_bank from libraries.csv", len(self.csv_bank))
         except Exception as e:
             LOGGER.error("Failed to load CSV library bank from %s: %s", Config.LIBRARIES_CSV, e)
+    # --- Shelfmark helpers ---
+    def _invalidate_shelf_index(self):
+        self._shelf_index = None
+
+    def normalize_shelfmark(self, shelf):
+        """
+        Normalize shelfmarks by removing Ms. prefixes, spaces, dots, and slashes.
+        This enables matching across common formatting variants.
+        """
+        if not shelf:
+            return ""
+        without_prefix = re.sub(r"^\s*m[\.\s]*s[\.\s]*\.?\s*", "", str(shelf), flags=re.IGNORECASE)
+        cleaned = re.sub(r"[\\s./]+", "", without_prefix).lower()
+        if cleaned.startswith("ms"):
+            cleaned = cleaned[2:]
+        return cleaned
+
+    def _ensure_shelf_index(self):
+        if self._shelf_index is not None:
+            return
+
+        # Ensure CSV is loaded for comprehensive coverage
+        if not self.csv_bank:
+            self._load_csv_bank()
+
+        self._shelf_index = {}
+
+        def add_entry(shelf, sys_id, title=""):
+            norm = self.normalize_shelfmark(shelf)
+            if not norm or not sys_id:
+                return
+            entry = {'sys_id': sys_id, 'shelfmark': shelf, 'title': title or ''}
+            if norm not in self._shelf_index:
+                self._shelf_index[norm] = []
+            if entry not in self._shelf_index[norm]:
+                self._shelf_index[norm].append(entry)
+
+        for sys_id, data in self.csv_bank.items():
+            add_entry(data.get('shelfmark'), sys_id, data.get('title', ''))
+
+        for sys_id, data in self.nli_cache.items():
+            add_entry(data.get('shelfmark'), sys_id, data.get('title', ''))
+            if data.get('shelfmark_alt'):
+                add_entry(data.get('shelfmark_alt'), sys_id, data.get('title', ''))
+
+    def find_shelfmark_matches(self, query, max_results=10):
+        """
+        Return possible system IDs for a shelfmark query.
+        Matching ignores dots/slashes/spaces and supports partial matches.
+        """
+        if not query:
+            return []
+        self._ensure_shelf_index()
+
+        normalized_query = self.normalize_shelfmark(query)
+        if not normalized_query:
+            return []
+
+        matches = []
+        seen = set()
+
+        def add_from_norm(norm, match_type):
+            if norm not in self._shelf_index:
+                return
+            for entry in self._shelf_index[norm]:
+                key = (entry['sys_id'], entry['shelfmark'])
+                if key in seen or len(matches) >= max_results:
+                    continue
+                seen.add(key)
+                matches.append({**entry, 'match_type': match_type, 'normalized': norm})
+
+        # Exact normalized match first
+        add_from_norm(normalized_query, 'exact')
+
+        # Partial matches where the query is contained within the normalized shelfmark (or vice versa)
+        if len(matches) < max_results:
+            for norm_key in self._shelf_index.keys():
+                if norm_key == normalized_query:
+                    continue
+                if (normalized_query in norm_key) or (norm_key in normalized_query):
+                    add_from_norm(norm_key, 'partial')
+                    if len(matches) >= max_results:
+                        break
+
+        # Sort: exact first, then shorter distance from query length
+        matches.sort(key=lambda m: (0 if m['match_type'] == 'exact' else 1, abs(len(m['normalized']) - len(normalized_query)), m['shelfmark']))
+        return matches[:max_results]
 
     def get_meta_for_id(self, sys_id):
         # Normalize sys_id to digits only (handles BOM/RTL marks/stray chars)
@@ -1768,11 +1857,13 @@ class MetadataManager:
                 'thumb_checked': True # Mark as checked to prevent repeated image download attempts
             }
             self.nli_cache[system_id] = meta
+            self._invalidate_shelf_index()
             return meta
 
         # 3. Only if necessary (not in cache/CSV) - Network request
         _, meta = self._fetch_single_worker(system_id)
         self.nli_cache[system_id] = meta
+        self._invalidate_shelf_index()
         return meta
 
     def fetch_iiif_manifest(self, system_id):
@@ -2256,6 +2347,7 @@ class MetadataManager:
         for future in as_completed(futures):
             sid, meta = future.result()
             self.nli_cache[sid] = meta
+            self._invalidate_shelf_index()
             current_progress += 1
             if progress_callback:
                 progress_callback(current_progress, len(system_ids), sid)

--- a/genizah_translations.py
+++ b/genizah_translations.py
@@ -16,10 +16,13 @@ TRANSLATIONS = {
     "Error": "שגיאה",
     "Warning": "אזהרה",
     "Information": "מידע",
+    "Info": "מידע",
     "Ready.": "מוכן.",
     "Loading...": "טוען...",
     "Please wait while components load...": "אנא המתן בעת טעינת הרכיבים...",
     "Stop": "עצור",
+    "Unknown Shelfmark": "מספר מדף לא ידוע",
+    "Untitled": "ללא כותרת",
     
     # --- Connectivity / Status ---
     "Online": "מקוון",
@@ -162,6 +165,7 @@ TRANSLATIONS = {
 
     # --- Browse Tab ---
     "Enter System ID...": "הכנס מספר מערכת...",
+    "Enter shelfmark...": "הכנס מספר מדף...",
     "Go": "עבור",
     "Enter ID to browse.": "הכנס מספר לדפדוף.",
     "Ktiv": "כתיב",
@@ -176,6 +180,8 @@ TRANSLATIONS = {
     "Waiting...": "ממתין...",
     "Not found or end.": "לא נמצא או סוף הקובץ.",
     "FL not found.": "מספר קובץ לא נמצא.",
+    "FL not found. Opening the manuscript by shelfmark/system ID.": "מספר קובץ לא נמצא. פותח את כתב היד לפי מספר מדף/מערכת.",
+    "Shelfmark or ID not found.": "מספר מדף או מערכת לא נמצאו.",
     "Nav": "ניווט",
     "Loading full manuscript...": "טוען כתב יד מלא...",
     "Could not load full text.": "לא ניתן לטעון טקסט מלא.",
@@ -187,6 +193,11 @@ TRANSLATIONS = {
     "Next >>": "הבא <<",
     "Page / Image": "עמוד / תמונה", 
     "Image": "תמונה",
+    "Shelfmark:": "מספר מדף:",
+    "Select shelfmark": "בחר מספר מדף",
+    "Multiple matches found. Please choose a manuscript to open:": "נמצאו מספר התאמות. בחר כתב יד לפתיחה:",
+    "No shelfmark matches found. Try a different format.": "לא נמצאו התאמות במספרי המדף. נסה פורמט אחר.",
+    "No single match. Close options:": "אין התאמה חד משמעית. אפשרויות קרובות:",
 
     # --- Settings Tab ---
     "Data & Index": "נתונים ואינדקס",


### PR DESCRIPTION
## Summary
- add a shelfmark input to the Browse tab that resolves manuscripts even when shelfmarks use dots, slashes, or spaces
- build shelfmark matching on metadata to suggest up to ten close options when there is no single match and allow loading from the chosen entry
- update translations and help text to document the new shelfmark browsing capability

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6953d7c620a88321b418d712be8e584c)