### PR TITLE
Fix list preview image loading

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -4833,17 +4833,10 @@ class GenizahGUI(QMainWindow):
             return
 
         try:
-            # Try to get image URL
-            full_header = page_data.get('full_header', '')
-            if not full_header:
-                return
-
-            parsed = self.meta_mgr.parse_full_id_components(full_header)
-            fl_id = parsed.get('fl_id')
-
             thumb_url = None
-            if fl_id:
-                thumb_url = self.meta_mgr._resolve_thumbnail([fl_id])
+            meta = self.meta_mgr.nli_cache.get(sys_id)
+            if meta:
+                thumb_url = meta.get('thumb_url')
 
             if not thumb_url:
                 thumb_url = self.meta_mgr.get_thumbnail(sys_id)

--- a/genizah_app.py
+++ b/genizah_app.py
@@ -4349,7 +4349,7 @@ class GenizahGUI(QMainWindow):
         
         self.lists_preview_contents.setVisible(visible)
         self.lists_preview_title.setVisible(visible)
-        self.btn_toggle_preview.setText("◀" if visible else "▶")
+        self.btn_toggle_preview.setText(tr("▶") if visible else tr("◀"))
 
         if not self.lists_main_splitter:
             return

--- a/genizah_app.py
+++ b/genizah_app.py
@@ -4841,34 +4841,66 @@ class GenizahGUI(QMainWindow):
             parsed = self.meta_mgr.parse_full_id_components(full_header)
             fl_id = parsed.get('fl_id')
 
-            if fl_id and hasattr(self, 'fetcher') and self.fetcher:
-                # Try cached image first
-                cached = self.fetcher.get_cached_image(fl_id)
-                if cached:
-                    self._lists_set_preview_image(cached)
-                else:
-                    # Fetch synchronously for now (can optimize later)
-                    self.lists_preview_image.setText(tr("Loading..."))
-                    QApplication.processEvents()
-                    img_data = self.fetcher.fetch_single(fl_id)
-                    if img_data:
-                        self._lists_set_preview_image(img_data)
-                    else:
-                        self.lists_preview_image.setText(tr("No image"))
+            thumb_url = None
+            if fl_id:
+                thumb_url = self.meta_mgr._resolve_thumbnail([fl_id])
+
+            if not thumb_url:
+                thumb_url = self.meta_mgr.get_thumbnail(sys_id)
+
+            if thumb_url:
+                self._lists_start_preview_download(thumb_url)
+            else:
+                self.lists_preview_image.setText(tr("No image"))
         except Exception as e:
             LOGGER.debug(f"Failed to load preview image: {e}")
             self.lists_preview_image.setText(tr("No image"))
 
-    def _lists_set_preview_image(self, img_data):
-        """Set preview image from data."""
-        try:
-            pixmap = QPixmap()
-            pixmap.loadFromData(img_data)
-            scaled = pixmap.scaled(280, 200, Qt.AspectRatioMode.KeepAspectRatio,
-                                  Qt.TransformationMode.SmoothTransformation)
-            self.lists_preview_image.setPixmap(scaled)
-        except:
+    def _lists_start_preview_download(self, thumb_url):
+        """Download and display preview image for lists panel."""
+        self._lists_cancel_preview_image_thread()
+        self.lists_preview_thumb_url = thumb_url
+        if not thumb_url:
             self.lists_preview_image.setText(tr("No image"))
+            return
+
+        self.lists_preview_image.setText(tr("Loading..."))
+        self.lists_preview_image.setPixmap(QPixmap())
+
+        self.lists_preview_img_thread = ImageLoaderThread(thumb_url)
+        self.lists_preview_img_thread.image_loaded.connect(
+            lambda image, url=thumb_url: self._lists_on_preview_image_loaded(image, url)
+        )
+        self.lists_preview_img_thread.load_failed.connect(
+            lambda url=thumb_url: self._lists_on_preview_image_failed(url)
+        )
+        self.lists_preview_img_thread.start()
+
+    def _lists_on_preview_image_loaded(self, image, thumb_url):
+        """Handle preview image loaded for lists panel."""
+        if thumb_url != getattr(self, 'lists_preview_thumb_url', None):
+            return
+        pix = QPixmap.fromImage(image)
+        scaled = pix.scaled(
+            self.lists_preview_image.size(),
+            Qt.AspectRatioMode.KeepAspectRatio,
+            Qt.TransformationMode.SmoothTransformation
+        )
+        self.lists_preview_image.setPixmap(scaled)
+        self.lists_preview_image.setText("")
+
+    def _lists_on_preview_image_failed(self, thumb_url):
+        """Handle preview image load failure for lists panel."""
+        if thumb_url != getattr(self, 'lists_preview_thumb_url', None):
+            return
+        self.lists_preview_image.setPixmap(QPixmap())
+        self.lists_preview_image.setText(tr("No image"))
+
+    def _lists_cancel_preview_image_thread(self):
+        preview_thread = getattr(self, 'lists_preview_img_thread', None)
+        if preview_thread and preview_thread.isRunning():
+            preview_thread.cancel()
+            preview_thread.wait(500)
 
     def lists_clear_details(self):
         """Clear the details panel and preview."""
@@ -4891,6 +4923,7 @@ class GenizahGUI(QMainWindow):
         self.lists_preview_text.clear()
         self.lists_preview_image.clear()
         self.lists_preview_image.setText(tr("No image"))
+        self._lists_cancel_preview_image_thread()
         if self.lists_preview_visible:
             self.lists_set_preview_visible(False, auto=True)
 

--- a/genizah_app.py
+++ b/genizah_app.py
@@ -4036,7 +4036,7 @@ class GenizahGUI(QMainWindow):
         self.lists_preview_title = QLabel(f"<b>{tr('Preview')}</b>")
         preview_header.addWidget(self.lists_preview_title)
         preview_header.addStretch()
-        self.btn_toggle_preview = QPushButton("◀")
+        self.btn_toggle_preview = QPushButton(tr("◀"))
         self.btn_toggle_preview.setFixedSize(24, 24)
         self.btn_toggle_preview.setToolTip(tr("Toggle Preview Panel"))
         self.btn_toggle_preview.clicked.connect(self.lists_toggle_preview)


### PR DESCRIPTION
### Motivation
- The lists preview panel sometimes showed no image because preview loading used a synchronous `fetcher.fetch_single` path that could be missing or stale. 
- The goal is to use the same thumbnail resolution logic as the rest of the UI and to load thumbnails asynchronously to avoid blocking the UI. 
- Avoid stale/overlapping downloads by tracking and cancelling preview image threads when they are no longer needed. 

### Description
- Replaced synchronous `fetcher.fetch_single` usage in `_lists_load_preview_image` with thumbnail resolution via `meta_mgr._resolve_thumbnail` and `meta_mgr.get_thumbnail` to obtain a `thumb_url`. 
- Added `_lists_start_preview_download`, `_lists_on_preview_image_loaded`, `_lists_on_preview_image_failed`, and `_lists_cancel_preview_image_thread` to download and display thumbnails asynchronously using `ImageLoaderThread`. 
- Ensure preview download threads are cancelled when clearing the details panel by calling `_lists_cancel_preview_image_thread` from `lists_clear_details`. 
- Removed the old `_lists_set_preview_image` synchronous image-path and switched to the unified `ImageLoaderThread` signal handlers for consistent scaling and display. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6963926a117083219db737bdc6a40f1c)