### PR TITLE
Fix lazy loading snippet display for images

### DIFF
--- a/Help.html
+++ b/Help.html
@@ -63,7 +63,6 @@
     }
     .rtl {
         direction: rtl;
-        text-align: right;
         unicode-bidi: isolate;
     }
     .ltr {

--- a/genizah_app.py
+++ b/genizah_app.py
@@ -6788,6 +6788,14 @@ class GenizahGUI(QMainWindow):
                     group_node.setData(0, Qt.ItemDataRole.UserRole + 200, items)  # Store items for lazy load
                     placeholder = QTreeWidgetItem(group_node, [tr("Loading...")])
                     placeholder.setData(0, Qt.ItemDataRole.UserRole + 201, "PLACEHOLDER")
+                    # Show snippet from first item on the group node
+                    if items:
+                        sorted_items = self._sort_comp_items(items)
+                        first_item = sorted_items[0]
+                        pages = first_item.get('pages', [])
+                        if pages:
+                            p0 = pages[0]
+                            self._set_comp_node_previews(group_node, p0.get('source_ctx', ''), p0.get('text', ''), p0.get('highlight_pattern'))
 
             # 3. Filtered 
             total_filt = len(clean_filt) + sum(len(v) for v in clean_filt_appx.values())
@@ -6809,6 +6817,14 @@ class GenizahGUI(QMainWindow):
                     g_node.setData(0, Qt.ItemDataRole.UserRole + 200, items)
                     placeholder = QTreeWidgetItem(g_node, [tr("Loading...")])
                     placeholder.setData(0, Qt.ItemDataRole.UserRole + 201, "PLACEHOLDER")
+                    # Show snippet from first item on the group node
+                    if items:
+                        sorted_items = self._sort_comp_items(items)
+                        first_item = sorted_items[0]
+                        pages = first_item.get('pages', [])
+                        if pages:
+                            p0 = pages[0]
+                            self._set_comp_node_previews(g_node, p0.get('source_ctx', ''), p0.get('text', ''), p0.get('highlight_pattern'))
 
             # 4. Excluded
             if self.comp_known:

--- a/genizah_app.py
+++ b/genizah_app.py
@@ -7013,28 +7013,50 @@ class GenizahGUI(QMainWindow):
     def _process_tree_batch(self):
         """Process one batch of items and schedule next batch."""
         if not hasattr(self, '_batch_queue') or self._batch_index >= len(self._batch_queue):
-            # Done loading - cleanup
+            # Done loading - cleanup and apply all deferred previews
+            parent = self._batch_parent
             self._batch_queue = None
             self._batch_parent = None
             self.comp_tree.setUpdatesEnabled(True)
             self.comp_tree_updating = False  # Re-enable itemChanged signal
             self._update_comp_filter_indicators()
             self._apply_comp_tree_filters()
+
+            # Apply deferred preview widgets to all loaded nodes
+            if parent:
+                def apply_all_previews():
+                    for i in range(parent.childCount()):
+                        child = parent.child(i)
+                        self._apply_comp_node_previews(child)
+                        for j in range(child.childCount()):
+                            self._apply_comp_node_previews(child.child(j))
+                QTimer.singleShot(0, apply_all_previews)
             return
 
         # Process batch
         self.comp_tree.setUpdatesEnabled(False)
         end_index = min(self._batch_index + self._batch_size, len(self._batch_queue))
+        start_index = self._batch_index
 
-        for i in range(self._batch_index, end_index):
+        for i in range(start_index, end_index):
             self._add_manuscript_node(self._batch_parent, self._batch_queue[i])
 
         self._batch_index = end_index
         self.comp_tree.setUpdatesEnabled(True)
 
+        # Apply previews for this batch
+        parent = self._batch_parent
+        def apply_batch_previews():
+            for i in range(start_index, min(end_index, parent.childCount())):
+                child = parent.child(i)
+                self._apply_comp_node_previews(child)
+                for j in range(child.childCount()):
+                    self._apply_comp_node_previews(child.child(j))
+        QTimer.singleShot(0, apply_batch_previews)
+
         # Schedule next batch with small delay to let UI breathe
         if self._batch_index < len(self._batch_queue):
-            QTimer.singleShot(0, self._process_tree_batch)
+            QTimer.singleShot(10, self._process_tree_batch)
 
     def _trigger_lazy_metadata_fetch(self):
         """Starts background fetching for items that are currently displayed but missing data."""

--- a/genizah_app.py
+++ b/genizah_app.py
@@ -7237,9 +7237,14 @@ class GenizahGUI(QMainWindow):
             self.comp_tree.setUpdatesEnabled(False)
             sorted_items = self._sort_comp_items(virtual_items)
             for ms_item in sorted_items:
-                self._add_manuscript_node(item, ms_item, defer_widgets=False)
+                self._add_manuscript_node(item, ms_item)  # defer_widgets=True (default)
             self.comp_tree.setUpdatesEnabled(True)
             self.comp_tree_updating = False
+
+            # Apply deferred preview widgets now that updates are enabled
+            for i in range(item.childCount()):
+                child = item.child(i)
+                self._apply_comp_node_previews(child)
 
             # Clear virtual data to prevent re-population
             item.setData(0, Qt.ItemDataRole.UserRole + 200, None)

--- a/genizah_app.py
+++ b/genizah_app.py
@@ -6788,14 +6788,6 @@ class GenizahGUI(QMainWindow):
                     group_node.setData(0, Qt.ItemDataRole.UserRole + 200, items)  # Store items for lazy load
                     placeholder = QTreeWidgetItem(group_node, [tr("Loading...")])
                     placeholder.setData(0, Qt.ItemDataRole.UserRole + 201, "PLACEHOLDER")
-                    # Show snippet from first item on the group node
-                    if items:
-                        sorted_items = self._sort_comp_items(items)
-                        first_item = sorted_items[0]
-                        pages = first_item.get('pages', [])
-                        if pages:
-                            p0 = pages[0]
-                            self._set_comp_node_previews(group_node, p0.get('source_ctx', ''), p0.get('text', ''), p0.get('highlight_pattern'))
 
             # 3. Filtered 
             total_filt = len(clean_filt) + sum(len(v) for v in clean_filt_appx.values())
@@ -6817,14 +6809,6 @@ class GenizahGUI(QMainWindow):
                     g_node.setData(0, Qt.ItemDataRole.UserRole + 200, items)
                     placeholder = QTreeWidgetItem(g_node, [tr("Loading...")])
                     placeholder.setData(0, Qt.ItemDataRole.UserRole + 201, "PLACEHOLDER")
-                    # Show snippet from first item on the group node
-                    if items:
-                        sorted_items = self._sort_comp_items(items)
-                        first_item = sorted_items[0]
-                        pages = first_item.get('pages', [])
-                        if pages:
-                            p0 = pages[0]
-                            self._set_comp_node_previews(g_node, p0.get('source_ctx', ''), p0.get('text', ''), p0.get('highlight_pattern'))
 
             # 4. Excluded
             if self.comp_known:
@@ -7253,7 +7237,7 @@ class GenizahGUI(QMainWindow):
             self.comp_tree.setUpdatesEnabled(False)
             sorted_items = self._sort_comp_items(virtual_items)
             for ms_item in sorted_items:
-                self._add_manuscript_node(item, ms_item)
+                self._add_manuscript_node(item, ms_item, defer_widgets=False)
             self.comp_tree.setUpdatesEnabled(True)
             self.comp_tree_updating = False
 

--- a/genizah_app.py
+++ b/genizah_app.py
@@ -6870,6 +6870,8 @@ class GenizahGUI(QMainWindow):
                 folio_info = f" [{p_shelf}]" if p_shelf else ""
                 self._set_comp_tree_text(ms_node, 1, f"{shelf} ({tr('Image')} {p_num}{folio_info})")
                 self._set_comp_node_previews(ms_node, p_item.get('source_ctx', ''), p_item.get('text', ''), p_item.get('highlight_pattern'), defer_widgets=defer_widgets)
+                # Store for collapse restore
+                ms_node.setData(1, Qt.ItemDataRole.UserRole, (p_item.get('source_ctx', ''), p_item.get('text', '')))
             else:
                 if pages:
                     p0 = pages[0]
@@ -6877,6 +6879,8 @@ class GenizahGUI(QMainWindow):
                     folio_count = f", {len(folios)} folios" if len(folios) > 1 else ""
                     self._set_comp_tree_text(ms_node, 1, f"{shelf} ({len(pages)} matches{folio_count})")
                     self._set_comp_node_previews(ms_node, p0.get('source_ctx', ''), p0.get('text', ''), p0.get('highlight_pattern'), defer_widgets=defer_widgets)
+                    # Store for collapse restore
+                    ms_node.setData(1, Qt.ItemDataRole.UserRole, (p0.get('source_ctx', ''), p0.get('text', '')))
 
                 for p_item in pages:
                     p_sid, p_num, p_shelf, _ = self._get_meta_for_header(p_item['raw_header'])
@@ -6910,12 +6914,16 @@ class GenizahGUI(QMainWindow):
                 _, p_num, _, _ = self._get_meta_for_header(p_item['raw_header'])
                 self._set_comp_tree_text(ms_node, 1, f"{shelf or tr('Unknown Shelfmark')} ({tr('Image')} {p_num})")
                 self._set_comp_node_previews(ms_node, p_item.get('source_ctx', ''), p_item.get('text', ''), p_item.get('highlight_pattern'), defer_widgets=defer_widgets)
+                # Store for collapse restore
+                ms_node.setData(1, Qt.ItemDataRole.UserRole, (p_item.get('source_ctx', ''), p_item.get('text', '')))
             else:
                 if pages:
                     p0 = pages[0]
                     _, p0_num, _, _ = self._get_meta_for_header(p0['raw_header'])
                     self._set_comp_tree_text(ms_node, 1, f"{shelf or tr('Unknown Shelfmark')} ({tr('Image')} {p0_num}...)")
                     self._set_comp_node_previews(ms_node, p0.get('source_ctx', ''), p0.get('text', ''), p0.get('highlight_pattern'), defer_widgets=defer_widgets)
+                    # Store for collapse restore
+                    ms_node.setData(1, Qt.ItemDataRole.UserRole, (p0.get('source_ctx', ''), p0.get('text', '')))
 
                 for p_item in pages:
                     _, p_num, _, _ = self._get_meta_for_header(p_item['raw_header'])
@@ -7241,13 +7249,18 @@ class GenizahGUI(QMainWindow):
             self.comp_tree.setUpdatesEnabled(True)
             self.comp_tree_updating = False
 
-            # Apply deferred preview widgets now that updates are enabled
-            for i in range(item.childCount()):
-                child = item.child(i)
-                self._apply_comp_node_previews(child)
-
             # Clear virtual data to prevent re-population
             item.setData(0, Qt.ItemDataRole.UserRole + 200, None)
+
+            # Apply deferred preview widgets after Qt processes the tree update
+            def apply_previews():
+                for i in range(item.childCount()):
+                    child = item.child(i)
+                    self._apply_comp_node_previews(child)
+                    # Also apply to grandchildren (page nodes)
+                    for j in range(child.childCount()):
+                        self._apply_comp_node_previews(child.child(j))
+            QTimer.singleShot(0, apply_previews)
 
         if item.childCount() > 0:
             self._clear_comp_node_previews(item)


### PR DESCRIPTION
Show the snippet from the first (best-scoring) item on group nodes when they are created with virtual children. Previously, the snippet was only visible after expanding and collapsing the group.