### PR TITLE
Restore custom variants and mutation limits feature

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -2756,6 +2756,9 @@ class GenizahGUI(QMainWindow):
             # Init Lab Engine (lightweight init)
             self.lab_engine = LabEngine(self.meta_mgr, self.var_mgr)
 
+            # Connect lab settings to search engine for custom variants support
+            self.searcher.lab_settings = self.lab_engine.settings
+
             # Setup Panels (guaranteed to exist as init_ui runs before startup thread)
             if hasattr(self, 'lab_panel_search'):
                 self.lab_panel_search.set_engine(self.lab_engine)

--- a/genizah_app.py
+++ b/genizah_app.py
@@ -306,6 +306,114 @@ class LabScoringDialog(QDialog):
         self.settings.save()
         self.accept()
 
+class CustomVariantsDialog(QDialog):
+    """Dialog for configuring custom letter/word variants and max substitutions per word."""
+    def __init__(self, parent, lab_engine):
+        super().__init__(parent)
+        self.setWindowTitle(tr("Custom Variants"))
+        self.resize(500, 450)
+        self.lab_engine = lab_engine
+        self.settings = lab_engine.settings
+        if CURRENT_LANG == 'he':
+            self.setLayoutDirection(Qt.LayoutDirection.RightToLeft)
+
+        layout = QVBoxLayout()
+
+        # Explanation
+        lbl_info = QLabel(tr("Define custom letter substitutions (e.g., כו=מ means כו and מ are interchangeable)."))
+        lbl_info.setWordWrap(True)
+        layout.addWidget(lbl_info)
+
+        # Enable checkbox
+        self.chk_use_custom = QCheckBox(tr("Use Custom Variants"))
+        self.chk_use_custom.setChecked(self.settings.use_custom_variants)
+        self.chk_use_custom.setToolTip(tr("Enable searching with custom variant substitutions."))
+        layout.addWidget(self.chk_use_custom)
+
+        # Max changes per word
+        hbox_max = QHBoxLayout()
+        hbox_max.addWidget(QLabel(tr("Max Changes per Word:")))
+        self.spin_max_changes = QSpinBox()
+        self.spin_max_changes.setRange(1, 5)
+        self.spin_max_changes.setValue(self.settings.max_char_changes)
+        self.spin_max_changes.setToolTip(tr("Maximum number of character substitutions allowed per word (controls combinatorial explosion)."))
+        hbox_max.addWidget(self.spin_max_changes)
+        hbox_max.addStretch()
+        layout.addLayout(hbox_max)
+
+        # Custom variants text
+        lbl_variants = QLabel(tr("Custom Variants (char=char, word=word):"))
+        lbl_variants.setStyleSheet("font-weight: bold; margin-top: 10px;")
+        layout.addWidget(lbl_variants)
+
+        self.txt_variants = QPlainTextEdit()
+        self.txt_variants.setPlaceholderText("ד=ר\nכו=מ\nאי=י")
+        # Load existing variants
+        existing_text = self._variants_dict_to_text(self.settings.custom_variants)
+        self.txt_variants.setPlainText(existing_text)
+        layout.addWidget(self.txt_variants)
+
+        lbl_hint = QLabel(tr("Each line should contain a pair like: א=ב (both directions are searched automatically)"))
+        lbl_hint.setStyleSheet("color: gray; font-size: 10px;")
+        lbl_hint.setWordWrap(True)
+        layout.addWidget(lbl_hint)
+
+        # Buttons
+        btn_box = QHBoxLayout()
+        btn_box.addStretch()
+        self.btn_cancel = QPushButton(tr("Cancel"))
+        self.btn_cancel.clicked.connect(self.reject)
+        self.btn_save = QPushButton(tr("Save & Close"))
+        self.btn_save.clicked.connect(self.save_and_close)
+        btn_box.addWidget(self.btn_cancel)
+        btn_box.addWidget(self.btn_save)
+        layout.addLayout(btn_box)
+
+        self.setLayout(layout)
+
+    def _variants_dict_to_text(self, variants_dict):
+        """Convert variants dict {a: [b,c], b: [a]} to text format 'a=b\\na=c'."""
+        lines = []
+        seen = set()
+        for key, values in variants_dict.items():
+            for val in values:
+                pair = tuple(sorted([key, val]))
+                if pair not in seen:
+                    seen.add(pair)
+                    lines.append(f"{key}={val}")
+        return "\n".join(lines)
+
+    def _text_to_variants_dict(self, text):
+        """Convert text format 'a=b' to variants dict with bidirectional mapping."""
+        variants = {}
+        for line in text.strip().split('\n'):
+            line = line.strip()
+            if '=' not in line:
+                continue
+            parts = line.split('=', 1)
+            if len(parts) != 2:
+                continue
+            a, b = parts[0].strip(), parts[1].strip()
+            if not a or not b:
+                continue
+            # Bidirectional
+            if a not in variants:
+                variants[a] = []
+            if b not in variants[a]:
+                variants[a].append(b)
+            if b not in variants:
+                variants[b] = []
+            if a not in variants[b]:
+                variants[b].append(a)
+        return variants
+
+    def save_and_close(self):
+        self.settings.use_custom_variants = self.chk_use_custom.isChecked()
+        self.settings.max_char_changes = self.spin_max_changes.value()
+        self.settings.custom_variants = self._text_to_variants_dict(self.txt_variants.toPlainText())
+        self.settings.save()
+        self.accept()
+
 class LabPanel(QFrame):
     def __init__(self, parent, mode):
         super().__init__(parent)
@@ -398,6 +506,12 @@ class LabPanel(QFrame):
 
             self.layout.addStretch()
 
+            # Custom Variants
+            self.btn_variants = QPushButton(tr("Custom Variants..."))
+            self.btn_variants.setStyleSheet("background-color: #8e44ad; color: white; font-weight: bold; border-radius: 4px; padding: 4px;")
+            self.btn_variants.clicked.connect(self.open_variants)
+            self.layout.addWidget(self.btn_variants)
+
             # Advanced Scoring
             self.btn_scoring = QPushButton(tr("Advanced Scoring..."))
             self.btn_scoring.setStyleSheet("background-color: #7f8c8d; color: white; font-weight: bold; border-radius: 4px; padding: 4px;")
@@ -432,6 +546,12 @@ class LabPanel(QFrame):
             self.layout.addWidget(self.spin_max_final)
 
             self.layout.addStretch()
+
+            # Custom Variants
+            self.btn_variants = QPushButton(tr("Custom Variants..."))
+            self.btn_variants.setStyleSheet("background-color: #8e44ad; color: white; font-weight: bold; border-radius: 4px; padding: 4px;")
+            self.btn_variants.clicked.connect(self.open_variants)
+            self.layout.addWidget(self.btn_variants)
 
             # Advanced Scoring
             self.btn_scoring = QPushButton(tr("Advanced Scoring..."))
@@ -473,6 +593,11 @@ class LabPanel(QFrame):
     def open_scoring(self):
          if not self.lab_engine: return
          d = LabScoringDialog(self, self.lab_engine)
+         d.exec()
+
+    def open_variants(self):
+         if not self.lab_engine: return
+         d = CustomVariantsDialog(self, self.lab_engine)
          d.exec()
 
     def _mark_rebuild_required(self):

--- a/genizah_core.py
+++ b/genizah_core.py
@@ -3268,6 +3268,7 @@ class SearchEngine:
     def __init__(self, meta_mgr, variants_mgr):
         self.meta_mgr = meta_mgr
         self.var_mgr = variants_mgr
+        self.lab_settings = None  # Set by main app after lab_engine is created
         self.index = None
         self.searcher = None
         self.reload_index()
@@ -3306,21 +3307,30 @@ class SearchEngine:
             regex_str = terms[0]
             candidates = re.findall(r'[\u0590-\u05FF]{2,}', regex_str)
             if candidates: return " AND ".join(candidates)
-            else: return "*" 
+            else: return "*"
+
+        # Get custom variants from lab_settings if enabled
+        custom_vars = None
+        max_changes = None
+        if self.lab_settings and self.lab_settings.use_custom_variants:
+            custom_vars = self.lab_settings.custom_variants
+            max_changes = self.lab_settings.max_char_changes
 
         parts = []
         for term in terms:
             if term.upper() in ['AND', 'OR', 'NOT', '(', ')']:
                 parts.append(term)
                 continue
-                
+
             if mode == 'fuzzy':
-                if len(term) < 3: parts.append(f'"{term}"') 
+                if len(term) < 3: parts.append(f'"{term}"')
                 elif len(term) < 5: parts.append(f'"{term}"~1')
                 else: parts.append(f'"{term}"~2')
             else:
                 # 1. Get variants (limit 200 is usually enough if quality is good)
-                all_vars = self.var_mgr.get_variants(term, mode, limit=200)
+                all_vars = self.var_mgr.get_variants(term, mode, limit=200,
+                                                     custom_variants=custom_vars,
+                                                     max_char_changes=max_changes)
                 
                 # 2. Prepare list
                 clean_vars = []
@@ -3350,12 +3360,21 @@ class SearchEngine:
             try: return re.compile(" ".join(terms), re.IGNORECASE)
             except: return None
 
+        # Get custom variants from lab_settings if enabled
+        custom_vars = None
+        max_changes = None
+        if self.lab_settings and self.lab_settings.use_custom_variants:
+            custom_vars = self.lab_settings.custom_variants
+            max_changes = self.lab_settings.max_char_changes
+
         parts = []
         for term in terms:
             regex_mode = 'variants_maximum' if mode == 'fuzzy' else mode
-            
+
             # 1. Get variants
-            vars_list = self.var_mgr.get_variants(term, regex_mode, limit=Config.REGEX_VARIANTS_LIMIT)
+            vars_list = self.var_mgr.get_variants(term, regex_mode, limit=Config.REGEX_VARIANTS_LIMIT,
+                                                  custom_variants=custom_vars,
+                                                  max_char_changes=max_changes)
             
             # 2. Ensure exact term
             if term not in vars_list:

--- a/genizah_core.py
+++ b/genizah_core.py
@@ -90,7 +90,9 @@ except ImportError:
 class LabSettings:
     """Manages configuration for the Lab Mode, including scoring weights."""
     def __init__(self):
-        self.custom_variants = {} 
+        self.custom_variants = {}
+        self.use_custom_variants = False
+        self.max_char_changes = 1
         self.candidate_limit = 5000
         self.min_should_match = 75
         self.gap_penalty = 2
@@ -128,6 +130,8 @@ class LabSettings:
                 with open(Config.LAB_CONFIG_FILE, 'r', encoding='utf-8') as f:
                     data = json.load(f)
                     self.custom_variants = data.get('custom_variants', {})
+                    self.use_custom_variants = data.get('use_custom_variants', False)
+                    self.max_char_changes = data.get('max_char_changes', 1)
                     self.use_dynamic_weights = data.get('use_dynamic_weights', False)
                     self.candidate_limit = data.get('candidate_limit', 2000)
                     self.min_should_match = data.get('min_should_match', 60)
@@ -158,6 +162,8 @@ class LabSettings:
             with open(Config.LAB_CONFIG_FILE, 'w', encoding='utf-8') as f:
                 json.dump({
                     'custom_variants': self.custom_variants,
+                    'use_custom_variants': self.use_custom_variants,
+                    'max_char_changes': self.max_char_changes,
                     'use_dynamic_weights': self.use_dynamic_weights,
                     'candidate_limit': self.candidate_limit,
                     'min_should_match': self.min_should_match,
@@ -209,6 +215,49 @@ class LabEngine:
                 pass
 
         self._reload_lab_index()
+
+    def _expand_with_custom_variants(self, text):
+        """Expand query text using custom variants from settings.
+
+        If custom variants are enabled and defined, generates additional
+        variants of the query by applying character/string substitutions.
+        Returns a list of query strings (original + variants).
+        """
+        if not self.settings.use_custom_variants or not self.settings.custom_variants:
+            return [text]
+
+        # Use VariantManager to expand each word
+        words = text.split()
+        if not words:
+            return [text]
+
+        # Get variants for each word
+        max_changes = self.settings.max_char_changes
+        custom_vars = self.settings.custom_variants
+
+        expanded_words_list = []
+        for word in words:
+            word_variants = self.var_mgr.get_variants(
+                word, 'literal',  # Base mode doesn't matter since we're using custom variants
+                limit=50,
+                custom_variants=custom_vars,
+                max_char_changes=max_changes
+            )
+            expanded_words_list.append(word_variants if word_variants else [word])
+
+        # Generate combinations (limit to avoid explosion)
+        import itertools
+        result_queries = set()
+        result_queries.add(text)  # Always include original
+
+        # For each word position, try different variants
+        for i, variants in enumerate(expanded_words_list):
+            for v in variants[:20]:  # Limit variants per word
+                new_words = words.copy()
+                new_words[i] = v
+                result_queries.add(' '.join(new_words))
+
+        return list(result_queries)[:100]  # Limit total queries
 
     def _close_index(self):
         self.lab_searcher = None
@@ -685,11 +734,21 @@ class LabEngine:
         target_field = "fingerprint_dyn" if use_dyn else self.LAB_FINGERPRINT_FIELD
         target_map = self.dynamic_rank_map if use_dyn else HEBREW_FREQ
 
-        # 1. Prepare Fingerprints
-        fp_str = text_to_fingerprint(query_str, freq_map=target_map)
-        if not fp_str: return []
-        
-        query_fp_list = fp_str.split()
+        # 1. Prepare Fingerprints (with custom variant expansion)
+        query_variants = self._expand_with_custom_variants(query_str)
+
+        # Collect fingerprints from all variants
+        all_fingerprints = set()
+        for variant_query in query_variants:
+            fp_str = text_to_fingerprint(variant_query, freq_map=target_map)
+            if fp_str:
+                all_fingerprints.update(fp_str.split())
+
+        if not all_fingerprints: return []
+
+        # Use combined fingerprints
+        fp_str = ' '.join(all_fingerprints)
+        query_fp_list = list(all_fingerprints)
         
         # 2. Fetch Candidates
         slop = max(50, int(self.settings.gap_penalty) * 10) 
@@ -839,11 +898,21 @@ class LabEngine:
             
             if self._is_phrase_statistically_weak(chunk_text): continue
 
-            fp_str = text_to_fingerprint(chunk_text, freq_map=target_map)
-            if not fp_str or len(chunk_tokens) < 4: continue
-            
-            fp_list = fp_str.split()
-            needed_unique_fps = set(fp_list) 
+            # Expand chunk with custom variants
+            chunk_variants = self._expand_with_custom_variants(chunk_text)
+
+            # Collect fingerprints from all variants
+            all_fps = set()
+            for variant_chunk in chunk_variants:
+                fp_var = text_to_fingerprint(variant_chunk, freq_map=target_map)
+                if fp_var:
+                    all_fps.update(fp_var.split())
+
+            if not all_fps or len(chunk_tokens) < 4: continue
+
+            fp_str = ' '.join(all_fps)
+            fp_list = list(all_fps)
+            needed_unique_fps = all_fps 
 
             # Query with Boost
             query_tokens = fp_str.split()
@@ -1564,8 +1633,17 @@ class VariantManager:
                             return result
         return result
 
-    def get_variants(self, term: str, mode: str, limit: int = Config.VARIANT_GEN_LIMIT) -> list[str]:
-        """Generate spelling variants for Hebrew search terms using multiple maps."""
+    def get_variants(self, term: str, mode: str, limit: int = Config.VARIANT_GEN_LIMIT,
+                      custom_variants: dict = None, max_char_changes: int = None) -> list[str]:
+        """Generate spelling variants for Hebrew search terms using multiple maps.
+
+        Args:
+            term: The search term to generate variants for
+            mode: Search mode ('variants', 'variants_extended', 'variants_maximum')
+            limit: Maximum number of variants to generate
+            custom_variants: Optional dict of custom bidirectional mappings {char: [replacements]}
+            max_char_changes: Optional max substitutions per word (overrides default per layer)
+        """
         if len(term) < 2:
             return [term]
 
@@ -1574,6 +1652,7 @@ class VariantManager:
         # Rank 1: Basic Variants
         # Rank 2: Extended Variants
         # Rank 3: Maximum Variants
+        # Rank 4: Custom Variants (highest priority for user-defined)
 
         candidates = {term: 0}
 
@@ -1588,11 +1667,30 @@ class VariantManager:
             layers.append((self.extended_map, 2, 2))
             layers.append((self.maximum_map, 2, 3))
         else:
+            # Even in literal mode, apply custom variants if provided
+            pass
+
+        # Add custom variants layer if provided
+        if custom_variants:
+            # Convert dict {a: [b,c]} to multimap format
+            custom_map = defaultdict(set)
+            for key, values in custom_variants.items():
+                for val in values:
+                    custom_map[key].add(val)
+                    custom_map[val].add(key)  # Bidirectional
+            if custom_map:
+                # Custom variants get rank 0 (highest priority, just after original term)
+                custom_max = max_char_changes if max_char_changes else 2
+                layers.insert(0, (custom_map, custom_max, 0))
+
+        if not layers:
             return [term]
 
         # Process layers
-        for mapping, max_changes, rank in layers:
-            layer_vars = self.generate_variants(term, mapping, max_changes, limit)
+        for mapping, layer_max_changes, rank in layers:
+            # If max_char_changes is specified, use it for all layers
+            effective_max = max_char_changes if max_char_changes else layer_max_changes
+            layer_vars = self.generate_variants(term, mapping, effective_max, limit)
             for v in layer_vars:
                 if v not in candidates:
                     candidates[v] = rank

--- a/genizah_translations.py
+++ b/genizah_translations.py
@@ -389,6 +389,14 @@ TRANSLATIONS = {
     "Minimum score required for a chunk to be considered a match.": "ציון מינימלי הדרוש למקטע כדי להיחשב כהתאמה.",
     "Maximum number of results to display in the tree (prevents freezing). All results are exported.": "מספר מקסימלי של תוצאות להצגה בעץ (מונע קפיאה). כל התוצאות מיוצאות.",
 
+    # --- Custom Variants Dialog ---
+    "Custom Variants": "ווריאנטים מותאמים",
+    "Custom Variants...": "ווריאנטים מותאמים...",
+    "Define custom letter substitutions (e.g., כו=מ means כו and מ are interchangeable).": "הגדר החלפות אותיות מותאמות (למשל, כו=מ פירושו שכו ו-מ ניתנים להחלפה).",
+    "Enable searching with custom variant substitutions.": "אפשר חיפוש עם החלפות וריאנטים מותאמות.",
+    "Maximum number of character substitutions allowed per word (controls combinatorial explosion).": "מספר מקסימלי של החלפות תווים המותרות למילה (שולט בפיצוץ קומבינטורי).",
+    "Each line should contain a pair like: א=ב (both directions are searched automatically)": "כל שורה צריכה להכיל זוג כמו: א=ב (שני הכיוונים נחפשים אוטומטית)",
+
     # --- Result Dialog ---
     "Manuscript Viewer": "צפייה בכתב יד",
     "Result {} of {}": "תוצאה {} מתוך {}", 


### PR DESCRIPTION
- Add use_custom_variants and max_char_changes settings to LabSettings
- Create CustomVariantsDialog for editing character substitution pairs
- Add "Custom Variants..." button to LabPanel (search and composition modes)
- Enhance VariantManager.get_variants() to support custom variants and max changes
- Integrate custom variant expansion into lab_search and lab_composition_search
- Add Hebrew translations for all new UI elements

The feature allows users to define custom letter/word substitutions (e.g., כו=מ) that are applied bidirectionally during search. The max_char_changes setting controls the combinatorial explosion by limiting substitutions per word.