### PR TITLE
Improve Oxford part navigation and cross-manuscript paging

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -27,7 +27,7 @@ from PyQt6.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout, QH
                              QCompleter)
 from PyQt6.QtCore import (Qt, QTimer, QUrl, QSize, pyqtSignal, QThread, QEventLoop, QEvent, QRect, QRectF)
 from PyQt6.QtGui import (QFont, QIcon, QDesktopServices, QPixmap, QImage, QFontMetrics, QTextDocument, QTransform, QPainter, QColor,
-                         QStandardItemModel, QStandardItem)
+                         QStandardItemModel, QStandardItem, QPalette)
 
 from version import APP_VERSION
 
@@ -1829,7 +1829,7 @@ class ResultDialog(QDialog):
             # Jump by number (user typed in box)
             try: p = int(target)
             except: p = 1
-            page_data = self.searcher.get_browse_page(self.current_sys_id, p_num=p, next_prev=0)
+            page_data = self.searcher.get_browse_page(self.current_sys_id, p_num=p, next_prev=0, allow_cross=True)
         else:
             # Relative Navigation (Next/Prev)
             # Use internal index if we have it, otherwise rely on p_num
@@ -1840,12 +1840,17 @@ class ResultDialog(QDialog):
                 self.current_sys_id, 
                 p_num=p_arg, 
                 next_prev=offset,
-                absolute_index=idx_arg # <--- THIS FIXES THE BUG
+                absolute_index=idx_arg, # <--- THIS FIXES THE BUG
+                allow_cross=True
             )
             
         if not page_data: return
 
         # --- UPDATE STATE ---
+        new_sys = page_data.get('sys_id', self.current_sys_id)
+        if new_sys and new_sys != self.current_sys_id:
+            self.current_sys_id = new_sys
+
         self.current_p_num = page_data['p_num']
         self.current_internal_idx = page_data['internal_index'] # <--- SAVE IT
         
@@ -1854,6 +1859,15 @@ class ResultDialog(QDialog):
         self.current_full_header = page_data.get('full_header', '')
         self.current_page_text = page_data.get('text', '')
         self.current_page_uid = page_data.get('uid')
+
+        # Keep the dialog's data object aligned with the currently displayed folio
+        if self.data is not None:
+            self.data['raw_header'] = page_data.get('full_header', self.data.get('raw_header', ''))
+            self.data['uid'] = page_data.get('uid', self.data.get('uid'))
+            self.data['full_text'] = page_data.get('text', self.data.get('full_text', ''))
+            display_block = self.data.get('display', {})
+            display_block['id'] = self.current_sys_id
+            self.data['display'] = display_block
 
         # Update Info Label
         info_html = f"<b>{tr('Sys')}:</b> {self.current_sys_id} | <b>{tr('FL')}:</b> {self.current_fl_id or '?'}"
@@ -1992,12 +2006,17 @@ class ResultDialog(QDialog):
             self.btn_ext_info.setVisible(False)
             return
 
-        html = "<div style='font-family:Arial;'>"
+        palette = self.txt_extended_info.palette()
+        text_color = palette.color(QPalette.ColorRole.Text).name()
+        base_color = palette.color(QPalette.ColorRole.Base).name()
+        part_bg = QColor(base_color).lighter(115).name()
+
+        html = f"<div style='font-family:Arial; color:{text_color}; background-color:{base_color};'>"
 
         # Oxford Part metadata section
         if part_meta:
             part_display = self.meta_mgr.codico_mgr.get_part_display_name(oxford_part_id)
-            html += f"<div style='background-color: #e8f4f8; padding: 10px; margin-bottom: 10px; border-left: 3px solid #3498db;'>"
+            html += f"<div style='background-color: {part_bg}; color:{text_color}; padding: 10px; margin-bottom: 10px; border-left: 3px solid #3498db;'>"
             html += f"<p><b>📖 {tr('Codicological Part')}:</b> {part_display}</p>"
 
             folio_range = part_meta.get('folio_range', [])
@@ -3129,6 +3148,7 @@ class GenizahGUI(QMainWindow):
             # Get Oxford images for image labels
             part_images = self.meta_mgr.get_part_images(self.current_browse_part_id)
             image_idx = 0
+            part_display = self.meta_mgr.codico_mgr.get_part_display_name(self.current_browse_part_id)
 
             for folio_idx, sid in enumerate(self.current_browse_part_folios):
                 pages = self.searcher.get_full_manuscript(sid)
@@ -3139,6 +3159,9 @@ class GenizahGUI(QMainWindow):
                 shelf, _ = self.meta_mgr.get_meta_for_id(sid)
                 if not shelf or shelf == "Unknown":
                     shelf = sid
+                shelf_display = shelf
+                if part_display:
+                    shelf_display = f"{part_display} | {shelf}"
 
                 for p in pages:
                     # Get image label from Oxford images
@@ -3161,7 +3184,7 @@ class GenizahGUI(QMainWindow):
                         <a href="{link_href}" style='color: #2980b9; text-decoration: none; font-weight: bold;'>
                             {link_text}
                         </a>
-                        <span style='font-size: 0.85em; color: #777; margin-left: 10px;'>{shelf}</span>
+                        <span style='font-size: 0.85em; color: #777; margin-left: 10px;'>{shelf_display}</span>
                     </div>
                     """
 
@@ -5987,6 +6010,20 @@ class GenizahGUI(QMainWindow):
 
         return sys_id, page, shelf_lbl, title_lbl
 
+    def _update_part_state_for_sid(self, sid):
+        """Refresh Part context (Neubauer) for the given system ID."""
+        part_id = self.meta_mgr.get_part_for_folio(sid) if self.meta_mgr else None
+        if part_id:
+            folios = self.meta_mgr.get_folios_for_part(part_id) or []
+            self.current_browse_part_id = part_id
+            self.current_browse_part_folios = folios
+            self.current_browse_part_folio_idx = folios.index(sid) if sid in folios else 0
+        else:
+            self.current_browse_part_id = None
+            self.current_browse_part_folios = []
+            self.current_browse_part_folio_idx = 0
+        return part_id
+
     def browse_load(self):
         if not self.searcher: return
         sid = self.browse_sys_input.text().strip()
@@ -6093,6 +6130,12 @@ class GenizahGUI(QMainWindow):
             if shelf_query:
                 msg = tr("Shelfmark not found.")
             QMessageBox.warning(self, tr("Error"), msg)
+            return
+
+        # If this folio belongs to an Oxford Part, load the Part context directly
+        part_for_sid = self.meta_mgr.get_part_for_folio(sid)
+        if part_for_sid:
+            self._browse_load_part(part_for_sid, target_folio=sid)
             return
 
         self.current_browse_sid = sid
@@ -6232,15 +6275,39 @@ class GenizahGUI(QMainWindow):
             self.current_browse_sid, 
             p_num=p_arg, 
             next_prev=d,
-            absolute_index=idx_arg
+            absolute_index=idx_arg,
+            allow_cross=True
         )
 
-        if page_data:
-            self.browse_render_page(page_data)
-        else:
+        if not page_data:
             QMessageBox.warning(self, tr("Nav"), tr("Not found or end."))
+            return
+
+        new_sid = page_data.get('sys_id', self.current_browse_sid)
+        if new_sid != self.current_browse_sid:
+            self.current_browse_sid = new_sid
+            self.browse_sys_input.setText(new_sid)
+            shelf, _ = self.meta_mgr.get_meta_for_id(new_sid)
+            if shelf and shelf != "Unknown":
+                self.browse_shelf_input.setText(shelf)
+            self._set_last_browse_field("sys")
+            # Refresh Part context
+            self._update_part_state_for_sid(new_sid)
+            # Kick off metadata enrichment for new manuscript
+            cached_meta = self.meta_mgr.nli_cache.get(new_sid)
+            if cached_meta:
+                self.on_browse_enriched_loaded(new_sid, cached_meta)
+            else:
+                self.enrich_browse_worker = EnrichMetadataThread(self.meta_mgr, new_sid)
+                self.enrich_browse_worker.finished_signal.connect(self.on_browse_enriched_loaded)
+                self.enrich_browse_worker.start()
+
+        self.browse_render_page(page_data)
     
     def browse_render_page(self, pd):
+        if pd.get('sys_id') and pd.get('sys_id') != self.current_browse_sid:
+            self.current_browse_sid = pd['sys_id']
+
         self.current_browse_p = pd['p_num']
         
         if 'internal_index' in pd:

--- a/genizah_core.py
+++ b/genizah_core.py
@@ -3581,9 +3581,13 @@ class SearchEngine:
                 })
         return full_content
         
-    def get_browse_page(self, sys_id, p_num=None, next_prev=0, absolute_index=None):
+    def get_browse_page(self, sys_id, p_num=None, next_prev=0, absolute_index=None, allow_cross=False):
         browse_map = self._load_browse_map()
         if not browse_map: return None
+
+        # Prepare ordered list for cross-manuscript navigation
+        if allow_cross and (not hasattr(self, '_ordered_sys_ids') or not self._ordered_sys_ids):
+            self._ordered_sys_ids = list(browse_map.keys())
 
         if sys_id not in browse_map: return None
         pages = browse_map[sys_id]
@@ -3623,6 +3627,20 @@ class SearchEngine:
         # Calculate New Index
         new_idx = target_idx + next_prev
         
+        # Handle crossing to adjacent manuscripts when requested
+        if (new_idx < 0 or new_idx >= len(pages)) and allow_cross and next_prev != 0:
+            direction = 1 if next_prev > 0 else -1
+            adjacent_id = self.get_adjacent_sys_id_by_file_order(sys_id, direction)
+            while adjacent_id:
+                if adjacent_id in browse_map and browse_map[adjacent_id]:
+                    pages = browse_map[adjacent_id]
+                    sys_id = adjacent_id
+                    new_idx = 0 if direction > 0 else len(pages) - 1
+                    break
+                adjacent_id = self.get_adjacent_sys_id_by_file_order(adjacent_id, direction)
+            else:
+                return None
+
         if new_idx < 0 or new_idx >= len(pages): return None
         
         target_page = pages[new_idx]
@@ -3635,7 +3653,8 @@ class SearchEngine:
             'text': text,
             'total_pages': len(pages), 
             'current_idx': new_idx + 1, # Display is 1-based
-            'internal_index': new_idx   # 0-based for logic (NEW)
+            'internal_index': new_idx,  # 0-based for logic (NEW)
+            'sys_id': sys_id
         }
 
     def get_browse_page_by_fl(self, fl_id, sys_id=None):


### PR DESCRIPTION
### Motivation

- Make browsing of Oxford (Bodleian) manuscripts respect codicological `Part` units and surface the Part shelfmark in continuous (View All) mode.
- Allow paging in the viewer and browse UI to continue to the next/previous manuscript following the transcription file order when reaching a Part or folio boundary.
- Keep the Part browsing state synchronized when moving between folios and when loading results from search so users can navigate Parts seamlessly.
- Ensure Oxford extended metadata text in the viewer is readable in dark mode by using the active palette colors.

### Description

- Added an `allow_cross` parameter to `SearchEngine.get_browse_page` and implemented logic to roll over to adjacent system IDs by file order, and returned the `sys_id` in page payloads for caller synchronization.
- Updated the browse flow (`browse_load`, `browse_load_all`, `browse_navigate`) and the result viewer (`ResultDialog.load_page`) to call `get_browse_page` with `allow_cross=True`, to update `current_browse_sid` when crossing manuscripts, and to refresh Part context via a new helper `GenizahGUI._update_part_state_for_sid`.
- When rendering `View All` for an Oxford `Part`, the code now shows the Part display name in separators and includes the shelfmark alongside Part info, and when loading a folio that belongs to a Part it auto-loads the Part context (`_browse_load_part`) where appropriate.
- Made extended-info HTML build use the widget palette (`QPalette`) and `QColor` so background/text colors respect dark mode, and synced the viewer dialog `data` fields with the currently displayed folio to keep UI actions consistent.

### Testing

- Compiled modified modules with `python -m compileall genizah_app.py genizah_core.py` and the compilation completed successfully.
- Verified no syntax errors on both `genizah_app.py` and `genizah_core.py` after the changes by running the compilation step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695d0668efa48321a7f77ce6f52d789c)