### PR TITLE
Fix duplicate search results in ms

### DIFF
--- a/genizah_core.py
+++ b/genizah_core.py
@@ -3966,9 +3966,17 @@ class SearchEngine:
         for group_key, pages in grouped.items():
             if not pages: continue
 
+            # Filter out continuous document results (sys:/part:) - they use wrong
+            # raw_header (first page's header instead of actual match location).
+            # Individual page results are more accurate.
+            page_results = [p for p in pages if not str(p.get('uid', '')).startswith(('sys:', 'part:'))]
+            continuous_results = [p for p in pages if str(p.get('uid', '')).startswith(('sys:', 'part:'))]
+
+            # Use page results if available, otherwise fall back to continuous
+            pages = page_results if page_results else continuous_results
+
             # Deduplicate pages by p_num within this group.
-            # Same page can appear multiple times if matched in both individual page
-            # document and continuous (system/part) document. Keep highest-scoring.
+            # Same page can appear multiple times from V0.7 and V0.8.
             p_num_best = {}
             for p in pages:
                 _, p_num = self.meta_mgr.parse_header_smart(p['raw_header'])

--- a/genizah_core.py
+++ b/genizah_core.py
@@ -3966,6 +3966,22 @@ class SearchEngine:
         for group_key, pages in grouped.items():
             if not pages: continue
 
+            # Deduplicate pages by p_num within this group.
+            # Same page can appear multiple times if matched in both individual page
+            # document and continuous (system/part) document. Keep highest-scoring.
+            p_num_best = {}
+            for p in pages:
+                _, p_num = self.meta_mgr.parse_header_smart(p['raw_header'])
+                if p_num and p_num != "Unknown":
+                    if p_num not in p_num_best or p['score'] > p_num_best[p_num]['score']:
+                        p_num_best[p_num] = p
+                else:
+                    # Pages without valid p_num: use uid as fallback key
+                    uid_key = f"_uid_{p.get('uid', id(p))}"
+                    if uid_key not in p_num_best or p['score'] > p_num_best[uid_key]['score']:
+                        p_num_best[uid_key] = p
+            pages = list(p_num_best.values())
+
             # Aggregate Score
             total_score = sum(p['score'] for p in pages)
 


### PR DESCRIPTION
When searching compositions, the same page could appear multiple times in results because:
1. It matched both as an individual page document and as part of a continuous (system/part) document
2. It existed in both V0.7 and V0.8 with different UIDs

Added deduplication by page number (p_num) within each manuscript group in group_pages_by_manuscript(). For each page number, only the highest scoring result is kept. Pages without valid p_num fall back to using uid as the key to avoid incorrect deduplication.