### PR TITLE
Fix Cambridge image display mismatch

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -111,7 +111,23 @@ def _get_initial_image_index(meta, page_num):
     return min(folio_entries, key=lambda pair: pair[1])[0]
 
 def _get_folio_number_from_shelfmark(shelfmark):
+    """Extract folio number from Oxford-style shelfmarks only.
+
+    Oxford shelfmarks like "MS. Heb. a. 1/1" or "Bodl. Or. 12/3" contain
+    actual folio numbers after the slash. Other libraries (Cambridge, NLI, etc.)
+    use classmarks where trailing numbers are not folio references.
+    """
     if not shelfmark:
+        return None
+    upper = shelfmark.upper()
+    # Only extract folio from Oxford-style shelfmarks (MS. Heb., Bodl., etc.)
+    is_oxford = (
+        'MS. HEB' in upper or
+        'MS HEB' in upper or
+        upper.startswith('BODL') or
+        'BODLEIAN' in upper
+    )
+    if not is_oxford:
         return None
     match = re.search(r'[/.](\d+)\s*$', shelfmark)
     if not match:

--- a/genizah_core.py
+++ b/genizah_core.py
@@ -2806,7 +2806,17 @@ class MetadataManager:
                             img_id = service.get('@id') if service else resource.get('@id')
 
                             if img_id:
-                                result['canvases'].append({'label': lbl, 'url': img_id})
+                                # Extract folio_num from label for proper page indexing
+                                # Labels like "1", "1r", "1v", "2" etc. - extract leading number
+                                # Labels like "Binding", "Cover" etc. - no folio_num
+                                folio_num = None
+                                lbl_match = re.match(r'^(\d+)', str(lbl).strip())
+                                if lbl_match:
+                                    try:
+                                        folio_num = int(lbl_match.group(1))
+                                    except (TypeError, ValueError):
+                                        pass
+                                result['canvases'].append({'label': lbl, 'url': img_id, 'folio_num': folio_num})
 
             return result
         except Exception as e:


### PR DESCRIPTION
Cambridge IIIF manifests include a binding/cover canvas as the first image, but search results reference pages starting from 1. This caused an off-by-one error where page 1 displayed the binding instead of the actual first page.

The fix extracts folio_num from canvas labels (e.g., "1", "1r", "2v") so that _get_initial_image_index can correctly map page numbers to canvas indices, skipping non-numbered canvases like "Binding" or "Cover".