### PR TITLE
Route reports to Documents\GenizahSearchPro\Reports

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -4124,7 +4124,7 @@ class GenizahGUI(QMainWindow):
         if not documents_folder or not os.path.isdir(documents_folder):
             documents_folder = os.path.expanduser("~")
 
-        default_folder = os.path.join(documents_folder, "GenizahSearchPro")
+        default_folder = os.path.join(documents_folder, "GenizahSearchPro", "Reports")
         try:
             os.makedirs(default_folder, exist_ok=True)
         except Exception:
@@ -4157,8 +4157,7 @@ class GenizahGUI(QMainWindow):
 
         # Lab Mode: save to Lab Dir
         if getattr(self, 'btn_lab_mode_toggle', None) and self.btn_lab_mode_toggle.isChecked():
-            base_dir = os.path.join(Config.BASE_DIR, "Reports")
-            os.makedirs(base_dir, exist_ok=True)
+            base_dir = Config.REPORTS_DIR
         else:
             # Use smart default folder (last used or My Documents\Genizah Search Pro)
             base_dir = self._get_default_save_folder()

--- a/genizah_core.py
+++ b/genizah_core.py
@@ -1107,6 +1107,30 @@ class Config:
         os.makedirs(fallback, exist_ok=True)
         return fallback
 
+    @staticmethod
+    def _get_documents_dir() -> str:
+        """Best-effort Documents directory (Windows-aware), falling back to home."""
+        documents_dir = None
+        try:
+            import ctypes.wintypes
+
+            CSIDL_PERSONAL = 5  # My Documents
+            buf = ctypes.create_unicode_buffer(ctypes.wintypes.MAX_PATH)
+            ctypes.windll.shell32.SHGetFolderPathW(None, CSIDL_PERSONAL, None, 0, buf)
+            if buf.value:
+                documents_dir = buf.value
+        except Exception:
+            pass
+
+        if not documents_dir or not os.path.isdir(documents_dir):
+            for folder_name in ["Documents", "My Documents"]:
+                candidate = os.path.join(os.path.expanduser("~"), folder_name)
+                if os.path.isdir(candidate):
+                    documents_dir = candidate
+                    break
+
+        return documents_dir if documents_dir and os.path.isdir(documents_dir) else os.path.expanduser("~")
+
     # 1. Determine Base Paths
     if getattr(sys, "frozen", False):
         BASE_DIR = os.path.dirname(sys.executable)
@@ -1143,9 +1167,9 @@ class Config:
         INDEX_DIR = _PORTABLE_INDEX_PATH
         os.makedirs(INDEX_DIR, exist_ok=True)
 
-    # 4. Output folders: try BASE_DIR first; fallback to INDEX_DIR
+    # 4. Output folders: always use Documents\GenizahSearchPro\Reports
     REPORTS_DIR = _pick_writable_dir(
-        os.path.join(BASE_DIR, "Reports"),
+        os.path.join(_get_documents_dir(), "GenizahSearchPro", "Reports"),
         os.path.join(INDEX_DIR, "Reports"),
     )
 


### PR DESCRIPTION
### Motivation
- Avoid writing report files into the application install directory (e.g., `Program Files`) and prevent creating a `Reports` folder next to the executable.
- Use a per-user writable location under the user's Documents folder so reports are accessible and writable.
- Unify the GUI default save location and Lab mode output so all reports go to the same user-facing folder.

### Description
- Add `Config._get_documents_dir()` in `genizah_core.py` to locate the user's Documents folder with a Windows-aware fallback.
- Change `Config.REPORTS_DIR` to prefer `Documents\GenizahSearchPro\Reports` and fall back to `INDEX_DIR/Reports` using the existing `_pick_writable_dir` logic.
- Update `genizah_app.py` so the default save folder is `Documents\GenizahSearchPro\Reports` and Lab mode uses `Config.REPORTS_DIR` instead of creating a `Reports` folder under `BASE_DIR`.
- Preserve existing fallback behavior when the Documents folder is unavailable or cannot be created.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696281b4e438832180304e057ed87d96)