### PR TITLE
Personal lists: RTL preview layout, select-all, FL image IDs, and export fixes

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -2092,10 +2092,14 @@ class ResultDialog(QDialog):
 
         if sys_id:
             fl_id = parent._normalize_fl_id(self.current_fl_id)
-            parent.show_add_to_list_menu([sys_id], source=tr("from browse"),
-                                          anchor_widget=self.btn_add_to_list, fl_id_map={sys_id: fl_id} if fl_id else None)
+            img = self.current_p_num
+            parent.show_add_to_list_menu(
+                [{'sys_id': sys_id, 'fl_id': fl_id, 'img': img}],
+                source=tr("from browse"),
+                anchor_widget=self.btn_add_to_list
+            )
             # Also add to recently viewed
-            parent.lists_mgr.add_to_recent(sys_id, fl_id=fl_id)
+            parent.lists_mgr.add_to_recent(sys_id, fl_id=fl_id, img=img)
 
     def _refresh_find_highlights(self):
         apply_find_highlight(self.text_ms, self.find_ms_input.text().strip())
@@ -2164,7 +2168,7 @@ class ResultDialog(QDialog):
         parent = self.parent()
         if parent and hasattr(parent, 'lists_mgr') and parent.lists_mgr and self.current_sys_id:
             fl_id = parent._normalize_fl_id(ids.get('fl_id'))
-            parent.lists_mgr.add_to_recent(self.current_sys_id, fl_id=fl_id)
+            parent.lists_mgr.add_to_recent(self.current_sys_id, fl_id=fl_id, img=ids.get('p_num'))
 
         # --- Prepare Text Content ---
         # 1. Manuscript Text (Apply Pattern!)
@@ -3710,11 +3714,11 @@ class GenizahGUI(QMainWindow):
             return
 
         fl_id = self._normalize_fl_id(self.browse_fl_input.text().strip())
+        img = self.current_browse_p
         self.show_add_to_list_menu(
-            [self.current_browse_sid],
+            [{'sys_id': self.current_browse_sid, 'fl_id': fl_id, 'img': img}],
             source=tr("from browse"),
-            anchor_widget=self.btn_browse_add_to_list,
-            fl_id_map={self.current_browse_sid: fl_id} if fl_id else None
+            anchor_widget=self.btn_browse_add_to_list
         )
 
     def _set_last_browse_field(self, field):
@@ -4010,6 +4014,10 @@ class GenizahGUI(QMainWindow):
         self.lists_detail_shelfmark.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
         details_layout.addRow(tr("Shelfmark:"), self.lists_detail_shelfmark)
 
+        self.lists_detail_image = QLabel()
+        self.lists_detail_image.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
+        details_layout.addRow(tr("Image:"), self.lists_detail_image)
+
         self.lists_detail_title = QLabel()
         self.lists_detail_title.setWordWrap(True)
         self.lists_detail_title.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
@@ -4021,10 +4029,6 @@ class GenizahGUI(QMainWindow):
         self.lists_detail_sys_id = QLabel()
         self.lists_detail_sys_id.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
         details_layout.addRow(tr("System ID:"), self.lists_detail_sys_id)
-
-        self.lists_detail_image = QLabel()
-        self.lists_detail_image.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
-        details_layout.addRow(tr("Image:"), self.lists_detail_image)
 
         # Tags with add button
         tags_widget = QWidget()
@@ -4108,14 +4112,14 @@ class GenizahGUI(QMainWindow):
         # Items table
         self.lists_items_table = QTableWidget()
         self.lists_items_table.setColumnCount(6)
-        self.lists_items_table.setHorizontalHeaderLabels(["", tr("Shelfmark"), tr("Title"), tr("Image"), tr("Tags"), tr("Actions")])
+        self.lists_items_table.setHorizontalHeaderLabels(["", tr("Shelfmark"), tr("Image"), tr("Title"), tr("Tags"), tr("Actions")])
         self.lists_items_table.horizontalHeader().setSectionResizeMode(0, QHeaderView.ResizeMode.Fixed)
         self.lists_items_table.setColumnWidth(0, 30)  # Checkbox
         self.lists_items_table.horizontalHeader().setSectionResizeMode(1, QHeaderView.ResizeMode.Interactive)
         self.lists_items_table.setColumnWidth(1, 150)
-        self.lists_items_table.horizontalHeader().setSectionResizeMode(2, QHeaderView.ResizeMode.Stretch)
-        self.lists_items_table.horizontalHeader().setSectionResizeMode(3, QHeaderView.ResizeMode.Interactive)
-        self.lists_items_table.setColumnWidth(3, 90)
+        self.lists_items_table.horizontalHeader().setSectionResizeMode(2, QHeaderView.ResizeMode.Interactive)
+        self.lists_items_table.setColumnWidth(2, 90)
+        self.lists_items_table.horizontalHeader().setSectionResizeMode(3, QHeaderView.ResizeMode.Stretch)
         self.lists_items_table.horizontalHeader().setSectionResizeMode(4, QHeaderView.ResizeMode.Interactive)
         self.lists_items_table.setColumnWidth(4, 120)
         self.lists_items_table.horizontalHeader().setSectionResizeMode(5, QHeaderView.ResizeMode.Fixed)
@@ -4238,7 +4242,7 @@ class GenizahGUI(QMainWindow):
 
         # Initialize state
         self.lists_current_list_id = 'default'
-        self.lists_current_item_sys_id = None
+        self.lists_current_item_id = None
         self.lists_preview_visible = True
         self.lists_set_preview_visible(True, auto=True)
 
@@ -4252,9 +4256,13 @@ class GenizahGUI(QMainWindow):
         digits = re.sub(r"\D", "", str(fl_id or ""))
         return digits or None
 
-    def _format_fl_id_display(self, fl_id):
-        digits = self._normalize_fl_id(fl_id)
-        return f"FL{digits}" if digits else ""
+    def _format_image_display(self, img):
+        return str(img) if img not in (None, "") else ""
+
+    def _get_list_display_name(self, lst):
+        if CURRENT_LANG == 'en' and lst.get('name_en'):
+            return lst.get('name_en')
+        return lst.get('name', lst.get('name_en', 'List'))
 
     def lists_set_preview_visible(self, visible, auto=False):
         """Show/hide preview panel with a slim collapsed bar."""
@@ -4276,15 +4284,16 @@ class GenizahGUI(QMainWindow):
         else:
             self.lists_preview_last_sizes = self.lists_main_splitter.sizes()
             collapsed_width = 28
+            total = sum(self.lists_preview_last_sizes)
+            if total <= 0:
+                total = max(self.lists_main_splitter.width(), collapsed_width * 2)
             sizes = self.lists_preview_last_sizes[:]
             if self.lists_preview_index < len(sizes):
                 sizes[self.lists_preview_index] = collapsed_width
-                total = sum(sizes)
-                if total:
-                    for i in range(len(sizes)):
-                        if i != self.lists_preview_index:
-                            sizes[i] = max(1, total - collapsed_width)
-                            break
+                for i in range(len(sizes)):
+                    if i != self.lists_preview_index:
+                        sizes[i] = max(1, total - collapsed_width)
+                        break
                 self.lists_main_splitter.setSizes(sizes)
             self.lists_preview_panel.setMinimumWidth(collapsed_width)
             self.lists_preview_panel.setMaximumWidth(collapsed_width)
@@ -4308,7 +4317,7 @@ class GenizahGUI(QMainWindow):
 
             # Create colored dot
             color = lst.get('color', '#FFD700')
-            name = lst.get('name', lst.get('name_en', 'List'))
+            name = self._get_list_display_name(lst)
             count = lst.get('count', 0)
 
             if lst.get('is_system') and lst['id'] == 'recent':
@@ -4352,7 +4361,7 @@ class GenizahGUI(QMainWindow):
 
         if current_list:
             color = current_list.get('color', '#FFD700')
-            name = current_list.get('name', 'List')
+            name = self._get_list_display_name(current_list)
             self.lists_current_label.setText(f"<span style='color:{color}'>●</span> {name}")
 
             # Show/hide edit/delete buttons for system lists
@@ -4371,31 +4380,33 @@ class GenizahGUI(QMainWindow):
         filter_text = self.lists_filter_input.text().strip().lower()
 
         self.lists_items_table.blockSignals(True)
-        visible_sys_ids = set()
+        visible_item_ids = set()
 
         for item in items:
             shelfmark = item.get('shelfmark', 'Unknown')
             title = item.get('title', '')
             tags = item.get('tags', [])
-            fl_id = item.get('fl_id')
+            item_id = item.get('item_id') or item.get('sys_id')
+            img = item.get('img')
             sys_id = item.get('sys_id')
             is_unidentified = item.get('shelfmark_override') is not None
 
             # Apply filter
             if filter_text:
-                searchable = f"{shelfmark} {title} {' '.join(tags)} {fl_id or ''}".lower()
+                searchable = f"{shelfmark} {title} {' '.join(tags)} {img or ''}".lower()
                 if filter_text not in searchable:
                     continue
 
             row = self.lists_items_table.rowCount()
             self.lists_items_table.insertRow(row)
-            visible_sys_ids.add(sys_id)
+            if item_id:
+                visible_item_ids.add(item_id)
 
             # Checkbox
             chk_item = QTableWidgetItem()
             chk_item.setFlags(Qt.ItemFlag.ItemIsUserCheckable | Qt.ItemFlag.ItemIsEnabled)
             chk_item.setCheckState(Qt.CheckState.Unchecked)
-            chk_item.setData(Qt.ItemDataRole.UserRole, sys_id)
+            chk_item.setData(Qt.ItemDataRole.UserRole, item_id)
             self.lists_items_table.setItem(row, 0, chk_item)
 
             # Shelfmark
@@ -4405,11 +4416,11 @@ class GenizahGUI(QMainWindow):
                 shelf_item.setToolTip(tr("(unidentified)"))
             self.lists_items_table.setItem(row, 1, shelf_item)
 
-            # Title
-            self.lists_items_table.setItem(row, 2, QTableWidgetItem(title))
-
             # Image
-            self.lists_items_table.setItem(row, 3, QTableWidgetItem(self._format_fl_id_display(fl_id)))
+            self.lists_items_table.setItem(row, 2, QTableWidgetItem(str(img or "")))
+
+            # Title
+            self.lists_items_table.setItem(row, 3, QTableWidgetItem(title))
 
             # Tags
             self.lists_items_table.setItem(row, 4, QTableWidgetItem(", ".join(tags)))
@@ -4423,25 +4434,25 @@ class GenizahGUI(QMainWindow):
             btn_view = QPushButton("👁️")
             btn_view.setFixedSize(24, 24)
             btn_view.setToolTip(tr("Quick View"))
-            btn_view.clicked.connect(lambda _, sid=sys_id: self.lists_quick_view_by_id(sid))
+            btn_view.clicked.connect(lambda _, iid=item_id: self.lists_quick_view_by_id(iid))
             actions_layout.addWidget(btn_view)
 
             btn_browse = QPushButton("📖")
             btn_browse.setFixedSize(24, 24)
             btn_browse.setToolTip(tr("Browse"))
-            btn_browse.clicked.connect(lambda _, sid=sys_id: self.lists_browse_by_id(sid))
+            btn_browse.clicked.connect(lambda _, iid=item_id: self.lists_browse_by_id(iid))
             actions_layout.addWidget(btn_browse)
 
             btn_copy = QPushButton("📋")
             btn_copy.setFixedSize(24, 24)
             btn_copy.setToolTip(tr("Copy Info"))
-            btn_copy.clicked.connect(lambda _, sid=sys_id: self.lists_copy_info_by_id(sid))
+            btn_copy.clicked.connect(lambda _, iid=item_id: self.lists_copy_info_by_id(iid))
             actions_layout.addWidget(btn_copy)
 
             btn_remove = QPushButton("🗑️")
             btn_remove.setFixedSize(24, 24)
             btn_remove.setToolTip(tr("Remove from List"))
-            btn_remove.clicked.connect(lambda _, sid=sys_id: self.lists_remove_item_by_id(sid))
+            btn_remove.clicked.connect(lambda _, iid=item_id: self.lists_remove_item_by_id(iid))
             actions_layout.addWidget(btn_remove)
 
             self.lists_items_table.setCellWidget(row, 5, actions_widget)
@@ -4450,8 +4461,8 @@ class GenizahGUI(QMainWindow):
         self.lists_update_selection_label()
         self.chk_lists_select_all.setEnabled(self.lists_items_table.rowCount() > 0)
         self.lists_sync_select_all_checkbox()
-        if not self.lists_current_item_sys_id or self.lists_current_item_sys_id not in visible_sys_ids:
-            self.lists_current_item_sys_id = None
+        if not self.lists_current_item_id or self.lists_current_item_id not in visible_item_ids:
+            self.lists_current_item_id = None
             self.lists_clear_details()
 
     def lists_on_list_selected(self, item, column):
@@ -4459,7 +4470,7 @@ class GenizahGUI(QMainWindow):
         list_id = item.data(0, Qt.ItemDataRole.UserRole)
         if list_id:
             self.lists_current_list_id = list_id
-            self.lists_current_item_sys_id = None
+            self.lists_current_item_id = None
             self.lists_refresh_items()
             self.lists_clear_details()
 
@@ -4471,10 +4482,10 @@ class GenizahGUI(QMainWindow):
         row = item.row()
         chk_item = self.lists_items_table.item(row, 0)
         if chk_item:
-            sys_id = chk_item.data(Qt.ItemDataRole.UserRole)
-            if sys_id:
-                self.lists_current_item_sys_id = sys_id
-                self.lists_show_item_details(sys_id)
+            item_id = chk_item.data(Qt.ItemDataRole.UserRole)
+            if item_id:
+                self.lists_current_item_id = item_id
+                self.lists_show_item_details(item_id)
 
     def lists_on_item_checkbox_changed(self, item):
         """Handle checkbox state change."""
@@ -4534,25 +4545,27 @@ class GenizahGUI(QMainWindow):
             self.chk_lists_select_all.setCheckState(Qt.CheckState.PartiallyChecked)
         self._lists_select_all_guard = False
 
-    def lists_get_selected_sys_ids(self):
-        """Get list of selected sys_ids."""
+    def lists_get_selected_item_ids(self):
+        """Get list of selected item ids."""
         selected = []
         for row in range(self.lists_items_table.rowCount()):
             chk = self.lists_items_table.item(row, 0)
             if chk and chk.checkState() == Qt.CheckState.Checked:
-                sys_id = chk.data(Qt.ItemDataRole.UserRole)
-                if sys_id:
-                    selected.append(sys_id)
+                item_id = chk.data(Qt.ItemDataRole.UserRole)
+                if item_id:
+                    selected.append(item_id)
         return selected
 
-    def lists_show_item_details(self, sys_id):
+    def lists_show_item_details(self, item_id):
         """Show details for a specific item."""
         if not self.lists_mgr:
             return
 
-        item = self.lists_mgr.get_item(sys_id)
+        item = self.lists_mgr.get_item(item_id)
         if not item:
             return
+        sys_id = item.get('sys_id')
+        img = item.get('img')
 
         # Get metadata
         shelfmark = 'Unknown'
@@ -4563,9 +4576,9 @@ class GenizahGUI(QMainWindow):
             shelfmark, title = self.meta_mgr.get_meta_for_id(sys_id)
 
         self.lists_detail_shelfmark.setText(shelfmark)
+        self.lists_detail_image.setText(str(img) if img not in (None, "") else "-")
         self.lists_detail_title.setText(title)
         self.lists_detail_sys_id.setText(sys_id or '')
-        self.lists_detail_image.setText(self._format_fl_id_display(item.get('fl_id')) or '-')
 
         # Lists
         list_names = []
@@ -4590,7 +4603,7 @@ class GenizahGUI(QMainWindow):
         # Add tag button
         btn_add_tag = QPushButton("+")
         btn_add_tag.setFixedSize(20, 20)
-        btn_add_tag.clicked.connect(lambda: self.lists_add_tag_to_item(sys_id))
+        btn_add_tag.clicked.connect(lambda: self.lists_add_tag_to_item(item_id))
         self.lists_detail_tags_container.addWidget(btn_add_tag)
         self.lists_detail_tags_container.addStretch()
 
@@ -4610,11 +4623,12 @@ class GenizahGUI(QMainWindow):
             self.lists_detail_added.setText('-')
 
         # Load text preview and image
-        self._lists_load_preview(sys_id)
+        if sys_id:
+            self._lists_load_preview(sys_id, img=img)
         if not self.lists_preview_visible:
             self.lists_set_preview_visible(True, auto=True)
 
-    def _lists_load_preview(self, sys_id):
+    def _lists_load_preview(self, sys_id, img=None):
         """Load text and image preview for an item."""
         # Clear previous preview
         self.lists_preview_text.clear()
@@ -4625,7 +4639,13 @@ class GenizahGUI(QMainWindow):
             return
 
         # Get page data
-        page_data = self.searcher.get_browse_page(sys_id, p_num=1)
+        p_num = 1
+        if img not in (None, ""):
+            try:
+                p_num = int(img)
+            except ValueError:
+                p_num = 1
+        page_data = self.searcher.get_browse_page(sys_id, p_num=p_num)
         if not page_data:
             self.lists_preview_text.setPlainText(tr("Could not load text"))
             return
@@ -4711,11 +4731,11 @@ class GenizahGUI(QMainWindow):
 
     def lists_save_item_details(self):
         """Save changes to the current item."""
-        if not self.lists_mgr or not self.lists_current_item_sys_id:
+        if not self.lists_mgr or not self.lists_current_item_id:
             return
 
         note = self.lists_detail_note.text()
-        self.lists_mgr.update_item(self.lists_current_item_sys_id, note=note)
+        self.lists_mgr.update_item(self.lists_current_item_id, note=note)
 
     def lists_create_new_list(self):
         """Create a new list."""
@@ -4782,7 +4802,7 @@ class GenizahGUI(QMainWindow):
             return
 
         # Simple dialog - select target
-        items = [l['name'] for l in lists]
+        items = [self._get_list_display_name(l) for l in lists]
         target_name, ok = QInputDialog.getItem(
             self, tr("Merge Lists"),
             tr("Merge '{}' into:").format(
@@ -4794,7 +4814,7 @@ class GenizahGUI(QMainWindow):
         if ok and target_name:
             target_list = None
             for l in lists:
-                if l['name'] == target_name:
+                if self._get_list_display_name(l) == target_name:
                     target_list = l
                     break
 
@@ -4808,12 +4828,12 @@ class GenizahGUI(QMainWindow):
         if not self.lists_mgr:
             return
 
-        selected = self.lists_get_selected_sys_ids()
+        selected = self.lists_get_selected_item_ids()
         if not selected:
             return
 
         lists = [l for l in self.lists_mgr.get_all_lists(include_recent=False)]
-        items = [l['name'] for l in lists]
+        items = [self._get_list_display_name(l) for l in lists]
 
         target_name, ok = QInputDialog.getItem(
             self, tr("Move to List..."),
@@ -4824,7 +4844,7 @@ class GenizahGUI(QMainWindow):
         if ok and target_name:
             target_list = None
             for l in lists:
-                if l['name'] == target_name:
+                if self._get_list_display_name(l) == target_name:
                     target_list = l
                     break
 
@@ -4837,7 +4857,7 @@ class GenizahGUI(QMainWindow):
         if not self.lists_mgr:
             return
 
-        selected = self.lists_get_selected_sys_ids()
+        selected = self.lists_get_selected_item_ids()
         if not selected:
             return
 
@@ -4846,15 +4866,15 @@ class GenizahGUI(QMainWindow):
             self.lists_mgr.add_tag_to_items(selected, tag.strip())
             self.lists_refresh_items()
 
-    def lists_add_tag_to_item(self, sys_id):
+    def lists_add_tag_to_item(self, item_id):
         """Add a tag to a specific item."""
         if not self.lists_mgr:
             return
 
         tag, ok = QInputDialog.getText(self, tr("Add Tag"), tr("Enter tag:"))
         if ok and tag.strip():
-            self.lists_mgr.add_tag_to_items([sys_id], tag.strip())
-            self.lists_show_item_details(sys_id)
+            self.lists_mgr.add_tag_to_items([item_id], tag.strip())
+            self.lists_show_item_details(item_id)
             self.lists_refresh_items()
 
     def lists_remove_selected_items(self):
@@ -4862,7 +4882,7 @@ class GenizahGUI(QMainWindow):
         if not self.lists_mgr:
             return
 
-        selected = self.lists_get_selected_sys_ids()
+        selected = self.lists_get_selected_item_ids()
         if not selected:
             return
 
@@ -4873,30 +4893,43 @@ class GenizahGUI(QMainWindow):
         )
 
         if reply == QMessageBox.StandardButton.Yes:
-            for sys_id in selected:
-                self.lists_mgr.remove_item_from_list(sys_id, self.lists_current_list_id)
+            for item_id in selected:
+                self.lists_mgr.remove_item_from_list(item_id, self.lists_current_list_id)
             self.lists_refresh_all()
 
-    def lists_remove_item_by_id(self, sys_id):
+    def lists_remove_item_by_id(self, item_id):
         """Remove a specific item from current list."""
         if not self.lists_mgr:
             return
 
-        self.lists_mgr.remove_item_from_list(sys_id, self.lists_current_list_id)
+        self.lists_mgr.remove_item_from_list(item_id, self.lists_current_list_id)
         self.lists_refresh_all()
 
     def lists_quick_view_item(self):
         """Quick view the current item."""
-        if self.lists_current_item_sys_id:
-            self.lists_quick_view_by_id(self.lists_current_item_sys_id)
+        if self.lists_current_item_id:
+            self.lists_quick_view_by_id(self.lists_current_item_id)
 
-    def lists_quick_view_by_id(self, sys_id):
+    def lists_quick_view_by_id(self, item_id):
         """Open quick view dialog for an item."""
         if not self.searcher or not self.meta_mgr:
             return
+        item = self.lists_mgr.get_item(item_id)
+        if not item:
+            return
+        sys_id = item.get('sys_id')
+        img = item.get('img')
+        if not sys_id:
+            return
 
         # Get page data from browse index to have all required fields
-        page_data = self.searcher.get_browse_page(sys_id, p_num=1)
+        p_num = 1
+        if img not in (None, ""):
+            try:
+                p_num = int(img)
+            except ValueError:
+                p_num = 1
+        page_data = self.searcher.get_browse_page(sys_id, p_num=p_num)
         if not page_data:
             QMessageBox.warning(self, tr("View Error"), tr("Could not load manuscript data."))
             return
@@ -4923,11 +4956,16 @@ class GenizahGUI(QMainWindow):
 
     def lists_browse_item(self):
         """Browse the current item in the Browse tab."""
-        if self.lists_current_item_sys_id:
-            self.lists_browse_by_id(self.lists_current_item_sys_id)
+        if self.lists_current_item_id:
+            self.lists_browse_by_id(self.lists_current_item_id)
 
-    def lists_browse_by_id(self, sys_id):
+    def lists_browse_by_id(self, item_id):
         """Open an item in the Browse tab."""
+        item = self.lists_mgr.get_item(item_id)
+        if not item:
+            return
+        sys_id = item.get('sys_id')
+        img = item.get('img')
         if not sys_id:
             return
 
@@ -4939,10 +4977,10 @@ class GenizahGUI(QMainWindow):
 
     def lists_copy_item_info(self):
         """Copy current item info to clipboard."""
-        if self.lists_current_item_sys_id:
-            self.lists_copy_info_by_id(self.lists_current_item_sys_id)
+        if self.lists_current_item_id:
+            self.lists_copy_info_by_id(self.lists_current_item_id)
 
-    def lists_copy_info_by_id(self, sys_id):
+    def lists_copy_info_by_id(self, item_id):
         """Copy item info to clipboard with format options."""
         if not self.lists_mgr:
             return
@@ -4950,28 +4988,30 @@ class GenizahGUI(QMainWindow):
         menu = QMenu(self)
 
         action_compact = menu.addAction(tr("Compact"))
-        action_compact.triggered.connect(lambda: self._do_copy_info(sys_id, 'compact'))
+        action_compact.triggered.connect(lambda: self._do_copy_info(item_id, 'compact'))
 
         action_detailed = menu.addAction(tr("Detailed"))
-        action_detailed.triggered.connect(lambda: self._do_copy_info(sys_id, 'detailed'))
+        action_detailed.triggered.connect(lambda: self._do_copy_info(item_id, 'detailed'))
 
         action_link = menu.addAction(tr("With Link"))
-        action_link.triggered.connect(lambda: self._do_copy_info(sys_id, 'with_link'))
+        action_link.triggered.connect(lambda: self._do_copy_info(item_id, 'with_link'))
 
         menu.exec(QCursor.pos())
 
-    def _do_copy_info(self, sys_id, format_type):
+    def _do_copy_info(self, item_id, format_type):
         """Actually copy the info to clipboard."""
         if not self.lists_mgr:
             return
 
         # Get info even if item is not in a list
-        item = self.lists_mgr.get_item(sys_id)
+        item = self.lists_mgr.get_item(item_id)
 
         if item:
-            text = self.lists_mgr.get_item_copy_text(sys_id, format_type)
+            sys_id = item.get('sys_id')
+            text = self.lists_mgr.get_item_copy_text(item_id, format_type)
         else:
             # Item not in lists, generate text from metadata
+            sys_id = item_id
             shelfmark, title = self.meta_mgr.get_meta_for_id(sys_id) if self.meta_mgr else ('Unknown', '')
 
             if format_type == 'compact':
@@ -5190,15 +5230,15 @@ class GenizahGUI(QMainWindow):
         source = item.get('source', '')
         notes = item.get('notes', '')
         tags = item.get('tags', [])
-        fl_id = item.get('fl_id')
+        img = item.get('img')
 
         lines = []
         if shelfmark:
             lines.append(shelfmark)
+        if img not in (None, ""):
+            lines.append(f"  {tr('Image')}: {self._format_image_display(img)}")
         if title:
             lines.append(f"  {title}")
-        if fl_id:
-            lines.append(f"  {tr('Image')}: {self._format_fl_id_display(fl_id)}")
         lines.append(f"  ID: {sys_id}")
         if source:
             lines.append(f"  {tr('Source')}: {source}")
@@ -5261,15 +5301,15 @@ class GenizahGUI(QMainWindow):
         ws.title = list_name[:31]  # Excel max sheet name length
 
         # Headers
-        headers = [tr('Shelfmark'), tr('Title'), tr('Image'), 'ID', tr('Source'), tr('Tags'), tr('Notes')]
+        headers = [tr('Shelfmark'), tr('Image'), tr('Title'), 'ID', tr('Source'), tr('Tags'), tr('Notes')]
         for col, header in enumerate(headers, 1):
             ws.cell(row=1, column=col, value=header)
 
         # Data
         for row, item in enumerate(items, 2):
             ws.cell(row=row, column=1, value=item.get('shelfmark', ''))
-            ws.cell(row=row, column=2, value=item.get('title', ''))
-            ws.cell(row=row, column=3, value=self._format_fl_id_display(item.get('fl_id')))
+            ws.cell(row=row, column=2, value=self._format_image_display(item.get('img')))
+            ws.cell(row=row, column=3, value=item.get('title', ''))
             ws.cell(row=row, column=4, value=item.get('sys_id', ''))
             ws.cell(row=row, column=5, value=item.get('source', ''))
             ws.cell(row=row, column=6, value=', '.join(item.get('tags', [])))
@@ -5303,16 +5343,16 @@ class GenizahGUI(QMainWindow):
             shelfmark = item.get('shelfmark', 'Unknown')
             title = item.get('title', '')
             sys_id = item.get('sys_id', '')
-            fl_id = item.get('fl_id')
+            img = item.get('img')
             source = item.get('source', '')
             tags = item.get('tags', [])
             notes = item.get('notes', '')
 
             doc.add_heading(f"{i}. {shelfmark}", level=2)
+            if img not in (None, ""):
+                doc.add_paragraph(f"{tr('Image')}: {self._format_image_display(img)}")
             if title:
                 doc.add_paragraph(title)
-            if fl_id:
-                doc.add_paragraph(f"{tr('Image')}: {self._format_fl_id_display(fl_id)}")
             doc.add_paragraph(f"ID: {sys_id}")
             if source:
                 doc.add_paragraph(f"{tr('Source')}: {source}")
@@ -5365,9 +5405,9 @@ class GenizahGUI(QMainWindow):
 
     # --- Add to List from other places ---
 
-    def show_add_to_list_menu(self, sys_ids, source='', anchor_widget=None, fl_id_map=None):
+    def show_add_to_list_menu(self, items, source='', anchor_widget=None):
         """Show menu for adding items to a list."""
-        if not self.lists_mgr or not sys_ids:
+        if not self.lists_mgr or not items:
             return
 
         menu = QMenu(self)
@@ -5394,13 +5434,13 @@ class GenizahGUI(QMainWindow):
                 name, ok = QInputDialog.getText(self, tr("Create New List"), tr("List Name:"))
                 if ok and name.strip():
                     list_id = self.lists_mgr.create_list(name.strip())
-                    self.lists_mgr.add_items_bulk(sys_ids, list_id, source=source, fl_id_map=fl_id_map)
+                    self.lists_mgr.add_items_bulk(items, list_id, source=source)
                     self.status_label.setText(tr("Added to list."))
                     self.lists_refresh_all()  # Refresh to show new list
             else:
                 list_id = action.data()
                 if list_id:
-                    added = self.lists_mgr.add_items_bulk(sys_ids, list_id, source=source, fl_id_map=fl_id_map)
+                    added = self.lists_mgr.add_items_bulk(items, list_id, source=source)
                     if added > 0:
                         self.status_label.setText(tr("Added to list."))
                         self.lists_refresh_all()  # Refresh to show new items
@@ -6458,9 +6498,8 @@ class GenizahGUI(QMainWindow):
         if not self.lists_mgr:
             return
 
-        # Collect selected sys_ids
-        sys_ids = []
-        fl_id_map = {}
+        # Collect selected items
+        items = []
         for i in range(self.results_table.rowCount()):
             chk = self.results_table.item(i, self.COL_CHECKBOX)
             if chk and chk.checkState() == Qt.CheckState.Checked:
@@ -6469,15 +6508,15 @@ class GenizahGUI(QMainWindow):
                     display = res.get('display', {})
                     sys_id = display.get('id')
                     if sys_id:
-                        sys_ids.append(sys_id)
-                        fl_id = self._normalize_fl_id(self._extract_fl_id(res))
-                        if fl_id:
-                            fl_id_map[sys_id] = fl_id
+                        items.append({
+                            'sys_id': sys_id,
+                            'img': display.get('img'),
+                            'fl_id': self._normalize_fl_id(self._extract_fl_id(res))
+                        })
 
-        if sys_ids:
+        if items:
             source = f"Search: {self.last_search_query[:50]}" if self.last_search_query else "Search"
-            self.show_add_to_list_menu(sys_ids, source=source, anchor_widget=self.btn_add_to_list,
-                                       fl_id_map=fl_id_map or None)
+            self.show_add_to_list_menu(items, source=source, anchor_widget=self.btn_add_to_list)
 
     def open_result_in_browse(self, res, shelfmark=None, title=None, fl_id=None):
         sid = None
@@ -9374,7 +9413,8 @@ class GenizahGUI(QMainWindow):
         # Add to Recently Viewed
         if self.lists_mgr:
             fl_id = self._normalize_fl_id(page_data.get('fl_id') if page_data else self.browse_fl_input.text().strip())
-            self.lists_mgr.add_to_recent(sid, fl_id=fl_id)
+            img = page_data.get('p_num') if page_data else None
+            self.lists_mgr.add_to_recent(sid, fl_id=fl_id, img=img)
 
         # Disable controls until loaded
         self.btn_b_catalog.setEnabled(False)

--- a/genizah_app.py
+++ b/genizah_app.py
@@ -4284,16 +4284,17 @@ class GenizahGUI(QMainWindow):
         else:
             self.lists_preview_last_sizes = self.lists_main_splitter.sizes()
             collapsed_width = 28
-            total = sum(self.lists_preview_last_sizes)
+            total = self.lists_main_splitter.width()
             if total <= 0:
-                total = max(self.lists_main_splitter.width(), collapsed_width * 2)
+                total = max(sum(self.lists_preview_last_sizes), collapsed_width * 2)
             sizes = self.lists_preview_last_sizes[:]
             if self.lists_preview_index < len(sizes):
                 sizes[self.lists_preview_index] = collapsed_width
                 for i in range(len(sizes)):
                     if i != self.lists_preview_index:
                         sizes[i] = max(1, total - collapsed_width)
-                        break
+                    else:
+                        sizes[i] = collapsed_width
                 self.lists_main_splitter.setSizes(sizes)
             self.lists_preview_panel.setMinimumWidth(collapsed_width)
             self.lists_preview_panel.setMaximumWidth(collapsed_width)

--- a/genizah_app.py
+++ b/genizah_app.py
@@ -4268,7 +4268,9 @@ class GenizahGUI(QMainWindow):
         """Show/hide preview panel with a slim collapsed bar."""
         if self.lists_preview_visible == visible and not auto:
             return
+            
         self.lists_preview_visible = visible
+        
         self.lists_preview_contents.setVisible(visible)
         self.lists_preview_title.setVisible(visible)
         self.btn_toggle_preview.setText("◀" if visible else "▶")
@@ -4276,30 +4278,40 @@ class GenizahGUI(QMainWindow):
         if not self.lists_main_splitter:
             return
 
+        collapsed_width = 32 
+
         if visible:
+            self.lists_preview_panel.setMaximumWidth(16777215) # QWIDGETSIZE_MAX
+            
             self.lists_preview_panel.setMinimumWidth(250)
-            self.lists_preview_panel.setMaximumWidth(16777215)
+            
             self.lists_preview_panel.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Expanding)
+            
             if self.lists_preview_last_sizes:
                 self.lists_main_splitter.setSizes(self.lists_preview_last_sizes)
+            
+            self.lists_main_splitter.setCollapsible(self.lists_preview_index, False)
+
         else:
+            
             self.lists_preview_last_sizes = self.lists_main_splitter.sizes()
-            collapsed_width = 28
-            total = self.lists_main_splitter.width()
-            if total <= 0:
-                total = max(sum(self.lists_preview_last_sizes), collapsed_width * 2)
-            sizes = self.lists_preview_last_sizes[:]
-            if self.lists_preview_index < len(sizes):
-                sizes[self.lists_preview_index] = collapsed_width
-                for i in range(len(sizes)):
-                    if i != self.lists_preview_index:
-                        sizes[i] = max(1, total - collapsed_width)
-                    else:
-                        sizes[i] = collapsed_width
-                self.lists_main_splitter.setSizes(sizes)
-            self.lists_preview_panel.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding)
+            
             self.lists_preview_panel.setMinimumWidth(collapsed_width)
             self.lists_preview_panel.setMaximumWidth(collapsed_width)
+            
+            self.lists_preview_panel.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding)
+            
+            sizes = self.lists_main_splitter.sizes()
+            total = sum(sizes)
+            
+            new_sizes = [0] * len(sizes)
+            for i in range(len(sizes)):
+                if i == self.lists_preview_index:
+                    new_sizes[i] = collapsed_width
+                else:
+                    new_sizes[i] = total - collapsed_width
+            
+            self.lists_main_splitter.setSizes(new_sizes)
 
     def lists_refresh_all(self):
         """Refresh the lists sidebar and current items view."""

--- a/genizah_app.py
+++ b/genizah_app.py
@@ -1933,7 +1933,7 @@ class ResultDialog(QDialog):
         self.btn_search_parallels.clicked.connect(self.search_for_parallels)
 
         # Add to List button
-        self.btn_add_to_list = QPushButton(tr("☆ Add to List"))
+        self.btn_add_to_list = QPushButton(_format_add_to_list_label(False))
         self.btn_add_to_list.clicked.connect(self.add_current_to_list)
 
         self.btn_ext_info = QPushButton(tr("Show Extended Info"))
@@ -2100,6 +2100,20 @@ class ResultDialog(QDialog):
             )
             # Also add to recently viewed
             parent.lists_mgr.add_to_recent(sys_id, fl_id=fl_id, img=img)
+            self._update_add_to_list_button()
+
+    def _update_add_to_list_button(self):
+        parent = self.parent()
+        if not parent or not hasattr(parent, 'lists_mgr') or not parent.lists_mgr:
+            return
+        if not self.current_sys_id:
+            return
+        in_list = parent._is_item_in_non_recent_list(
+            self.current_sys_id,
+            img=self.current_p_num,
+            fl_id=parent._normalize_fl_id(self.current_fl_id),
+        )
+        self.btn_add_to_list.setText(_format_add_to_list_label(in_list))
 
     def _refresh_find_highlights(self):
         apply_find_highlight(self.text_ms, self.find_ms_input.text().strip())
@@ -2268,6 +2282,7 @@ class ResultDialog(QDialog):
         self.current_full_header = page_data.get('full_header', '')
         self.current_page_text = page_data.get('text', '')
         self.current_page_uid = page_data.get('uid')
+        self._update_add_to_list_button()
 
         # Keep the dialog's data object aligned with the currently displayed folio
         if self.data is not None:
@@ -2719,15 +2734,32 @@ class ActionsHoverWidget(QWidget):
         layout.setSpacing(4)
         layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.buttons = []
+        self.always_visible_buttons = set()
 
-    def add_btn(self, btn):
+    def add_btn(self, btn, always_visible=False):
         self.layout().addWidget(btn)
         self.buttons.append(btn)
-        btn.setVisible(False)
+        if always_visible:
+            self.always_visible_buttons.add(btn)
+            btn.setVisible(True)
+        else:
+            btn.setVisible(False)
 
     def set_buttons_visible(self, visible):
         for b in self.buttons:
-            b.setVisible(visible)
+            if b in self.always_visible_buttons:
+                b.setVisible(True)
+            else:
+                b.setVisible(visible)
+
+
+def _format_add_to_list_label(in_list=False):
+    star = "⭐" if in_list else "☆"
+    return f"{star} {tr('Add to List')}"
+
+
+def _format_list_star(in_list=False):
+    return "⭐" if in_list else "☆"
 
 class GenizahGUI(QMainWindow):
     """Main application window orchestrating search, browsing, and indexing."""
@@ -2801,6 +2833,7 @@ class GenizahGUI(QMainWindow):
         self.comp_thread = None 
         self.comp_worker = None
         self.hovered_row = -1
+        self.lists_hovered_row = -1
         self.results_loaded = 0
         self.snippet_queue = []
 
@@ -3116,7 +3149,7 @@ class GenizahGUI(QMainWindow):
         self._update_results_filter_indicators()
 
         self.results_table.setColumnWidth(self.COL_CHECKBOX, 30) # Checkbox column
-        self.results_table.setColumnWidth(self.COL_ACTIONS, 70)
+        self.results_table.setColumnWidth(self.COL_ACTIONS, 95)
         self.results_table.setColumnWidth(self.COL_SYS_ID, 135)
         self.results_table.setColumnWidth(self.COL_SHELF, 175)
         self.results_table.horizontalHeader().setSectionResizeMode(self.COL_SNIPPET, QHeaderView.ResizeMode.Stretch)
@@ -3184,7 +3217,7 @@ class GenizahGUI(QMainWindow):
         bot.addWidget(self.status_label, 1)
 
         # Add to List button
-        self.btn_add_to_list = QPushButton(tr("☆ Add to List"))
+        self.btn_add_to_list = QPushButton(_format_add_to_list_label(False))
         self.btn_add_to_list.clicked.connect(self.search_add_selected_to_list)
         self.btn_add_to_list.setEnabled(False)
         bot.addWidget(self.btn_add_to_list)
@@ -3361,6 +3394,11 @@ class GenizahGUI(QMainWindow):
         rl.addWidget(self.comp_tree)
         
         exp_layout = QHBoxLayout()
+        self.btn_comp_add_to_list = QPushButton(_format_add_to_list_label(False))
+        self.btn_comp_add_to_list.clicked.connect(self.comp_add_selected_to_list)
+        self.btn_comp_add_to_list.setEnabled(False)
+        exp_layout.addWidget(self.btn_comp_add_to_list)
+        exp_layout.addStretch()
         self.lbl_comp_export = QLabel(tr("Save Report"))
         exp_layout.addWidget(self.lbl_comp_export)
         
@@ -3458,7 +3496,7 @@ class GenizahGUI(QMainWindow):
         row1.addWidget(self.btn_find_parallels)
 
         # Add to List button for browse tab
-        self.btn_browse_add_to_list = QPushButton(tr("☆ Add to List"))
+        self.btn_browse_add_to_list = QPushButton(_format_add_to_list_label(False))
         self.btn_browse_add_to_list.clicked.connect(self.browse_add_to_list)
         self.btn_browse_add_to_list.setEnabled(False)
         row1.addWidget(self.btn_browse_add_to_list)
@@ -3720,6 +3758,7 @@ class GenizahGUI(QMainWindow):
             source=tr("from browse"),
             anchor_widget=self.btn_browse_add_to_list
         )
+        self._update_browse_add_to_list_button()
 
     def _set_last_browse_field(self, field):
         self.last_browse_field = field
@@ -4127,6 +4166,9 @@ class GenizahGUI(QMainWindow):
         self.lists_items_table.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
         self.lists_items_table.itemClicked.connect(self.lists_on_item_clicked)
         self.lists_items_table.itemChanged.connect(self.lists_on_item_checkbox_changed)
+        self.lists_items_table.setMouseTracking(True)
+        self.lists_items_table.cellEntered.connect(self.on_lists_table_cell_entered)
+        self.lists_items_table.installEventFilter(self)
         main_layout.addWidget(self.lists_items_table, 1)
 
         # Single action bar
@@ -4317,6 +4359,8 @@ class GenizahGUI(QMainWindow):
         """Refresh the lists sidebar and current items view."""
         self.lists_refresh_sidebar()
         self.lists_refresh_items()
+        self._update_search_action_stars()
+        self._update_browse_add_to_list_button()
 
     def lists_refresh_sidebar(self):
         """Refresh the lists tree in the sidebar."""
@@ -4441,34 +4485,19 @@ class GenizahGUI(QMainWindow):
             self.lists_items_table.setItem(row, 4, QTableWidgetItem(", ".join(tags)))
 
             # Action buttons
-            actions_widget = QWidget()
-            actions_layout = QHBoxLayout(actions_widget)
-            actions_layout.setContentsMargins(2, 2, 2, 2)
-            actions_layout.setSpacing(2)
+            actions_widget = ActionsHoverWidget()
 
-            btn_view = QPushButton("👁️")
-            btn_view.setFixedSize(24, 24)
-            btn_view.setToolTip(tr("Quick View"))
-            btn_view.clicked.connect(lambda _, iid=item_id: self.lists_quick_view_by_id(iid))
-            actions_layout.addWidget(btn_view)
+            btn_view = self._create_action_button("👁️", tr("Quick View"), lambda _, iid=item_id: self.lists_quick_view_by_id(iid), parent=self.lists_items_table)
+            actions_widget.add_btn(btn_view)
 
-            btn_browse = QPushButton("📖")
-            btn_browse.setFixedSize(24, 24)
-            btn_browse.setToolTip(tr("Browse"))
-            btn_browse.clicked.connect(lambda _, iid=item_id: self.lists_browse_by_id(iid))
-            actions_layout.addWidget(btn_browse)
+            btn_browse = self._create_action_button("📖", tr("Browse"), lambda _, iid=item_id: self.lists_browse_by_id(iid), parent=self.lists_items_table)
+            actions_widget.add_btn(btn_browse)
 
-            btn_copy = QPushButton("📋")
-            btn_copy.setFixedSize(24, 24)
-            btn_copy.setToolTip(tr("Copy Info"))
-            btn_copy.clicked.connect(lambda _, iid=item_id: self.lists_copy_info_by_id(iid))
-            actions_layout.addWidget(btn_copy)
+            btn_copy = self._create_action_button("📋", tr("Copy Info"), lambda _, iid=item_id: self.lists_copy_info_by_id(iid), parent=self.lists_items_table)
+            actions_widget.add_btn(btn_copy)
 
-            btn_remove = QPushButton("🗑️")
-            btn_remove.setFixedSize(24, 24)
-            btn_remove.setToolTip(tr("Remove from List"))
-            btn_remove.clicked.connect(lambda _, iid=item_id: self.lists_remove_item_by_id(iid))
-            actions_layout.addWidget(btn_remove)
+            btn_remove = self._create_action_button("🗑️", tr("Remove from List"), lambda _, iid=item_id: self.lists_remove_item_by_id(iid), parent=self.lists_items_table)
+            actions_widget.add_btn(btn_remove)
 
             self.lists_items_table.setCellWidget(row, 5, actions_widget)
 
@@ -6002,8 +6031,12 @@ class GenizahGUI(QMainWindow):
 
             # Actions
             actions_widget = ActionsHoverWidget()
-            view_btn = self._create_action_button("👁", tr("View result"), lambda _, r=res: self.show_full_text_for_result(r))
+            list_btn = self._create_action_button("☆", tr("Add to List"), parent=self.results_table)
+            list_btn.clicked.connect(lambda _, r=res, b=list_btn: self.search_add_row_to_list(r, b))
+            list_btn.setProperty("action_role", "list_star")
+            actions_widget.add_btn(list_btn, always_visible=True)
             browse_btn = self._create_action_button("📖", tr("Browse manuscript"), lambda _, r=res: self.open_result_in_browse_from_table(r))
+            view_btn = self._create_action_button("👁", tr("View result"), lambda _, r=res: self.show_full_text_for_result(r))
             actions_widget.add_btn(browse_btn)
             actions_widget.add_btn(view_btn)
             self.results_table.setCellWidget(row_idx, self.COL_ACTIONS, actions_widget)
@@ -6040,6 +6073,7 @@ class GenizahGUI(QMainWindow):
             self.results_table.setItem(row_idx, self.COL_IMG, QTableWidgetItem(str(meta.get('img', ''))))
             # Src
             self.results_table.setItem(row_idx, self.COL_SRC, QTableWidgetItem(str(meta.get('source', ''))))
+            self._update_search_row_list_indicator(row_idx, res)
 
         self.results_loaded = end_idx
         self.results_table.setSortingEnabled(True)
@@ -6320,8 +6354,8 @@ class GenizahGUI(QMainWindow):
             progress_part = f" ({self.meta_progress_current}/{self.meta_to_fetch_count})"
         return tr("Metadata loaded: {}/{}").format(total_loaded, total_expected) + progress_part
 
-    def _create_action_button(self, content, tooltip, callback):
-        btn = QToolButton(self.results_table)
+    def _create_action_button(self, content, tooltip, callback=None, parent=None):
+        btn = QToolButton(parent or self.results_table)
         if isinstance(content, str):
             btn.setText(content)
             f = btn.font()
@@ -6333,8 +6367,59 @@ class GenizahGUI(QMainWindow):
         btn.setAutoRaise(True)
         btn.setCursor(Qt.CursorShape.PointingHandCursor)
         btn.setFixedSize(28, 24)
-        btn.clicked.connect(callback)
+        if callback:
+            btn.clicked.connect(callback)
         return btn
+
+    def _is_item_in_non_recent_list(self, sys_id, img=None, fl_id=None):
+        if not self.lists_mgr or not sys_id:
+            return False
+        item_id = self.lists_mgr._build_item_id(sys_id, img=img, fl_id=fl_id)
+        item = self.lists_mgr.get_item(item_id)
+        return bool(item and item.get('lists'))
+
+    def _set_add_to_list_button_label(self, button, in_list):
+        if not button:
+            return
+        button.setText(_format_add_to_list_label(in_list))
+
+    def _update_browse_add_to_list_button(self):
+        if not hasattr(self, 'btn_browse_add_to_list'):
+            return
+        in_list = self._is_item_in_non_recent_list(
+            self.current_browse_sid,
+            img=self.current_browse_p,
+            fl_id=self._normalize_fl_id(self.browse_fl_input.text().strip()),
+        )
+        self._set_add_to_list_button_label(self.btn_browse_add_to_list, in_list)
+
+    def _update_search_row_list_indicator(self, row, res=None):
+        actions_widget = self.results_table.cellWidget(row, self.COL_ACTIONS)
+        if not isinstance(actions_widget, ActionsHoverWidget):
+            return
+        if res is None:
+            item = self.results_table.item(row, self.COL_SYS_ID)
+            if item:
+                res = item.data(Qt.ItemDataRole.UserRole)
+        if not res:
+            return
+
+        display = res.get('display', {}) if isinstance(res, dict) else {}
+        sys_id = display.get('id')
+        img = display.get('img')
+        fl_id = self._normalize_fl_id(self._extract_fl_id(res))
+        in_list = self._is_item_in_non_recent_list(sys_id, img=img, fl_id=fl_id)
+
+        for btn in actions_widget.buttons:
+            if btn.property("action_role") == "list_star":
+                btn.setText(_format_list_star(in_list))
+                break
+
+    def _update_search_action_stars(self):
+        if not hasattr(self, 'results_table'):
+            return
+        for row in range(self.results_table.rowCount()):
+            self._update_search_row_list_indicator(row)
 
     def on_table_cell_entered(self, row, col):
         if row == self.hovered_row:
@@ -6353,6 +6438,20 @@ class GenizahGUI(QMainWindow):
         if isinstance(w, ActionsHoverWidget):
             w.set_buttons_visible(True)
 
+    def on_lists_table_cell_entered(self, row, col):
+        if row == self.lists_hovered_row:
+            return
+
+        if self.lists_hovered_row != -1:
+            w = self.lists_items_table.cellWidget(self.lists_hovered_row, 5)
+            if isinstance(w, ActionsHoverWidget):
+                w.set_buttons_visible(False)
+
+        self.lists_hovered_row = row
+        w = self.lists_items_table.cellWidget(row, 5)
+        if isinstance(w, ActionsHoverWidget):
+            w.set_buttons_visible(True)
+
     def eventFilter(self, source, event):
         if source == self.results_table and event.type() == QEvent.Type.Leave:
             if self.hovered_row != -1:
@@ -6360,6 +6459,12 @@ class GenizahGUI(QMainWindow):
                 if isinstance(w, ActionsHoverWidget):
                     w.set_buttons_visible(False)
                 self.hovered_row = -1
+        if source == self.lists_items_table and event.type() == QEvent.Type.Leave:
+            if self.lists_hovered_row != -1:
+                w = self.lists_items_table.cellWidget(self.lists_hovered_row, 5)
+                if isinstance(w, ActionsHoverWidget):
+                    w.set_buttons_visible(False)
+                self.lists_hovered_row = -1
         return super().eventFilter(source, event)
 
     def _collect_sorted_results(self):
@@ -6532,6 +6637,78 @@ class GenizahGUI(QMainWindow):
         if items:
             source = f"Search: {self.last_search_query[:50]}" if self.last_search_query else "Search"
             self.show_add_to_list_menu(items, source=source, anchor_widget=self.btn_add_to_list)
+
+    def search_add_row_to_list(self, res, anchor_widget=None):
+        """Add a single search result row to a list."""
+        if not self.lists_mgr or not isinstance(res, dict):
+            return
+        display = res.get('display', {})
+        sys_id = display.get('id')
+        if not sys_id:
+            return
+        items = [{
+            'sys_id': sys_id,
+            'img': display.get('img'),
+            'fl_id': self._normalize_fl_id(self._extract_fl_id(res)),
+        }]
+        source = f"Search: {self.last_search_query[:50]}" if self.last_search_query else "Search"
+        self.show_add_to_list_menu(items, source=source, anchor_widget=anchor_widget or self.results_table)
+
+    def _collect_selected_comp_pages(self):
+        selected = []
+        sel_main, sel_appx, sel_filt, sel_filt_appx, sel_known = self._collect_checked_comp_items_struct()
+
+        def add_item(item):
+            if not item:
+                return
+            if item.get('type') in ('manuscript', 'part'):
+                pages = item.get('pages', [])
+                if pages:
+                    selected.extend(pages)
+                else:
+                    selected.append(item)
+            else:
+                selected.append(item)
+
+        for item in sel_main:
+            add_item(item)
+        for group_items in sel_appx.values():
+            for item in group_items:
+                add_item(item)
+        for item in sel_filt:
+            add_item(item)
+        for group_items in sel_filt_appx.values():
+            for item in group_items:
+                add_item(item)
+        for item in sel_known:
+            add_item(item)
+
+        return selected
+
+    def comp_add_selected_to_list(self):
+        """Add selected composition results to a list."""
+        if not self.lists_mgr:
+            return
+
+        pages = self._collect_selected_comp_pages()
+        items = []
+        for page in pages:
+            raw_header = page.get('raw_header', '')
+            sys_id, p_num, _, _ = self._get_meta_for_header(raw_header)
+            if not sys_id:
+                continue
+            parsed = self.meta_mgr.parse_full_id_components(raw_header) if raw_header else {}
+            fl_id = self._normalize_fl_id(parsed.get('fl_id'))
+            items.append({
+                'sys_id': sys_id,
+                'img': p_num,
+                'fl_id': fl_id,
+            })
+
+        if items:
+            title = self.comp_title_input.text().strip()
+            source = f"Composition: {title[:50]}" if title else "Composition Search"
+            self.show_add_to_list_menu(items, source=source, anchor_widget=self.btn_comp_add_to_list)
 
     def open_result_in_browse(self, res, shelfmark=None, title=None, fl_id=None):
         sid = None
@@ -8831,6 +9008,8 @@ class GenizahGUI(QMainWindow):
             self.lbl_comp_export.setText(tr("Export selected results"))
         else:
             self.lbl_comp_export.setText(tr("Save Report"))
+        if hasattr(self, 'btn_comp_add_to_list'):
+            self.btn_comp_add_to_list.setEnabled(has_selection)
 
     def _collect_checked_comp_items_struct(self):
         """
@@ -9704,6 +9883,7 @@ class GenizahGUI(QMainWindow):
 
         self.btn_b_prev.setEnabled(pd['current_idx'] > 1)
         self.btn_b_next.setEnabled(pd['current_idx'] < pd['total_pages'])
+        self._update_browse_add_to_list_button()
 
         parsed = self.meta_mgr.parse_full_id_components(full_header)
         if parsed.get('fl_id'):

--- a/genizah_app.py
+++ b/genizah_app.py
@@ -5312,6 +5312,7 @@ class GenizahGUI(QMainWindow):
 
     def _export_as_json(self, list_id, list_name, items):
         """Export list as JSON."""
+        from datetime import datetime
         export_data = {
             'list_name': list_name,
             'exported': datetime.now().isoformat(),

--- a/genizah_app.py
+++ b/genizah_app.py
@@ -6439,6 +6439,8 @@ class GenizahGUI(QMainWindow):
             w.set_buttons_visible(True)
 
     def on_lists_table_cell_entered(self, row, col):
+        if not hasattr(self, "lists_items_table"):
+            return
         if row == self.lists_hovered_row:
             return
 
@@ -6459,7 +6461,7 @@ class GenizahGUI(QMainWindow):
                 if isinstance(w, ActionsHoverWidget):
                     w.set_buttons_visible(False)
                 self.hovered_row = -1
-        if source == self.lists_items_table and event.type() == QEvent.Type.Leave:
+        if hasattr(self, "lists_items_table") and source == self.lists_items_table and event.type() == QEvent.Type.Leave:
             if self.lists_hovered_row != -1:
                 w = self.lists_items_table.cellWidget(self.lists_hovered_row, 5)
                 if isinstance(w, ActionsHoverWidget):

--- a/genizah_app.py
+++ b/genizah_app.py
@@ -4279,6 +4279,7 @@ class GenizahGUI(QMainWindow):
         if visible:
             self.lists_preview_panel.setMinimumWidth(250)
             self.lists_preview_panel.setMaximumWidth(16777215)
+            self.lists_preview_panel.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Expanding)
             if self.lists_preview_last_sizes:
                 self.lists_main_splitter.setSizes(self.lists_preview_last_sizes)
         else:
@@ -4296,6 +4297,7 @@ class GenizahGUI(QMainWindow):
                     else:
                         sizes[i] = collapsed_width
                 self.lists_main_splitter.setSizes(sizes)
+            self.lists_preview_panel.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding)
             self.lists_preview_panel.setMinimumWidth(collapsed_width)
             self.lists_preview_panel.setMaximumWidth(collapsed_width)
 

--- a/genizah_app.py
+++ b/genizah_app.py
@@ -2091,9 +2091,11 @@ class ResultDialog(QDialog):
             sys_id = display.get('id')
 
         if sys_id:
-            parent.show_add_to_list_menu([sys_id], source=tr("from browse"), anchor_widget=self.btn_add_to_list)
+            fl_id = parent._normalize_fl_id(self.current_fl_id)
+            parent.show_add_to_list_menu([sys_id], source=tr("from browse"),
+                                          anchor_widget=self.btn_add_to_list, fl_id_map={sys_id: fl_id} if fl_id else None)
             # Also add to recently viewed
-            parent.lists_mgr.add_to_recent(sys_id)
+            parent.lists_mgr.add_to_recent(sys_id, fl_id=fl_id)
 
     def _refresh_find_highlights(self):
         apply_find_highlight(self.text_ms, self.find_ms_input.text().strip())
@@ -2161,7 +2163,8 @@ class ResultDialog(QDialog):
         # Add to Recently Viewed
         parent = self.parent()
         if parent and hasattr(parent, 'lists_mgr') and parent.lists_mgr and self.current_sys_id:
-            parent.lists_mgr.add_to_recent(self.current_sys_id)
+            fl_id = parent._normalize_fl_id(ids.get('fl_id'))
+            parent.lists_mgr.add_to_recent(self.current_sys_id, fl_id=fl_id)
 
         # --- Prepare Text Content ---
         # 1. Manuscript Text (Apply Pattern!)
@@ -3706,10 +3709,12 @@ class GenizahGUI(QMainWindow):
         if not self.current_browse_sid or not self.lists_mgr:
             return
 
+        fl_id = self._normalize_fl_id(self.browse_fl_input.text().strip())
         self.show_add_to_list_menu(
             [self.current_browse_sid],
             source=tr("from browse"),
-            anchor_widget=self.btn_browse_add_to_list
+            anchor_widget=self.btn_browse_add_to_list,
+            fl_id_map={self.current_browse_sid: fl_id} if fl_id else None
         )
 
     def _set_last_browse_field(self, field):
@@ -3967,15 +3972,26 @@ class GenizahGUI(QMainWindow):
 
         # Preview header with collapse button
         preview_header = QHBoxLayout()
-        preview_header.addWidget(QLabel(f"<b>{tr('Preview')}</b>"))
+        self.lists_preview_title = QLabel(f"<b>{tr('Preview')}</b>")
+        preview_header.addWidget(self.lists_preview_title)
         preview_header.addStretch()
+        self.btn_toggle_preview = QPushButton("◀")
+        self.btn_toggle_preview.setFixedSize(24, 24)
+        self.btn_toggle_preview.setToolTip(tr("Toggle Preview Panel"))
+        self.btn_toggle_preview.clicked.connect(self.lists_toggle_preview)
+        preview_header.addWidget(self.btn_toggle_preview)
         preview_layout.addLayout(preview_header)
+
+        self.lists_preview_contents = QWidget()
+        preview_contents_layout = QVBoxLayout(self.lists_preview_contents)
+        preview_contents_layout.setContentsMargins(0, 0, 0, 0)
+        preview_contents_layout.setSpacing(5)
 
         # Text preview area
         self.lists_preview_text = QTextEdit()
         self.lists_preview_text.setReadOnly(True)
         self.lists_preview_text.setPlaceholderText(tr("Select an item to preview"))
-        preview_layout.addWidget(self.lists_preview_text, 2)
+        preview_contents_layout.addWidget(self.lists_preview_text, 2)
 
         # Image area
         self.lists_preview_image = QLabel()
@@ -3983,7 +3999,7 @@ class GenizahGUI(QMainWindow):
         self.lists_preview_image.setMinimumHeight(150)
         self.lists_preview_image.setStyleSheet("background-color: #1a1a1a; border: 1px solid #333;")
         self.lists_preview_image.setText(tr("No image"))
-        preview_layout.addWidget(self.lists_preview_image, 1)
+        preview_contents_layout.addWidget(self.lists_preview_image, 1)
 
         # Details section
         details_group = QGroupBox(tr("Item Details"))
@@ -4001,6 +4017,14 @@ class GenizahGUI(QMainWindow):
 
         self.lists_detail_lists = QLabel()
         details_layout.addRow(tr("Lists:"), self.lists_detail_lists)
+
+        self.lists_detail_sys_id = QLabel()
+        self.lists_detail_sys_id.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
+        details_layout.addRow(tr("System ID:"), self.lists_detail_sys_id)
+
+        self.lists_detail_image = QLabel()
+        self.lists_detail_image.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
+        details_layout.addRow(tr("Image:"), self.lists_detail_image)
 
         # Tags with add button
         tags_widget = QWidget()
@@ -4025,7 +4049,8 @@ class GenizahGUI(QMainWindow):
         self.btn_detail_save.clicked.connect(self.lists_save_item_details)
         details_layout.addRow("", self.btn_detail_save)
 
-        preview_layout.addWidget(details_group)
+        preview_contents_layout.addWidget(details_group)
+        preview_layout.addWidget(self.lists_preview_contents)
 
         # --- Center Content Area ---
         center_widget = QWidget()
@@ -4048,13 +4073,6 @@ class GenizahGUI(QMainWindow):
         list_header.addWidget(self.lists_current_label)
 
         list_header.addStretch()
-
-        # Toggle preview button
-        self.btn_toggle_preview = QPushButton("◀")
-        self.btn_toggle_preview.setFixedSize(28, 28)
-        self.btn_toggle_preview.setToolTip(tr("Toggle Preview Panel"))
-        self.btn_toggle_preview.clicked.connect(self.lists_toggle_preview)
-        list_header.addWidget(self.btn_toggle_preview)
 
         # Edit/Delete buttons for current list
         self.btn_edit_list = QPushButton("✏️")
@@ -4089,17 +4107,19 @@ class GenizahGUI(QMainWindow):
 
         # Items table
         self.lists_items_table = QTableWidget()
-        self.lists_items_table.setColumnCount(5)
-        self.lists_items_table.setHorizontalHeaderLabels(["", tr("Shelfmark"), tr("Title"), tr("Tags"), tr("Actions")])
+        self.lists_items_table.setColumnCount(6)
+        self.lists_items_table.setHorizontalHeaderLabels(["", tr("Shelfmark"), tr("Title"), tr("Image"), tr("Tags"), tr("Actions")])
         self.lists_items_table.horizontalHeader().setSectionResizeMode(0, QHeaderView.ResizeMode.Fixed)
         self.lists_items_table.setColumnWidth(0, 30)  # Checkbox
         self.lists_items_table.horizontalHeader().setSectionResizeMode(1, QHeaderView.ResizeMode.Interactive)
         self.lists_items_table.setColumnWidth(1, 150)
         self.lists_items_table.horizontalHeader().setSectionResizeMode(2, QHeaderView.ResizeMode.Stretch)
         self.lists_items_table.horizontalHeader().setSectionResizeMode(3, QHeaderView.ResizeMode.Interactive)
-        self.lists_items_table.setColumnWidth(3, 120)
-        self.lists_items_table.horizontalHeader().setSectionResizeMode(4, QHeaderView.ResizeMode.Fixed)
+        self.lists_items_table.setColumnWidth(3, 90)
+        self.lists_items_table.horizontalHeader().setSectionResizeMode(4, QHeaderView.ResizeMode.Interactive)
         self.lists_items_table.setColumnWidth(4, 120)
+        self.lists_items_table.horizontalHeader().setSectionResizeMode(5, QHeaderView.ResizeMode.Fixed)
+        self.lists_items_table.setColumnWidth(5, 120)
         self.lists_items_table.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
         self.lists_items_table.itemClicked.connect(self.lists_on_item_clicked)
         self.lists_items_table.itemChanged.connect(self.lists_on_item_checkbox_changed)
@@ -4107,6 +4127,11 @@ class GenizahGUI(QMainWindow):
 
         # Single action bar
         action_bar = QHBoxLayout()
+
+        self.chk_lists_select_all = QCheckBox(tr("Select All"))
+        self.chk_lists_select_all.setTristate(True)
+        self.chk_lists_select_all.toggled.connect(self.lists_on_select_all_toggled)
+        action_bar.addWidget(self.chk_lists_select_all)
 
         self.lists_selection_label = QLabel("")
         action_bar.addWidget(self.lists_selection_label)
@@ -4179,23 +4204,35 @@ class GenizahGUI(QMainWindow):
 
         sidebar_layout.addLayout(sidebar_actions)
 
+        is_rtl = self.layoutDirection() == Qt.LayoutDirection.RightToLeft
+
         # Add to content splitter
-        content_splitter.addWidget(main_area)
-        content_splitter.addWidget(sidebar)
-        content_splitter.setStretchFactor(0, 1)
-        content_splitter.setStretchFactor(1, 0)
+        if is_rtl:
+            content_splitter.addWidget(sidebar)
+            content_splitter.addWidget(main_area)
+        else:
+            content_splitter.addWidget(main_area)
+            content_splitter.addWidget(sidebar)
+        content_splitter.setStretchFactor(content_splitter.indexOf(main_area), 1)
+        content_splitter.setStretchFactor(content_splitter.indexOf(sidebar), 0)
 
         center_layout.addWidget(content_splitter)
 
         # Add to main splitter
-        main_splitter.addWidget(self.lists_preview_panel)
-        main_splitter.addWidget(center_widget)
-        main_splitter.setStretchFactor(0, 0)
-        main_splitter.setStretchFactor(1, 1)
-        main_splitter.setSizes([300, 700])
+        if is_rtl:
+            main_splitter.addWidget(center_widget)
+            main_splitter.addWidget(self.lists_preview_panel)
+        else:
+            main_splitter.addWidget(self.lists_preview_panel)
+            main_splitter.addWidget(center_widget)
+        main_splitter.setStretchFactor(main_splitter.indexOf(self.lists_preview_panel), 0)
+        main_splitter.setStretchFactor(main_splitter.indexOf(center_widget), 1)
+        main_splitter.setSizes([300, 700] if not is_rtl else [700, 300])
 
         # Store reference to splitter for toggle
         self.lists_main_splitter = main_splitter
+        self.lists_preview_index = main_splitter.indexOf(self.lists_preview_panel)
+        self.lists_preview_last_sizes = None
 
         layout.addWidget(main_splitter)
 
@@ -4203,14 +4240,54 @@ class GenizahGUI(QMainWindow):
         self.lists_current_list_id = 'default'
         self.lists_current_item_sys_id = None
         self.lists_preview_visible = True
+        self.lists_set_preview_visible(True, auto=True)
 
         return panel
 
     def lists_toggle_preview(self):
         """Toggle the preview panel visibility."""
-        self.lists_preview_visible = not self.lists_preview_visible
-        self.lists_preview_panel.setVisible(self.lists_preview_visible)
-        self.btn_toggle_preview.setText("◀" if self.lists_preview_visible else "▶")
+        self.lists_set_preview_visible(not self.lists_preview_visible, auto=False)
+
+    def _normalize_fl_id(self, fl_id):
+        digits = re.sub(r"\D", "", str(fl_id or ""))
+        return digits or None
+
+    def _format_fl_id_display(self, fl_id):
+        digits = self._normalize_fl_id(fl_id)
+        return f"FL{digits}" if digits else ""
+
+    def lists_set_preview_visible(self, visible, auto=False):
+        """Show/hide preview panel with a slim collapsed bar."""
+        if self.lists_preview_visible == visible and not auto:
+            return
+        self.lists_preview_visible = visible
+        self.lists_preview_contents.setVisible(visible)
+        self.lists_preview_title.setVisible(visible)
+        self.btn_toggle_preview.setText("◀" if visible else "▶")
+
+        if not self.lists_main_splitter:
+            return
+
+        if visible:
+            self.lists_preview_panel.setMinimumWidth(250)
+            self.lists_preview_panel.setMaximumWidth(16777215)
+            if self.lists_preview_last_sizes:
+                self.lists_main_splitter.setSizes(self.lists_preview_last_sizes)
+        else:
+            self.lists_preview_last_sizes = self.lists_main_splitter.sizes()
+            collapsed_width = 28
+            sizes = self.lists_preview_last_sizes[:]
+            if self.lists_preview_index < len(sizes):
+                sizes[self.lists_preview_index] = collapsed_width
+                total = sum(sizes)
+                if total:
+                    for i in range(len(sizes)):
+                        if i != self.lists_preview_index:
+                            sizes[i] = max(1, total - collapsed_width)
+                            break
+                self.lists_main_splitter.setSizes(sizes)
+            self.lists_preview_panel.setMinimumWidth(collapsed_width)
+            self.lists_preview_panel.setMaximumWidth(collapsed_width)
 
     def lists_refresh_all(self):
         """Refresh the lists sidebar and current items view."""
@@ -4294,22 +4371,25 @@ class GenizahGUI(QMainWindow):
         filter_text = self.lists_filter_input.text().strip().lower()
 
         self.lists_items_table.blockSignals(True)
+        visible_sys_ids = set()
 
         for item in items:
             shelfmark = item.get('shelfmark', 'Unknown')
             title = item.get('title', '')
             tags = item.get('tags', [])
+            fl_id = item.get('fl_id')
             sys_id = item.get('sys_id')
             is_unidentified = item.get('shelfmark_override') is not None
 
             # Apply filter
             if filter_text:
-                searchable = f"{shelfmark} {title} {' '.join(tags)}".lower()
+                searchable = f"{shelfmark} {title} {' '.join(tags)} {fl_id or ''}".lower()
                 if filter_text not in searchable:
                     continue
 
             row = self.lists_items_table.rowCount()
             self.lists_items_table.insertRow(row)
+            visible_sys_ids.add(sys_id)
 
             # Checkbox
             chk_item = QTableWidgetItem()
@@ -4328,8 +4408,11 @@ class GenizahGUI(QMainWindow):
             # Title
             self.lists_items_table.setItem(row, 2, QTableWidgetItem(title))
 
+            # Image
+            self.lists_items_table.setItem(row, 3, QTableWidgetItem(self._format_fl_id_display(fl_id)))
+
             # Tags
-            self.lists_items_table.setItem(row, 3, QTableWidgetItem(", ".join(tags)))
+            self.lists_items_table.setItem(row, 4, QTableWidgetItem(", ".join(tags)))
 
             # Action buttons
             actions_widget = QWidget()
@@ -4361,10 +4444,15 @@ class GenizahGUI(QMainWindow):
             btn_remove.clicked.connect(lambda _, sid=sys_id: self.lists_remove_item_by_id(sid))
             actions_layout.addWidget(btn_remove)
 
-            self.lists_items_table.setCellWidget(row, 4, actions_widget)
+            self.lists_items_table.setCellWidget(row, 5, actions_widget)
 
         self.lists_items_table.blockSignals(False)
         self.lists_update_selection_label()
+        self.chk_lists_select_all.setEnabled(self.lists_items_table.rowCount() > 0)
+        self.lists_sync_select_all_checkbox()
+        if not self.lists_current_item_sys_id or self.lists_current_item_sys_id not in visible_sys_ids:
+            self.lists_current_item_sys_id = None
+            self.lists_clear_details()
 
     def lists_on_list_selected(self, item, column):
         """Handle list selection in the sidebar."""
@@ -4406,6 +4494,45 @@ class GenizahGUI(QMainWindow):
             self.lists_selection_label.setText(tr("{} selected").format(count))
         else:
             self.lists_selection_label.setText("")
+        self.lists_sync_select_all_checkbox()
+
+    def lists_on_select_all_toggled(self, checked):
+        """Toggle all checkboxes in the list table."""
+        if not hasattr(self, "_lists_select_all_guard"):
+            self._lists_select_all_guard = False
+        if self._lists_select_all_guard:
+            return
+        self.lists_items_table.blockSignals(True)
+        for row in range(self.lists_items_table.rowCount()):
+            chk = self.lists_items_table.item(row, 0)
+            if chk:
+                chk.setCheckState(Qt.CheckState.Checked if checked else Qt.CheckState.Unchecked)
+        self.lists_items_table.blockSignals(False)
+        self.lists_update_selection_label()
+
+    def lists_sync_select_all_checkbox(self):
+        """Sync 'Select All' checkbox state with row selections."""
+        if not hasattr(self, "_lists_select_all_guard"):
+            self._lists_select_all_guard = False
+        total = self.lists_items_table.rowCount()
+        if total == 0:
+            self._lists_select_all_guard = True
+            self.chk_lists_select_all.setCheckState(Qt.CheckState.Unchecked)
+            self._lists_select_all_guard = False
+            return
+        checked_count = 0
+        for row in range(total):
+            chk = self.lists_items_table.item(row, 0)
+            if chk and chk.checkState() == Qt.CheckState.Checked:
+                checked_count += 1
+        self._lists_select_all_guard = True
+        if checked_count == 0:
+            self.chk_lists_select_all.setCheckState(Qt.CheckState.Unchecked)
+        elif checked_count == total:
+            self.chk_lists_select_all.setCheckState(Qt.CheckState.Checked)
+        else:
+            self.chk_lists_select_all.setCheckState(Qt.CheckState.PartiallyChecked)
+        self._lists_select_all_guard = False
 
     def lists_get_selected_sys_ids(self):
         """Get list of selected sys_ids."""
@@ -4437,6 +4564,8 @@ class GenizahGUI(QMainWindow):
 
         self.lists_detail_shelfmark.setText(shelfmark)
         self.lists_detail_title.setText(title)
+        self.lists_detail_sys_id.setText(sys_id or '')
+        self.lists_detail_image.setText(self._format_fl_id_display(item.get('fl_id')) or '-')
 
         # Lists
         list_names = []
@@ -4482,6 +4611,8 @@ class GenizahGUI(QMainWindow):
 
         # Load text preview and image
         self._lists_load_preview(sys_id)
+        if not self.lists_preview_visible:
+            self.lists_set_preview_visible(True, auto=True)
 
     def _lists_load_preview(self, sys_id):
         """Load text and image preview for an item."""
@@ -4559,6 +4690,8 @@ class GenizahGUI(QMainWindow):
         self.lists_detail_shelfmark.setText('')
         self.lists_detail_title.setText('')
         self.lists_detail_lists.setText('')
+        self.lists_detail_sys_id.setText('')
+        self.lists_detail_image.setText('')
         self.lists_detail_note.setText('')
         self.lists_detail_source.setText('')
         self.lists_detail_added.setText('')
@@ -4573,6 +4706,8 @@ class GenizahGUI(QMainWindow):
         self.lists_preview_text.clear()
         self.lists_preview_image.clear()
         self.lists_preview_image.setText(tr("No image"))
+        if self.lists_preview_visible:
+            self.lists_set_preview_visible(False, auto=True)
 
     def lists_save_item_details(self):
         """Save changes to the current item."""
@@ -5023,7 +5158,7 @@ class GenizahGUI(QMainWindow):
             return
 
         list_name = lst.get('name', 'list')
-        items = self.lists_mgr.get_list_items(list_id)
+        items = self.lists_mgr.get_items_sorted(list_id, sort_by='shelfmark')
 
         if not items:
             QMessageBox.information(self, tr("Export List"), tr("List is empty."))
@@ -5055,12 +5190,15 @@ class GenizahGUI(QMainWindow):
         source = item.get('source', '')
         notes = item.get('notes', '')
         tags = item.get('tags', [])
+        fl_id = item.get('fl_id')
 
         lines = []
         if shelfmark:
             lines.append(shelfmark)
         if title:
             lines.append(f"  {title}")
+        if fl_id:
+            lines.append(f"  {tr('Image')}: {self._format_fl_id_display(fl_id)}")
         lines.append(f"  ID: {sys_id}")
         if source:
             lines.append(f"  {tr('Source')}: {source}")
@@ -5123,7 +5261,7 @@ class GenizahGUI(QMainWindow):
         ws.title = list_name[:31]  # Excel max sheet name length
 
         # Headers
-        headers = [tr('Shelfmark'), tr('Title'), 'ID', tr('Source'), tr('Tags'), tr('Notes')]
+        headers = [tr('Shelfmark'), tr('Title'), tr('Image'), 'ID', tr('Source'), tr('Tags'), tr('Notes')]
         for col, header in enumerate(headers, 1):
             ws.cell(row=1, column=col, value=header)
 
@@ -5131,10 +5269,11 @@ class GenizahGUI(QMainWindow):
         for row, item in enumerate(items, 2):
             ws.cell(row=row, column=1, value=item.get('shelfmark', ''))
             ws.cell(row=row, column=2, value=item.get('title', ''))
-            ws.cell(row=row, column=3, value=item.get('sys_id', ''))
-            ws.cell(row=row, column=4, value=item.get('source', ''))
-            ws.cell(row=row, column=5, value=', '.join(item.get('tags', [])))
-            ws.cell(row=row, column=6, value=item.get('notes', ''))
+            ws.cell(row=row, column=3, value=self._format_fl_id_display(item.get('fl_id')))
+            ws.cell(row=row, column=4, value=item.get('sys_id', ''))
+            ws.cell(row=row, column=5, value=item.get('source', ''))
+            ws.cell(row=row, column=6, value=', '.join(item.get('tags', [])))
+            ws.cell(row=row, column=7, value=item.get('notes', ''))
 
         default_name = f"{list_name}.xlsx"
         path, _ = QFileDialog.getSaveFileName(
@@ -5164,6 +5303,7 @@ class GenizahGUI(QMainWindow):
             shelfmark = item.get('shelfmark', 'Unknown')
             title = item.get('title', '')
             sys_id = item.get('sys_id', '')
+            fl_id = item.get('fl_id')
             source = item.get('source', '')
             tags = item.get('tags', [])
             notes = item.get('notes', '')
@@ -5171,6 +5311,8 @@ class GenizahGUI(QMainWindow):
             doc.add_heading(f"{i}. {shelfmark}", level=2)
             if title:
                 doc.add_paragraph(title)
+            if fl_id:
+                doc.add_paragraph(f"{tr('Image')}: {self._format_fl_id_display(fl_id)}")
             doc.add_paragraph(f"ID: {sys_id}")
             if source:
                 doc.add_paragraph(f"{tr('Source')}: {source}")
@@ -5223,7 +5365,7 @@ class GenizahGUI(QMainWindow):
 
     # --- Add to List from other places ---
 
-    def show_add_to_list_menu(self, sys_ids, source='', anchor_widget=None):
+    def show_add_to_list_menu(self, sys_ids, source='', anchor_widget=None, fl_id_map=None):
         """Show menu for adding items to a list."""
         if not self.lists_mgr or not sys_ids:
             return
@@ -5252,13 +5394,13 @@ class GenizahGUI(QMainWindow):
                 name, ok = QInputDialog.getText(self, tr("Create New List"), tr("List Name:"))
                 if ok and name.strip():
                     list_id = self.lists_mgr.create_list(name.strip())
-                    self.lists_mgr.add_items_bulk(sys_ids, list_id, source=source)
+                    self.lists_mgr.add_items_bulk(sys_ids, list_id, source=source, fl_id_map=fl_id_map)
                     self.status_label.setText(tr("Added to list."))
                     self.lists_refresh_all()  # Refresh to show new list
             else:
                 list_id = action.data()
                 if list_id:
-                    added = self.lists_mgr.add_items_bulk(sys_ids, list_id, source=source)
+                    added = self.lists_mgr.add_items_bulk(sys_ids, list_id, source=source, fl_id_map=fl_id_map)
                     if added > 0:
                         self.status_label.setText(tr("Added to list."))
                         self.lists_refresh_all()  # Refresh to show new items
@@ -6318,6 +6460,7 @@ class GenizahGUI(QMainWindow):
 
         # Collect selected sys_ids
         sys_ids = []
+        fl_id_map = {}
         for i in range(self.results_table.rowCount()):
             chk = self.results_table.item(i, self.COL_CHECKBOX)
             if chk and chk.checkState() == Qt.CheckState.Checked:
@@ -6327,10 +6470,14 @@ class GenizahGUI(QMainWindow):
                     sys_id = display.get('id')
                     if sys_id:
                         sys_ids.append(sys_id)
+                        fl_id = self._normalize_fl_id(self._extract_fl_id(res))
+                        if fl_id:
+                            fl_id_map[sys_id] = fl_id
 
         if sys_ids:
-            source = tr("from search: {}").format(self.last_search_query[:50]) if self.last_search_query else ""
-            self.show_add_to_list_menu(sys_ids, source=source, anchor_widget=self.btn_add_to_list)
+            source = f"Search: {self.last_search_query[:50]}" if self.last_search_query else "Search"
+            self.show_add_to_list_menu(sys_ids, source=source, anchor_widget=self.btn_add_to_list,
+                                       fl_id_map=fl_id_map or None)
 
     def open_result_in_browse(self, res, shelfmark=None, title=None, fl_id=None):
         sid = None
@@ -9226,7 +9373,8 @@ class GenizahGUI(QMainWindow):
 
         # Add to Recently Viewed
         if self.lists_mgr:
-            self.lists_mgr.add_to_recent(sid)
+            fl_id = self._normalize_fl_id(page_data.get('fl_id') if page_data else self.browse_fl_input.text().strip())
+            self.lists_mgr.add_to_recent(sid, fl_id=fl_id)
 
         # Disable controls until loaded
         self.btn_b_catalog.setEnabled(False)

--- a/genizah_core.py
+++ b/genizah_core.py
@@ -4532,6 +4532,10 @@ class ListsManager:
                         loaded['lists']['default'] = defaults['lists']['default']
                     if 'recent' not in loaded['lists']:
                         loaded['lists']['recent'] = defaults['lists']['recent']
+                    # Backfill sys_id on stored items (older format used key only)
+                    for item_id, item_data in loaded.get('items', {}).items():
+                        if isinstance(item_data, dict) and 'sys_id' not in item_data:
+                            item_data['sys_id'] = item_id
                     self.data = loaded
             except Exception as e:
                 LOGGER.warning(f"Failed to load lists: {e}")
@@ -4696,25 +4700,37 @@ class ListsManager:
 
     # --- Item Management ---
 
-    def add_item(self, sys_id, list_id='default', note='', tags=None, source='', fl_id=None):
+    def _build_item_id(self, sys_id, img=None, fl_id=None):
+        if img not in (None, ""):
+            return f"{sys_id}::img::{img}"
+        if fl_id not in (None, ""):
+            return f"{sys_id}::fl::{fl_id}"
+        return sys_id
+
+    def add_item(self, sys_id, list_id='default', note='', tags=None, source='', fl_id=None, img=None):
         """Add an item to a list. Returns True if added, False if already exists."""
         import time
 
         if list_id not in self.data['lists']:
             return False
 
-        if sys_id in self.data['items']:
+        item_id = self._build_item_id(sys_id, img=img, fl_id=fl_id)
+
+        if item_id in self.data['items']:
             # Item exists, add to list if not already
-            item = self.data['items'][sys_id]
+            item = self.data['items'][item_id]
             if list_id in item.get('lists', []):
                 return False  # Already in this list
             item['lists'].append(list_id)
             if fl_id:
                 item['fl_id'] = fl_id
+            if img not in (None, ""):
+                item['img'] = img
             item['modified'] = time.time()
         else:
             # New item
-            self.data['items'][sys_id] = {
+            self.data['items'][item_id] = {
+                'sys_id': sys_id,
                 'lists': [list_id],
                 'tags': tags or [],
                 'note': note,
@@ -4722,7 +4738,8 @@ class ListsManager:
                 'added': time.time(),
                 'modified': time.time(),
                 'shelfmark_override': None,  # For unidentified items
-                'fl_id': fl_id
+                'fl_id': fl_id,
+                'img': img
             }
 
         # Update all_tags
@@ -4734,7 +4751,7 @@ class ListsManager:
         self.save()
         return True
 
-    def add_items_bulk(self, sys_ids, list_id='default', source='', fl_id_map=None):
+    def add_items_bulk(self, items, list_id='default', source='', fl_id_map=None):
         """Add multiple items to a list at once."""
         import time
 
@@ -4742,20 +4759,36 @@ class ListsManager:
             return 0
 
         added = 0
-        for sys_id in sys_ids:
-            if sys_id in self.data['items']:
-                item = self.data['items'][sys_id]
+        for entry in items:
+            if isinstance(entry, dict):
+                sys_id = entry.get('sys_id')
+                fl_id = entry.get('fl_id')
+                img = entry.get('img')
+            else:
+                sys_id = entry
+                fl_id = fl_id_map.get(sys_id) if fl_id_map else None
+                img = None
+
+            if not sys_id:
+                continue
+
+            item_id = self._build_item_id(sys_id, img=img, fl_id=fl_id)
+
+            if item_id in self.data['items']:
+                item = self.data['items'][item_id]
                 if list_id not in item.get('lists', []):
                     item['lists'].append(list_id)
                     item['modified'] = time.time()
                     added += 1
-                fl_id = fl_id_map.get(sys_id) if fl_id_map else None
                 if fl_id and item.get('fl_id') != fl_id:
                     item['fl_id'] = fl_id
                     item['modified'] = time.time()
+                if img not in (None, "") and item.get('img') != img:
+                    item['img'] = img
+                    item['modified'] = time.time()
             else:
-                fl_id = fl_id_map.get(sys_id) if fl_id_map else None
-                self.data['items'][sys_id] = {
+                self.data['items'][item_id] = {
+                    'sys_id': sys_id,
                     'lists': [list_id],
                     'tags': [],
                     'note': '',
@@ -4763,21 +4796,22 @@ class ListsManager:
                     'added': time.time(),
                     'modified': time.time(),
                     'shelfmark_override': None,
-                    'fl_id': fl_id
+                    'fl_id': fl_id,
+                    'img': img
                 }
                 added += 1
 
         self.save()
         return added
 
-    def update_item(self, sys_id, note=None, tags=None, shelfmark_override=None, fl_id=None):
+    def update_item(self, item_id, note=None, tags=None, shelfmark_override=None, fl_id=None, img=None):
         """Update an item's properties."""
         import time
 
-        if sys_id not in self.data['items']:
+        if item_id not in self.data['items']:
             return False
 
-        item = self.data['items'][sys_id]
+        item = self.data['items'][item_id]
 
         if note is not None:
             item['note'] = note
@@ -4791,17 +4825,19 @@ class ListsManager:
             item['shelfmark_override'] = shelfmark_override
         if fl_id is not None:
             item['fl_id'] = fl_id
+        if img is not None:
+            item['img'] = img
 
         item['modified'] = time.time()
         self.save()
         return True
 
-    def remove_item_from_list(self, sys_id, list_id):
+    def remove_item_from_list(self, item_id, list_id):
         """Remove an item from a specific list."""
-        if sys_id not in self.data['items']:
+        if item_id not in self.data['items']:
             return False
 
-        item = self.data['items'][sys_id]
+        item = self.data['items'][item_id]
         if list_id not in item.get('lists', []):
             return False
 
@@ -4809,7 +4845,7 @@ class ListsManager:
 
         # If item has no more lists, remove it entirely
         if not item['lists']:
-            del self.data['items'][sys_id]
+            del self.data['items'][item_id]
 
         self.save()
         return True
@@ -4818,9 +4854,9 @@ class ListsManager:
         """Move items from one list to another."""
         import time
 
-        for sys_id in sys_ids:
-            if sys_id in self.data['items']:
-                item = self.data['items'][sys_id]
+        for item_id in sys_ids:
+            if item_id in self.data['items']:
+                item = self.data['items'][item_id]
                 if from_list_id in item.get('lists', []):
                     item['lists'].remove(from_list_id)
                 if to_list_id not in item.get('lists', []):
@@ -4833,53 +4869,62 @@ class ListsManager:
         """Get all items in a list with their metadata."""
         if list_id == 'recent':
             items = []
-            for sys_id in self.data.get('recent_items', []):
-                item_data = self.data['items'].get(sys_id, {})
+            for item_id in self.data.get('recent_items', []):
+                item_data = self.data['items'].get(item_id, {})
                 items.append({
-                    'sys_id': sys_id,
-                    **item_data
+                    **item_data,
+                    'item_id': item_id
                 })
+                if 'sys_id' not in items[-1] and item_id:
+                    items[-1]['sys_id'] = item_id
             return items
 
         items = []
-        for sys_id, item_data in self.data['items'].items():
+        for item_id, item_data in self.data['items'].items():
             if list_id in item_data.get('lists', []):
                 items.append({
-                    'sys_id': sys_id,
-                    **item_data
+                    **item_data,
+                    'item_id': item_id
                 })
+                if 'sys_id' not in items[-1] and item_id:
+                    items[-1]['sys_id'] = item_id
         return items
 
-    def get_item(self, sys_id):
+    def get_item(self, item_id):
         """Get a single item's data."""
-        if sys_id in self.data['items']:
-            return {'sys_id': sys_id, **self.data['items'][sys_id]}
+        if item_id in self.data['items']:
+            item = dict(self.data['items'][item_id])
+            if 'sys_id' not in item:
+                item['sys_id'] = item_id
+            item['item_id'] = item_id
+            return item
         return None
 
-    def is_item_in_any_list(self, sys_id):
+    def is_item_in_any_list(self, item_id):
         """Check if an item is in any list (excluding recent)."""
-        return sys_id in self.data['items']
+        return item_id in self.data['items']
 
-    def get_item_lists(self, sys_id):
+    def get_item_lists(self, item_id):
         """Get list of lists an item belongs to."""
-        if sys_id not in self.data['items']:
+        if item_id not in self.data['items']:
             return []
-        return self.data['items'][sys_id].get('lists', [])
+        return self.data['items'][item_id].get('lists', [])
 
     # --- Recently Viewed ---
 
-    def add_to_recent(self, sys_id, fl_id=None):
+    def add_to_recent(self, sys_id, fl_id=None, img=None):
         """Add an item to the recently viewed list."""
         import time
 
         recent = self.data.get('recent_items', [])
 
         # Remove if already present (we'll add to front)
-        if sys_id in recent:
-            recent.remove(sys_id)
+        item_id = self._build_item_id(sys_id, img=img, fl_id=fl_id)
+        if item_id in recent:
+            recent.remove(item_id)
 
         # Add to front
-        recent.insert(0, sys_id)
+        recent.insert(0, item_id)
 
         # Trim to max size
         if len(recent) > self.MAX_RECENT_ITEMS:
@@ -4888,8 +4933,9 @@ class ListsManager:
         self.data['recent_items'] = recent
 
         # Also ensure item exists in items dict for metadata
-        if sys_id not in self.data['items']:
-            self.data['items'][sys_id] = {
+        if item_id not in self.data['items']:
+            self.data['items'][item_id] = {
+                'sys_id': sys_id,
                 'lists': [],  # Not in any regular list, just recent
                 'tags': [],
                 'note': '',
@@ -4897,10 +4943,14 @@ class ListsManager:
                 'added': time.time(),
                 'modified': time.time(),
                 'shelfmark_override': None,
-                'fl_id': fl_id
+                'fl_id': fl_id,
+                'img': img
             }
-        elif fl_id:
-            self.data['items'][sys_id]['fl_id'] = fl_id
+        else:
+            if fl_id:
+                self.data['items'][item_id]['fl_id'] = fl_id
+            if img is not None:
+                self.data['items'][item_id]['img'] = img
 
         self.save()
 
@@ -4948,8 +4998,9 @@ class ListsManager:
 
         for item in items:
             item_export = {
-                'sys_id': item['sys_id'],
+                'sys_id': item.get('sys_id'),
                 'fl_id': item.get('fl_id'),
+                'img': item.get('img'),
                 'tags': item.get('tags', []),
                 'note': item.get('note', ''),
                 'source': item.get('source', ''),
@@ -4999,12 +5050,14 @@ class ListsManager:
                 note=item.get('note', ''),
                 tags=item.get('tags', []),
                 source=item.get('source', ''),
-                fl_id=item.get('fl_id')
+                fl_id=item.get('fl_id'),
+                img=item.get('img')
             )
 
             # Set shelfmark override for unidentified items
             if not is_identified and item.get('shelfmark'):
-                self.update_item(sys_id, shelfmark_override=item.get('shelfmark'))
+                item_id = self._build_item_id(sys_id, img=item.get('img'), fl_id=item.get('fl_id'))
+                self.update_item(item_id, shelfmark_override=item.get('shelfmark'))
 
             imported += 1
 
@@ -5056,15 +5109,16 @@ class ListsManager:
 
     # --- Copy Info ---
 
-    def get_item_copy_text(self, sys_id, format_type='compact'):
+    def get_item_copy_text(self, item_id, format_type='compact'):
         """
         Generate text for copying item info.
         format_type: 'compact', 'detailed', 'with_link'
         """
-        if sys_id not in self.data['items']:
+        if item_id not in self.data['items']:
             return ''
 
-        item = self.data['items'][sys_id]
+        item = self.data['items'][item_id]
+        sys_id = item.get('sys_id', item_id)
 
         shelfmark = 'Unknown'
         title = ''

--- a/genizah_core.py
+++ b/genizah_core.py
@@ -4696,7 +4696,7 @@ class ListsManager:
 
     # --- Item Management ---
 
-    def add_item(self, sys_id, list_id='default', note='', tags=None, source=''):
+    def add_item(self, sys_id, list_id='default', note='', tags=None, source='', fl_id=None):
         """Add an item to a list. Returns True if added, False if already exists."""
         import time
 
@@ -4709,6 +4709,8 @@ class ListsManager:
             if list_id in item.get('lists', []):
                 return False  # Already in this list
             item['lists'].append(list_id)
+            if fl_id:
+                item['fl_id'] = fl_id
             item['modified'] = time.time()
         else:
             # New item
@@ -4719,7 +4721,8 @@ class ListsManager:
                 'source': source,
                 'added': time.time(),
                 'modified': time.time(),
-                'shelfmark_override': None  # For unidentified items
+                'shelfmark_override': None,  # For unidentified items
+                'fl_id': fl_id
             }
 
         # Update all_tags
@@ -4731,7 +4734,7 @@ class ListsManager:
         self.save()
         return True
 
-    def add_items_bulk(self, sys_ids, list_id='default', source=''):
+    def add_items_bulk(self, sys_ids, list_id='default', source='', fl_id_map=None):
         """Add multiple items to a list at once."""
         import time
 
@@ -4746,7 +4749,12 @@ class ListsManager:
                     item['lists'].append(list_id)
                     item['modified'] = time.time()
                     added += 1
+                fl_id = fl_id_map.get(sys_id) if fl_id_map else None
+                if fl_id and item.get('fl_id') != fl_id:
+                    item['fl_id'] = fl_id
+                    item['modified'] = time.time()
             else:
+                fl_id = fl_id_map.get(sys_id) if fl_id_map else None
                 self.data['items'][sys_id] = {
                     'lists': [list_id],
                     'tags': [],
@@ -4754,14 +4762,15 @@ class ListsManager:
                     'source': source,
                     'added': time.time(),
                     'modified': time.time(),
-                    'shelfmark_override': None
+                    'shelfmark_override': None,
+                    'fl_id': fl_id
                 }
                 added += 1
 
         self.save()
         return added
 
-    def update_item(self, sys_id, note=None, tags=None, shelfmark_override=None):
+    def update_item(self, sys_id, note=None, tags=None, shelfmark_override=None, fl_id=None):
         """Update an item's properties."""
         import time
 
@@ -4780,6 +4789,8 @@ class ListsManager:
                     self.data['all_tags'].append(tag)
         if shelfmark_override is not None:
             item['shelfmark_override'] = shelfmark_override
+        if fl_id is not None:
+            item['fl_id'] = fl_id
 
         item['modified'] = time.time()
         self.save()
@@ -4857,7 +4868,7 @@ class ListsManager:
 
     # --- Recently Viewed ---
 
-    def add_to_recent(self, sys_id):
+    def add_to_recent(self, sys_id, fl_id=None):
         """Add an item to the recently viewed list."""
         import time
 
@@ -4885,8 +4896,11 @@ class ListsManager:
                 'source': '',
                 'added': time.time(),
                 'modified': time.time(),
-                'shelfmark_override': None
+                'shelfmark_override': None,
+                'fl_id': fl_id
             }
+        elif fl_id:
+            self.data['items'][sys_id]['fl_id'] = fl_id
 
         self.save()
 
@@ -4935,6 +4949,7 @@ class ListsManager:
         for item in items:
             item_export = {
                 'sys_id': item['sys_id'],
+                'fl_id': item.get('fl_id'),
                 'tags': item.get('tags', []),
                 'note': item.get('note', ''),
                 'source': item.get('source', ''),
@@ -4983,7 +4998,8 @@ class ListsManager:
                 list_id=list_id,
                 note=item.get('note', ''),
                 tags=item.get('tags', []),
-                source=item.get('source', '')
+                source=item.get('source', ''),
+                fl_id=item.get('fl_id')
             )
 
             # Set shelfmark override for unidentified items

--- a/version.py
+++ b/version.py
@@ -1,3 +1,3 @@
 """Centralized version definition for the Genizah Search Pro application."""
 
-APP_VERSION = "4.0.1"
+APP_VERSION = "4.1"


### PR DESCRIPTION
### Motivation
- Restore a right-to-left friendly lists layout and show the preview pane on the correct side with a toggle control. 
- Add a convenient "Select All" control for list-item checkboxes and keep selection count visible. 
- Persist FL image identifiers (`fl_id`) with list items and surface them in the UI and exports. 
- Fix export code that relied on a non-existing API and standardize the search-source label formatting.

### Description
- Updated `ListsManager` (`genizah_core.py`) to store and propagate `fl_id` in `add_item`, `add_items_bulk`, `update_item`, `add_to_recent`, `export_list`, and `import_list` and to accept an `fl_id_map` for bulk adds. 
- Modified the Lists UI (`genizah_app.py`) to: add an `Image` column in the items table, add `System ID` and `Image` fields to the details form, show/hide the preview panel via a slim toggle bar, auto-close preview when no item is selected, and handle RTL layout by swapping splitter sides when appropriate. 
- Implemented a `Select All` `QCheckBox` with tri-state sync logic (`lists_on_select_all_toggled`, `lists_sync_select_all_checkbox`) and wired it to the items table. 
- Propagated `fl_id` when adding items from browse/search dialogs (`show_add_to_list_menu` accepts `fl_id_map`), added helper functions ` _normalize_fl_id` and `_format_fl_id_display`, and updated list export formats (text/Excel/Word) to include the `Image` column and label. 
- Replaced a brittle list export lookup with `get_items_sorted` for consistent export ordering and changed the search add-source label to `Search: ...`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696324db8b4c832181ec456fc030915f)