### PR TITLE
Auto-title compositions and remember save folder

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -1970,43 +1970,42 @@ class ResultDialog(QDialog):
         # --- SPLIT VIEW (Manuscript | Source | External) ---
         self.main_splitter = QSplitter(Qt.Orientation.Horizontal)
 
-        # Inner Splitter for Text (Manuscript | Source)
-        self.text_splitter = QSplitter(Qt.Orientation.Horizontal)
-        
         # 1. Manuscript View (Left)
         ms_widget = QWidget()
         ms_layout = QVBoxLayout(ms_widget); ms_layout.setContentsMargins(0,0,0,0)
-        ms_layout.addWidget(QLabel("<b>" + tr("Manuscript Text") + "</b>"))
+        ms_text_widget = QWidget()
+        ms_text_layout = QVBoxLayout(ms_text_widget); ms_text_layout.setContentsMargins(0,0,0,0)
+        ms_text_layout.addWidget(QLabel("<b>" + tr("Manuscript Text") + "</b>"))
         ms_find_row = QHBoxLayout()
         ms_find_row.addWidget(QLabel(tr("Find:")))
         self.find_ms_input = QLineEdit()
         self.find_ms_input.setPlaceholderText(tr("Find in text..."))
         self.find_ms_input.textChanged.connect(lambda text: apply_find_highlight(self.text_ms, text.strip()))
         ms_find_row.addWidget(self.find_ms_input)
-        ms_layout.addLayout(ms_find_row)
+        ms_text_layout.addLayout(ms_find_row)
         self.text_ms = QTextBrowser(); self.text_ms.setFont(QFont("SBL Hebrew", 16)); self.text_ms.setLayoutDirection(Qt.LayoutDirection.RightToLeft)
-        ms_layout.addWidget(self.text_ms)
-        
-        # 2. Source Context View (Right)
+        ms_text_layout.addWidget(self.text_ms)
+
+        # 2. Source Context (Below Manuscript Text)
         self.src_widget = QWidget() # Container to hide/show easily
         src_layout = QVBoxLayout(self.src_widget); src_layout.setContentsMargins(0,0,0,0)
         src_layout.addWidget(QLabel("<b>" + tr("Match Context (Source)") + "</b>"))
-        src_find_row = QHBoxLayout()
-        src_find_row.addWidget(QLabel(tr("Find:")))
-        self.find_src_input = QLineEdit()
-        self.find_src_input.setPlaceholderText(tr("Find in text..."))
-        self.find_src_input.textChanged.connect(lambda text: apply_find_highlight(self.text_src, text.strip()))
-        src_find_row.addWidget(self.find_src_input)
-        src_layout.addLayout(src_find_row)
-        self.text_src = QTextBrowser(); self.text_src.setFont(QFont("SBL Hebrew", 16)); self.text_src.setLayoutDirection(Qt.LayoutDirection.RightToLeft)
+        self.text_src = QTextBrowser()
+        self.text_src.setFont(QFont("SBL Hebrew", 16))
+        self.text_src.setLayoutDirection(Qt.LayoutDirection.RightToLeft)
+        line_height = self.text_src.fontMetrics().lineSpacing()
+        self.text_src.setMinimumHeight(line_height * 3 + 12)
         src_layout.addWidget(self.text_src)
 
-        self.text_splitter.addWidget(ms_widget)
-        self.text_splitter.addWidget(self.src_widget)
-        self.text_splitter.setStretchFactor(0, 2)
-        self.text_splitter.setStretchFactor(1, 1)
-        
-        self.main_splitter.addWidget(self.text_splitter)
+        self.ms_text_splitter = QSplitter(Qt.Orientation.Vertical)
+        self.ms_text_splitter.addWidget(ms_text_widget)
+        self.ms_text_splitter.addWidget(self.src_widget)
+        self.ms_text_splitter.setStretchFactor(0, 5)
+        self.ms_text_splitter.setStretchFactor(1, 1)
+        self.ms_text_splitter.setSizes([600, line_height * 3 + 12])
+        ms_layout.addWidget(self.ms_text_splitter)
+
+        self.main_splitter.addWidget(ms_widget)
 
         # 3. External Viewer Pane (Initially Hidden)
         self.external_pane = QWidget()
@@ -2029,8 +2028,9 @@ class ResultDialog(QDialog):
         ext_layout.addWidget(self.ms_viewer, 1)
 
         self.main_splitter.addWidget(self.external_pane)
-        self.main_splitter.setStretchFactor(0, 3)
-        self.main_splitter.setStretchFactor(1, 7)
+        self.main_splitter.setStretchFactor(0, 1)
+        self.main_splitter.setStretchFactor(1, 1)
+        self.main_splitter.setSizes([650, 650])
 
         main_layout.addWidget(self.main_splitter, 1)
         
@@ -2075,7 +2075,17 @@ class ResultDialog(QDialog):
 
     def _refresh_find_highlights(self):
         apply_find_highlight(self.text_ms, self.find_ms_input.text().strip())
-        apply_find_highlight(self.text_src, self.find_src_input.text().strip())
+
+    def _apply_source_highlights(self, text, pattern_str):
+        if not text:
+            return ""
+        if pattern_str and '*' not in text:
+            try:
+                regex = re.compile(pattern_str, re.IGNORECASE)
+                text = regex.sub(r'*\g<0>*', text)
+            except:
+                pass
+        return text
 
     def open_external_link(self):
         if self.external_url:
@@ -2143,13 +2153,19 @@ class ResultDialog(QDialog):
         self._refresh_find_highlights()
         
         # 2. Source Context
-        src_raw = data.get('source_ctx', '')
-        if src_raw:
+        source_text = ""
+        parent = self.parent()
+        if parent and hasattr(parent, "comp_text_area"):
+            source_text = parent.comp_text_area.toPlainText().strip()
+        if not source_text:
+            source_text = data.get('source_ctx', '')
+        source_text = self._apply_source_highlights(source_text, pattern_str)
+        if source_text:
             self.src_widget.setVisible(True)
-            self.text_src.setHtml(self._htmlify(src_raw))
+            self.text_src.setHtml(self._htmlify(source_text))
         else:
             self.src_widget.setVisible(False)
-        self._refresh_find_highlights()
+            self.text_src.clear()
         
         # Load Page & Metadata
         self.load_page(target=p)
@@ -3842,10 +3858,14 @@ class GenizahGUI(QMainWindow):
         else:
             default_name = f"Manuscript_{self.current_browse_sid}.txt"
 
-        path, _ = QFileDialog.getSaveFileName(self, tr("Save Manuscript"),
-                                            os.path.join(Config.REPORTS_DIR, default_name), 
-                                            "Text (*.txt)")
+        path, _ = QFileDialog.getSaveFileName(
+            self,
+            tr("Save Manuscript"),
+            os.path.join(self._get_default_save_dir(), default_name),
+            "Text (*.txt)",
+        )
         if not path: return
+        self._remember_save_dir(path)
         
         pages = self.searcher.get_full_manuscript(self.current_browse_sid)
         if not pages: return
@@ -4075,14 +4095,33 @@ class GenizahGUI(QMainWindow):
         clean = re.sub(r"\s+", "_", clean).strip("_")
         return clean or fallback
 
+    def _get_default_save_dir(self):
+        cfg = load_app_config()
+        last_dir = cfg.get("last_save_dir")
+        if last_dir and os.path.isdir(last_dir):
+            return last_dir
+
+        home_dir = os.path.expanduser("~")
+        documents_dir = os.path.join(home_dir, "Documents")
+        my_documents_dir = os.path.join(home_dir, "My Documents")
+        base_documents = documents_dir if os.path.isdir(documents_dir) else my_documents_dir
+        if not os.path.isdir(base_documents):
+            base_documents = home_dir
+
+        target_dir = os.path.join(base_documents, "Genizah Search Pro")
+        os.makedirs(target_dir, exist_ok=True)
+        return target_dir
+
+    def _remember_save_dir(self, path):
+        if not path:
+            return
+        save_dir = os.path.dirname(path)
+        if save_dir:
+            save_app_config({"last_save_dir": save_dir})
+
     def _default_report_path(self, hint, fallback):
         filename = self._sanitize_filename(hint, fallback)
-
-        # Lab Mode: save to Lab Dir
-        base_dir = Config.REPORTS_DIR
-        if getattr(self, 'btn_lab_mode_toggle', None) and self.btn_lab_mode_toggle.isChecked():
-            base_dir = os.path.join(Config.BASE_DIR, "Reports")
-
+        base_dir = self._get_default_save_dir()
         os.makedirs(base_dir, exist_ok=True)
         return os.path.join(base_dir, f"{filename}.txt")
 
@@ -4981,6 +5020,7 @@ class GenizahGUI(QMainWindow):
 
         path, _ = QFileDialog.getSaveFileName(self, tr("Export Results"), default_path, selected_filter)
         if not path: return
+        self._remember_save_dir(path)
 
         # Prepare tabular data
         headers = [tr("System ID"), tr("Shelfmark"), tr("Title"), tr("Image/Page"), tr("Source"), tr("Snippet")]
@@ -5273,6 +5313,7 @@ class GenizahGUI(QMainWindow):
 
         path, _ = QFileDialog.getSaveFileName(self, tr("Save Report"), default_path, selected_filter)
         if not path: return
+        self._remember_save_dir(path)
 
         credit_text = self._get_credit_header()
         query_text = self.comp_text_area.toPlainText().strip()
@@ -6097,6 +6138,10 @@ class GenizahGUI(QMainWindow):
         if not txt:
             QMessageBox.warning(self, tr("Error"), tr("Please enter text to search."))
             return
+        if not self.comp_title_input.text().strip():
+            words = txt.split()
+            if words:
+                self.comp_title_input.setText(" ".join(words[:4]))
 
         self.is_comp_running = True
         self.btn_comp_run.setText(tr("Stop"))

--- a/genizah_core.py
+++ b/genizah_core.py
@@ -3891,7 +3891,7 @@ class SearchEngine:
                             else:
                                 words_out.append(word)
                         
-                        src_snippets.append(f"... {' '.join(words_out)} ...")
+                        src_snippets.append(" ".join(words_out))
 
                 spans = sorted(data['matches'], key=lambda x: x[0])
                 merged = []


### PR DESCRIPTION
### Motivation
- Ensure compositions get a reasonable title automatically when the user doesn't enter one by using the first four words of the input text.
- Provide a consistent, user-friendly default save location under `My Documents\Genizah Search Pro\` while honoring the last folder the user chose.
- Improve source-context readability and consistent highlighting in the result dialog by preferring the manuscript composition text as source context and increasing the source context pane height.
- Simplify find/highlight UX by removing the redundant source-side find input and unifying source highlight application.

### Description
- Add ` _get_default_save_dir` and `_remember_save_dir` in `genizah_app.py` and make `_default_report_path` use the remembered/default `Genizah Search Pro` documents folder so save dialogs default to that location.
- Update save flows to remember the chosen folder by calling `_remember_save_dir` after `QFileDialog.getSaveFileName` for exports, reports and manuscript saves, and use the remembered folder when opening the save dialog.
- Auto-fill the composition title in `run_composition` by setting `comp_title_input` to the first four words of the entered text when the title field is empty, implemented in `genizah_app.py` via `run_composition` changes.
- UI/source adjustments included: set the source context pane to three lines, prefer `comp_text_area.toPlainText()` as the source context when available, add `_apply_source_highlights` to apply regex highlights to source text, remove the source-side find input, adjust splitter layout and 50/50 main pane sizing, and remove leading/trailing ellipses from source snippets in `genizah_core.py`.

### Testing
- No automated tests were run for these changes.
- No CI unit or UI test suite was executed for this patch.
- Basic code paths for saving and running composition were exercised during development (manual run), but these are not automated tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6960ced2ae5c8321953ec23f984320dd)