### PR TITLE
Add shelfmark browsing resolution

### DIFF
--- a/Help.html
+++ b/Help.html
@@ -165,7 +165,8 @@
 <div class="box lang-en">
 <p>The <b>Browse Manuscript</b> tab is used for reading full manuscripts.</p>
 <ul>
-<li>Enter a <b>System ID</b> to load a manuscript.</li>
+<li>Enter a <b>System ID</b> or <b>shelfmark</b> to load a manuscript. Shelfmarks are matched even if they include dots, slashes, or spaces.</li>
+<li>If multiple shelfmarks match, pick from the suggested list (up to 100 closest options).</li>
 <li>View page images and transcribed text.</li>
 <li><b>View All</b> shows the manuscript as one continuous text.</li>
 <li><b>Save</b> exports the full manuscript to a text file.</li>
@@ -175,7 +176,8 @@
 <div class="box rtl lang-he">
 <p>לשונית <b>עיון בכתב יד</b> מאפשרת קריאה רציפה של כתבי יד.</p>
 <ul>
-<li>הזנת <b>מספר מערכת</b> לטעינת כתב יד.</li>
+<li>הזנת <b>מספר מערכת</b> או <b>מספר מדף</b> לטעינת כתב יד. ההתאמה מתעלמת מנקודות, לוכסנים ורווחים.</li>
+<li>אם נמצאו כמה מספרי מדף, ניתן לבחור מהרשימה המוצעת (עד 100 אפשרויות קרובות).</li>
 <li>צפייה בתמונות ובטקסט המתועתק.</li>
 <li><b>הכל</b> מציג את כתב היד כולו ברצף.</li>
 <li><b>שמור</b> מייצא את כתב היד לקובץ טקסט.</li>

--- a/genizah_app.py
+++ b/genizah_app.py
@@ -22,7 +22,7 @@ from PyQt6.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout, QH
                              QTextBrowser, QFileDialog, QMenu, QGroupBox, QSpinBox, QDoubleSpinBox,
                              QTreeWidget, QTreeWidgetItem, QPlainTextEdit, QStyle,
                              QGridLayout, QToolTip, QProgressDialog, QStackedLayout,
-                             QScrollArea, QFrame, QSlider, QStyleOptionButton, QSizePolicy)
+                             QScrollArea, QFrame, QSlider, QStyleOptionButton, QSizePolicy, QInputDialog)
 from PyQt6.QtCore import Qt, QTimer, QUrl, QSize, pyqtSignal, QThread, QEventLoop, QEvent, QRect
 from PyQt6.QtGui import QFont, QIcon, QDesktopServices, QPixmap, QImage, QFontMetrics, QTextDocument, QTransform
 
@@ -2594,6 +2594,7 @@ class GenizahGUI(QMainWindow):
         # Row 1: Search Inputs
         row1 = QHBoxLayout()
         self.browse_sys_input = QLineEdit(); self.browse_sys_input.setPlaceholderText(tr("Enter System ID..."))
+        self.browse_shelf_input = QLineEdit(); self.browse_shelf_input.setPlaceholderText(tr("Enter shelfmark..."))
         self.browse_fl_input = QLineEdit(); self.browse_fl_input.setPlaceholderText(tr("Enter FL ID..."))
         self.browse_fl_input.setFixedWidth(140)
 
@@ -2601,6 +2602,7 @@ class GenizahGUI(QMainWindow):
         self.btn_browse_go.clicked.connect(self.browse_load)
         self.btn_browse_go.setEnabled(False)
         self.browse_sys_input.returnPressed.connect(self.browse_load)
+        self.browse_shelf_input.returnPressed.connect(self.browse_load)
         self.browse_fl_input.returnPressed.connect(self.browse_load)
         
         self.btn_b_catalog = QPushButton(tr("Ktiv")); self.btn_b_catalog.setToolTip(tr("Open in Ktiv Website"))
@@ -2616,6 +2618,7 @@ class GenizahGUI(QMainWindow):
         self.btn_b_all.setEnabled(False)
 
         row1.addWidget(QLabel(tr("System ID:"))); row1.addWidget(self.browse_sys_input)
+        row1.addWidget(QLabel(tr("Shelfmark:"))); row1.addWidget(self.browse_shelf_input)
         row1.addWidget(QLabel(tr("FL:"))); row1.addWidget(self.browse_fl_input)
         row1.addWidget(self.btn_browse_go)
         row1.addSpacing(20)
@@ -5478,14 +5481,16 @@ class GenizahGUI(QMainWindow):
     def browse_load(self):
         if not self.searcher: return
         sid = self.browse_sys_input.text().strip()
+        shelf_query = self.browse_shelf_input.text().strip()
         fl_id = self.browse_fl_input.text().strip()
-        if not sid and not fl_id: return
+        if not sid and not fl_id and not shelf_query: return
 
         # Reset UI
         self.browse_text.setText(tr("Loading metadata..."))
         self.browse_viewer.load_images({}) # Clear viewer
 
         page_data = None
+        # 1) Resolve via FL
         if fl_id:
             page_data = self.searcher.get_browse_page_by_fl(fl_id, sid or None)
             if not page_data and not sid:
@@ -5496,8 +5501,46 @@ class GenizahGUI(QMainWindow):
                 self.browse_sys_input.setText(sid or "")
                 self.browse_fl_input.setText(page_data.get('fl_id', fl_id))
 
+        # 2) Resolve via Shelfmark (if system not provided yet)
+        if not sid and shelf_query:
+            shelf_res = self.meta_mgr.resolve_system_by_shelfmark(shelf_query)
+            if shelf_res['sys_id']:
+                sid = shelf_res['sys_id']
+                # Prefill with canonical shelfmark if available
+                if shelf_res['selected_shelfmark']:
+                    self.browse_shelf_input.setText(shelf_res['selected_shelfmark'])
+                self.browse_sys_input.setText(sid or "")
+            elif shelf_res['options']:
+                def _format_option(opt, idx):
+                    base = opt['shelfmark']
+                    title = (opt.get('title') or "").strip()
+                    if title:
+                        base = f"{base} | {title}"
+                    label = f"{idx + 1}. {base}"
+                    if len(label) > 60:
+                        label = label[:57] + "..."
+                    return label
+
+                display_options = [_format_option(opt, idx) for idx, opt in enumerate(shelf_res['options'])]
+                choice, ok = QInputDialog.getItem(
+                    self, tr("Shelfmark"), tr("Multiple shelfmarks found. Select one:"), display_options, 0, False
+                )
+                if not ok:
+                    return
+                if choice in display_options:
+                    idx = display_options.index(choice)
+                    opt = shelf_res['options'][idx]
+                    sid = opt['sys_id']
+                    self.browse_shelf_input.setText(opt['shelfmark'])
+                    self.browse_sys_input.setText(sid or "")
+            else:
+                QMessageBox.warning(self, tr("Error"), tr("Shelfmark not found.")); return
+
         if not sid:
-            QMessageBox.warning(self, tr("Error"), tr("FL not found."))
+            msg = tr("FL not found.")
+            if shelf_query:
+                msg = tr("Shelfmark not found.")
+            QMessageBox.warning(self, tr("Error"), msg)
             return
 
         self.current_browse_sid = sid
@@ -5559,6 +5602,8 @@ class GenizahGUI(QMainWindow):
         _, _, shelf, title = self._get_meta_for_header(full_header)
         info_text = f"<b>{shelf}</b><br>{title or ''}"
         self.browse_info_lbl.setText(info_text)
+        if shelf:
+            self.browse_shelf_input.setText(shelf)
 
         # עדכון מונה עמודים וכפתורים
         self.lbl_page_count.setText(f"{pd['current_idx']}/{pd['total_pages']}")

--- a/genizah_app.py
+++ b/genizah_app.py
@@ -1800,12 +1800,6 @@ class ResultDialog(QDialog):
         fl_val = self.combo_img_labels.currentData()
         if fl_val == -1: return
 
-        # We need to find the Page Number (p_num) that corresponds to this FL.
-        # This is a reverse lookup.
-        # Since we don't have the full map in memory easily, we can use the searcher helper.
-        # But that might be slow if we do it on UI thread.
-        # Let's fire a quick thread to find it? Or assume searcher is fast enough (it uses pickle map).
-
         try:
             page_data = self.searcher.get_browse_page_by_fl(str(fl_val), self.current_sys_id)
             if page_data:
@@ -4133,14 +4127,16 @@ class GenizahGUI(QMainWindow):
         self.excluded_shelfmarks = shelves
         self.lbl_exclude_status.setText(tr("Excluded: {}").format(len(entries)))
 
-    def normalize_shelfmark(self, shelf: str):
-        if not shelf:
+    def _normalize_shelfmark(self, shelfmark: str) -> str:
+        """Normalize shelfmarks: remove ALL non-alphanumeric chars (spaces, dots, etc)."""
+        if not shelfmark:
             return ""
-        without_prefix = re.sub(r"^\s*m[\.\s]*s[\.\s]*\.?\s*", "", shelf, flags=re.IGNORECASE)
-        cleaned = re.sub(r"[^\w]", "", without_prefix).lower()
-        # Treat optional "ms" prefix as non-significant for comparisons
+        
+        cleaned = re.sub(r'\W+', '', shelfmark).casefold()
+        
         if cleaned.startswith("ms"):
             cleaned = cleaned[2:]
+            
         return cleaned
 
     def _get_meta_for_header(self, raw_header):

--- a/genizah_app.py
+++ b/genizah_app.py
@@ -2124,6 +2124,7 @@ class GenizahGUI(QMainWindow):
         self.group_thread = None
         self.is_searching = False
         self.is_comp_running = False
+        self.last_browse_field = None
         self.current_browse_sid = None
         self.current_browse_p = None
         self.current_browse_internal_idx = None
@@ -2604,6 +2605,9 @@ class GenizahGUI(QMainWindow):
         self.browse_sys_input.returnPressed.connect(self.browse_load)
         self.browse_shelf_input.returnPressed.connect(self.browse_load)
         self.browse_fl_input.returnPressed.connect(self.browse_load)
+        self.browse_sys_input.textEdited.connect(lambda _t: self._set_last_browse_field("sys"))
+        self.browse_shelf_input.textEdited.connect(lambda _t: self._set_last_browse_field("shelf"))
+        self.browse_fl_input.textEdited.connect(lambda _t: self._set_last_browse_field("fl"))
         
         self.btn_b_catalog = QPushButton(tr("Ktiv")); self.btn_b_catalog.setToolTip(tr("Open in Ktiv Website"))
         self.btn_b_catalog.clicked.connect(self.browse_open_catalog); self.btn_b_catalog.setEnabled(False)
@@ -2721,6 +2725,9 @@ class GenizahGUI(QMainWindow):
         else:
             self.browse_viewer.setVisible(True)
             self.browse_load_page()
+
+    def _set_last_browse_field(self, field):
+        self.last_browse_field = field
 
     def browse_load_page(self):
         """Load single page text and sync viewer."""
@@ -5490,51 +5497,88 @@ class GenizahGUI(QMainWindow):
         self.browse_viewer.load_images({}) # Clear viewer
 
         page_data = None
-        # 1) Resolve via FL
-        if fl_id:
-            page_data = self.searcher.get_browse_page_by_fl(fl_id, sid or None)
-            if not page_data and not sid:
-                QMessageBox.warning(self, tr("Error"), tr("FL not found."))
-                return
-            if page_data:
-                sid = page_data.get('sys_id', sid)
-                self.browse_sys_input.setText(sid or "")
-                self.browse_fl_input.setText(page_data.get('fl_id', fl_id))
 
-        # 2) Resolve via Shelfmark (if system not provided yet)
-        if not sid and shelf_query:
-            shelf_res = self.meta_mgr.resolve_system_by_shelfmark(shelf_query)
-            if shelf_res['sys_id']:
-                sid = shelf_res['sys_id']
-                # Prefill with canonical shelfmark if available
-                if shelf_res['selected_shelfmark']:
-                    self.browse_shelf_input.setText(shelf_res['selected_shelfmark'])
-                self.browse_sys_input.setText(sid or "")
-            elif shelf_res['options']:
-                def _format_option(opt, idx):
-                    base = opt['shelfmark']
-                    title = (opt.get('title') or "").strip()
-                    if title:
-                        base = f"{base} | {title}"
-                    label = f"{idx + 1}. {base}"
-                    if len(label) > 60:
-                        label = label[:57] + "..."
-                    return label
+        # Determine priority based on last edited field (default: shelfmark > system ID > FL)
+        priority = []
+        if self.last_browse_field == "fl" and fl_id:
+            priority.append("fl")
+        elif self.last_browse_field == "shelf" and shelf_query:
+            priority.append("shelf")
+        elif self.last_browse_field == "sys" and sid:
+            priority.append("sys")
 
-                display_options = [_format_option(opt, idx) for idx, opt in enumerate(shelf_res['options'])]
-                choice, ok = QInputDialog.getItem(
-                    self, tr("Shelfmark"), tr("Multiple shelfmarks found. Select one:"), display_options, 0, False
-                )
-                if not ok:
-                    return
-                if choice in display_options:
-                    idx = display_options.index(choice)
-                    opt = shelf_res['options'][idx]
-                    sid = opt['sys_id']
-                    self.browse_shelf_input.setText(opt['shelfmark'])
+        if shelf_query and "shelf" not in priority:
+            priority.append("shelf")
+        if sid and "sys" not in priority:
+            priority.append("sys")
+        if fl_id and "fl" not in priority:
+            priority.append("fl")
+
+        def format_option(opt, idx):
+            base = opt['shelfmark']
+            title = (opt.get('title') or "").strip()
+            if title:
+                base = f"{base} | {title}"
+            label = f"{idx + 1}. {base}"
+            if len(label) > 60:
+                label = label[:57] + "..."
+            return label
+
+        for field in priority:
+            if field == "fl":
+                if not fl_id:
+                    continue
+                pd = self.searcher.get_browse_page_by_fl(fl_id, sid or None)
+                if pd:
+                    page_data = pd
+                    sid = pd.get('sys_id', sid)
                     self.browse_sys_input.setText(sid or "")
-            else:
-                QMessageBox.warning(self, tr("Error"), tr("Shelfmark not found.")); return
+                    self.browse_fl_input.setText(pd.get('fl_id', fl_id))
+                    break
+                # If no other identifiers exist, stop and warn
+                if not sid and not shelf_query:
+                    QMessageBox.warning(self, tr("Error"), tr("FL not found."))
+                    return
+                continue
+
+            if field == "shelf":
+                if not shelf_query:
+                    continue
+                shelf_res = self.meta_mgr.resolve_system_by_shelfmark(shelf_query)
+                if shelf_res['sys_id']:
+                    sid = shelf_res['sys_id']
+                    if shelf_res['selected_shelfmark']:
+                        self.browse_shelf_input.setText(shelf_res['selected_shelfmark'])
+                    self.browse_sys_input.setText(sid or "")
+                    break
+                elif shelf_res['options']:
+                    options = shelf_res['options']
+                    if len(options) == 1:
+                        opt = options[0]
+                        sid = opt['sys_id']
+                        self.browse_shelf_input.setText(opt['shelfmark'])
+                        self.browse_sys_input.setText(sid or "")
+                        break
+                    display_options = [format_option(opt, idx) for idx, opt in enumerate(options)]
+                    choice, ok = QInputDialog.getItem(
+                        self, tr("Shelfmark"), tr("Multiple shelfmarks found. Select one:"), display_options, 0, False
+                    )
+                    if not ok:
+                        return
+                    if choice in display_options:
+                        idx = display_options.index(choice)
+                        opt = options[idx]
+                        sid = opt['sys_id']
+                        self.browse_shelf_input.setText(opt['shelfmark'])
+                        self.browse_sys_input.setText(sid or "")
+                        break
+                # Shelfmark was the chosen path; stop if not resolved
+                QMessageBox.warning(self, tr("Error"), tr("Shelfmark not found."))
+                return
+
+            if field == "sys":
+                if sid:
+                    break
 
         if not sid:
             msg = tr("FL not found.")

--- a/genizah_core.py
+++ b/genizah_core.py
@@ -2283,12 +2283,15 @@ class MetadataManager:
 
     # ---------------- Shelfmark Resolution Helpers ----------------
     def _normalize_shelfmark(self, shelfmark: str) -> str:
-        """Normalize shelfmarks for tolerant comparisons."""
+        """Normalize shelfmarks: remove ALL non-alphanumeric chars (spaces, dots, etc)."""
         if not shelfmark:
             return ""
-        cleaned = re.sub(r"[\\.\\s/]", "", shelfmark).casefold()
+        
+        cleaned = re.sub(r'\W+', '', shelfmark).casefold()
+        
         if cleaned.startswith("ms"):
             cleaned = cleaned[2:]
+            
         return cleaned
 
     def _iter_shelfmark_sources(self):

--- a/genizah_core.py
+++ b/genizah_core.py
@@ -2286,7 +2286,10 @@ class MetadataManager:
         """Normalize shelfmarks for tolerant comparisons."""
         if not shelfmark:
             return ""
-        return re.sub(r"[\\.\\s/]", "", shelfmark).casefold()
+        cleaned = re.sub(r"[\\.\\s/]", "", shelfmark).casefold()
+        if cleaned.startswith("ms"):
+            cleaned = cleaned[2:]
+        return cleaned
 
     def _iter_shelfmark_sources(self):
         """Yield shelfmark candidates from CSV bank and cached metadata."""

--- a/genizah_core.py
+++ b/genizah_core.py
@@ -2281,6 +2281,76 @@ class MetadataManager:
 
         return list(results)
 
+    # ---------------- Shelfmark Resolution Helpers ----------------
+    def _normalize_shelfmark(self, shelfmark: str) -> str:
+        """Normalize shelfmarks for tolerant comparisons."""
+        if not shelfmark:
+            return ""
+        return re.sub(r"[\\.\\s/]", "", shelfmark).casefold()
+
+    def _iter_shelfmark_sources(self):
+        """Yield shelfmark candidates from CSV bank and cached metadata."""
+        # CSV bank
+        for sys_id, data in self.csv_bank.items():
+            shelf = data.get('shelfmark', '')
+            title = data.get('title', '')
+            if shelf:
+                yield sys_id, shelf, title
+        # NLI cache (may contain enriched shelfmarks)
+        for sys_id, data in self.nli_cache.items():
+            shelf = data.get('shelfmark', '')
+            alt = data.get('shelfmark_alt', '')
+            title = data.get('title', '')
+            for candidate in [shelf, alt]:
+                if candidate:
+                    yield sys_id, candidate, title
+
+    def resolve_system_by_shelfmark(self, query, limit=100):
+        """
+        Resolve a system ID by shelfmark, ignoring dots/slashes/spaces.
+        Returns a dict: {'sys_id': ..., 'options': [...], 'selected_shelfmark': ...}
+        """
+        result = {'sys_id': None, 'options': [], 'selected_shelfmark': None}
+
+        norm_query = self._normalize_shelfmark(query)
+        if not norm_query:
+            return result
+
+        exact_matches = []
+        partial_matches = []
+        seen = set()
+
+        def shelf_sort_key(entry):
+            shelf = entry.get('shelfmark', '')
+            title = entry.get('title', '')
+            sid_val = entry.get('sys_id', '')
+            return (natural_sort_key(shelf), natural_sort_key(title), natural_sort_key(sid_val))
+
+        for sys_id, shelf, title in self._iter_shelfmark_sources():
+            norm_shelf = self._normalize_shelfmark(shelf)
+            if not norm_shelf or (sys_id, norm_shelf) in seen:
+                continue
+            seen.add((sys_id, norm_shelf))
+
+            entry = {'sys_id': sys_id, 'shelfmark': shelf, 'title': title}
+            if norm_shelf == norm_query:
+                exact_matches.append(entry)
+            elif norm_query in norm_shelf:
+                partial_matches.append(entry)
+
+        if len(exact_matches) == 1:
+            result['sys_id'] = exact_matches[0]['sys_id']
+            result['selected_shelfmark'] = exact_matches[0]['shelfmark']
+            return result
+
+        exact_matches.sort(key=shelf_sort_key)
+        partial_matches.sort(key=shelf_sort_key)
+
+        # Aggregate suggestions (exact first, then partial), capped at limit
+        suggestions = exact_matches + partial_matches
+        result['options'] = suggestions[:limit]
+        return result
+
     def get_display_data(self, full_header, src_label):
         sys_id, p_num = self.parse_header_smart(full_header)
 

--- a/genizah_translations.py
+++ b/genizah_translations.py
@@ -55,6 +55,8 @@ TRANSLATIONS = {
     "System ID:": "מספר מערכת:",
     "FL": "מס' קובץ",
     "FL:": "מס' קובץ:",
+    "Shelfmark:": "מספר מדף:",
+    "Enter shelfmark...": "הכנס מספר מדף...",
     "Enter FL ID...": "הכנס מספר קובץ...",
     "Shelfmark": "מספר מדף",
     "Title": "כותרת",
@@ -162,6 +164,7 @@ TRANSLATIONS = {
 
     # --- Browse Tab ---
     "Enter System ID...": "הכנס מספר מערכת...",
+    "Enter shelfmark...": "הכנס מספר מדף...",
     "Go": "עבור",
     "Enter ID to browse.": "הכנס מספר לדפדוף.",
     "Ktiv": "כתיב",
@@ -176,6 +179,8 @@ TRANSLATIONS = {
     "Waiting...": "ממתין...",
     "Not found or end.": "לא נמצא או סוף הקובץ.",
     "FL not found.": "מספר קובץ לא נמצא.",
+    "Shelfmark not found.": "מספר המדף לא נמצא.",
+    "Multiple shelfmarks found. Select one:": "נמצאו מספר מספרי מדף. בחר אחד:",
     "Nav": "ניווט",
     "Loading full manuscript...": "טוען כתב יד מלא...",
     "Could not load full text.": "לא ניתן לטעון טקסט מלא.",


### PR DESCRIPTION
## Summary
- allow browsing by shelfmark with tolerant matching that ignores punctuation and spacing
- show up to 100 shelfmark suggestions sorted naturally with compact 60-character labels when matches are ambiguous, and fill the system ID once chosen
- update Browse help text to document the shelfmark search behavior

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6953d7c620a88321b418d712be8e584c)