### PR TITLE
Display short Oxford part label (e.g. "[part 23]") in shelfmark

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -2068,14 +2068,15 @@ class ResultDialog(QDialog):
         self.btn_ext_info.setVisible(True)
 
         self.lbl_title.setText(meta.get('title', ''))
-        shelf = meta.get('shelfmark')
+            shelf = meta.get('shelfmark')
         if shelf and shelf != "Unknown":
             library = marc.get('current_owner')
             if library: shelf = f"{library} | {shelf}"
             # Add Part info to shelfmark if available
             if oxford_part_id:
-                part_display = self.meta_mgr.codico_mgr.get_part_display_name(oxford_part_id)
-                shelf = f"{shelf} [{part_display}]"
+                part_label = self.meta_mgr.codico_mgr.get_part_label(oxford_part_id)
+                if part_label:
+                    shelf = f"{shelf} [{part_label}]"
             self.lbl_shelf.setText(shelf)
 
     def sync_external_view(self):

--- a/genizah_core.py
+++ b/genizah_core.py
@@ -1840,6 +1840,17 @@ class CodicologicalManager:
             return f"{part_id} part"
         return part_id
 
+    def get_part_label(self, part_id):
+        """Return a short Part label suitable for shelfmark suffixes (e.g., "part 23")."""
+        if not part_id:
+            return ""
+
+        match = re.search(r'/([A-Za-z0-9]+)$', part_id)
+        if match:
+            return f"part {match.group(1)}"
+
+        return "part"
+
     def is_part_id(self, identifier):
         """Check if an identifier is a Part ID (vs a regular shelfmark)."""
         # Check for "part" suffix (new format)


### PR DESCRIPTION
### Motivation

- Oxford Parts were being shown with their full Part display text in the shelfmark area which duplicated long Oxford metadata and made the viewer header verbose.
- The intent is to show a concise, user-friendly suffix like `[part 23]` at the end of the shelfmark instead of the full part display string.

### Description

- Added a new helper `get_part_label` to `CodicologicalManager` in `genizah_core.py` that extracts and returns a short label like `part 23` from an Oxford Part ID.
- Updated the result/info UI code in `genizah_app.py` to call `get_part_label` and append the short label (in brackets) to the shelf display when an Oxford Part is present.
- Changes are limited to `genizah_core.py` and `genizah_app.py` and do not change existing part parsing or index data structures.

### Testing

- No automated tests were executed for this change.
- The change was committed as `Adjust Oxford part label display` and is ready for review and test integration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695d31150fe08321bc747a9632c233fc)