### PR TITLE
Hide source context in term search result viewer

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -2154,11 +2154,12 @@ class ResultDialog(QDialog):
         
         # 2. Source Context
         source_text = ""
-        parent = self.parent()
-        if parent and hasattr(parent, "comp_text_area"):
-            source_text = parent.comp_text_area.toPlainText().strip()
-        if not source_text:
-            source_text = data.get('source_ctx', '')
+        if 'source_ctx' in data:
+            parent = self.parent()
+            if parent and hasattr(parent, "comp_text_area"):
+                source_text = parent.comp_text_area.toPlainText().strip()
+            if not source_text:
+                source_text = data.get('source_ctx', '')
         source_text = self._apply_source_highlights(source_text, pattern_str)
         if source_text:
             self.src_widget.setVisible(True)


### PR DESCRIPTION
### Motivation
- Prevent the result viewer from showing the composition/source context panel for simple term/search results that do not include composition context data.
- Avoid unintentionally leaking the text from the composition editor (`comp_text_area`) into term-search result views.
- Make the `ResultDialog` behavior consistent by only showing source context when the result explicitly carries `source_ctx` data.

### Description
- Change `ResultDialog.load_result_by_index` to only attempt to populate the source context when the `data` dict contains the `source_ctx` key. 
- Move the lookup of `parent.comp_text_area` into the `source_ctx` presence branch so composition text is not used as a fallback for term results.
- Update visibility handling of `self.src_widget` and clearing of `self.text_src` when no source context is present.
- File modified: `genizah_app.py` (small conditional change around source context handling).

### Testing
- No automated tests were executed for this change.
- No test failures reported because no tests were run.
- Manual verification was implied by the change intent but not recorded as automated tests.
- The change is a small, localized UI logic fix and does not alter public APIs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69610f5df0d4832192d8bac82c5c7e7b)