### PR TITLE
Improve sys_id resolution and caching to fix document/browse navigation

### DIFF
--- a/web/pages/browse.py
+++ b/web/pages/browse.py
@@ -550,13 +550,14 @@ def create_browse_page(initial_sys_id: Optional[str] = None, highlight: Optional
                     with ui.element('div').classes('image-viewer-container'):
                         # Image container
                         with ui.element('div').classes('image-container'):
-                            if page.fl_id:
-                                # Build IIIF URL
-                                digits = re.sub(r"\D", "", str(page.fl_id))
-                                if digits:
-                                    # Use a reasonable default size
-                                    img_url = f"https://iiif.nli.org.il/IIIFv21/FL{digits}/full/1000,/0/default.jpg"
+                            if page.image_url or page.fl_id:
+                                img_url = page.image_url
+                                if not img_url and page.fl_id:
+                                    digits = re.sub(r"\D", "", str(page.fl_id))
+                                    if digits:
+                                        img_url = f"https://iiif.nli.org.il/IIIFv21/FL{digits}/full/1000,/0/default.jpg"
 
+                                if img_url:
                                     ui.image(img_url).classes(
                                         'zoomable-image'
                                     ).style(
@@ -628,9 +629,9 @@ def create_browse_page(initial_sys_id: Optional[str] = None, highlight: Optional
                                 # Source badge
                                 source_class = get_source_badge_class(page.full_header)
                                 source_text = 'V0.8' if 'V0.8' in page.full_header else 'V0.7'
-                                ui.element('span').classes(
+                                ui.label(source_text).classes(
                                     f'source-badge {source_class}'
-                                ).text(source_text)
+                                )
 
                         # Transcription content
                         with ui.scroll_area().classes('transcription-content'):

--- a/web/pages/document.py
+++ b/web/pages/document.py
@@ -44,7 +44,7 @@ def create_document_page(uid: str):
 
         try:
             # Extract system ID from UID
-            state.sys_id = service.extract_sys_id(uid)
+            state.sys_id = service.resolve_sys_id(uid)
 
             # Try different methods to load the document
             browse_result = None
@@ -143,7 +143,7 @@ def create_document_page(uid: str):
                 with ui.card().classes('w-full p-8 text-center'):
                     ui.icon('error', size='3rem').classes('text-red-500')
                     ui.label(state.error).classes('text-red-600 mt-2')
-                    ui.button(tr('Back'), on_click=lambda: ui.navigate.to('/search')).classes('mt-4')
+                    ui.button(tr('Back'), on_click=lambda: ui.run_javascript('history.back()')).classes('mt-4')
                 return
 
             if not state.pages:
@@ -233,7 +233,7 @@ def create_document_page(uid: str):
             ui.button(
                 tr('Back'),
                 icon='arrow_back',
-                on_click=lambda: ui.navigate.to('/search')
+                on_click=lambda: ui.run_javascript('history.back()')
             ).props('flat')
 
         # Metadata card

--- a/web/services.py
+++ b/web/services.py
@@ -665,6 +665,47 @@ class GenizahService:
                 thumb_url = get_thumbnail_url(fl_id) if fl_id else None
                 image_url = get_full_image_url(fl_id) if fl_id else None
 
+                if not image_url:
+                    enriched = self._meta_mgr.enrich_metadata(result.get('sys_id', sys_id))
+                    images = enriched.get('images_ext') or enriched.get('images_nli') or enriched.get('images', [])
+                    if images:
+                        idx = 0
+                        folio_entries = []
+                        if p_num is not None:
+                            for i, img in enumerate(images):
+                                folio_num = img.get('folio_num')
+                                if folio_num is None:
+                                    continue
+                                try:
+                                    folio_entries.append((i, int(folio_num)))
+                                except (TypeError, ValueError):
+                                    continue
+                            try:
+                                p_val = int(p_num)
+                            except (TypeError, ValueError):
+                                p_val = None
+                            if folio_entries and p_val is not None:
+                                match = next((i for i, num in folio_entries if num == p_val), None)
+                                if match is not None:
+                                    idx = match
+                                else:
+                                    prior = [(i, num) for i, num in folio_entries if num <= p_val]
+                                    if prior:
+                                        idx = max(prior, key=lambda pair: pair[1])[0]
+                                    else:
+                                        idx = min(folio_entries, key=lambda pair: pair[1])[0]
+                            elif p_val is not None:
+                                idx = max(p_val - 1, 0)
+                        if idx >= len(images):
+                            idx = len(images) - 1
+                        img = images[idx]
+                        fl_id = fl_id or img.get('fl_id')
+                        thumb_url = img.get('thumb_url') or (get_thumbnail_url(fl_id) if fl_id else None)
+                        url = img.get('url', '')
+                        image_url = build_iiif_image_url(url, 'full') if url else (
+                            get_full_image_url(fl_id) if fl_id else None
+                        )
+
                 return BrowsePage(
                     uid=result.get('uid', ''),
                     p_num=result.get('p_num', 0),

--- a/web/services.py
+++ b/web/services.py
@@ -514,11 +514,11 @@ class GenizahService:
 
                 return results
 
-        except Exception as e:
-            print(f"Composition search error: {e}")
-            import traceback
-            traceback.print_exc()
-            return []
+            except Exception as e:
+                print(f"Composition search error: {e}")
+                import traceback
+                traceback.print_exc()
+                return []
 
     def search_composition_logic(
         self,

--- a/web/services.py
+++ b/web/services.py
@@ -215,6 +215,8 @@ class GenizahService:
             # Metadata cache for web requests (TTL-based)
             self._metadata_cache: Dict[str, Tuple[Dict, float]] = {}
             self._cache_ttl = 300  # 5 minutes
+            self._uid_sys_id_cache: Dict[str, Tuple[str, float]] = {}
+            self._uid_cache_ttl = 3600  # 1 hour
 
             GenizahService._initialized = True
 
@@ -408,7 +410,10 @@ class GenizahService:
                     if isinstance(display, str):
                         display = {'shelfmark': display, 'title': '', 'img': '', 'source': '', 'id': ''}
 
-                    sys_id = display.get('id', '') or self.extract_sys_id(r.get('uid', ''))
+                    sys_id = display.get('id', '') or self.extract_sys_id(
+                        r.get('raw_header', '') or r.get('uid', '')
+                    )
+                    self.cache_uid_sys_id(r.get('uid', ''), sys_id)
 
                     # Extract page highlights for cross-page results
                     page_highlights = r.get('page_highlights', [])
@@ -505,14 +510,15 @@ class GenizahService:
                         display=display,
                         uid=r.get('uid', '')
                     ))
+                    self.cache_uid_sys_id(r.get('uid', ''), sys_id)
 
                 return results
 
-            except Exception as e:
-                print(f"Composition search error: {e}")
-                import traceback
-                traceback.print_exc()
-                return []
+        except Exception as e:
+            print(f"Composition search error: {e}")
+            import traceback
+            traceback.print_exc()
+            return []
 
     def search_composition_logic(
         self,
@@ -1128,6 +1134,24 @@ class GenizahService:
             return match.group(1)
 
         return ''
+
+    def cache_uid_sys_id(self, uid: str, sys_id: str) -> None:
+        """Cache UID to system ID mapping for later resolution."""
+        if not uid or not sys_id:
+            return
+        self._uid_sys_id_cache[uid] = (sys_id, time.time())
+
+    def resolve_sys_id(self, uid_or_header: str) -> str:
+        """Resolve sys_id using cache first, then fallback extraction."""
+        if not uid_or_header:
+            return ''
+        cached = self._uid_sys_id_cache.get(uid_or_header)
+        if cached:
+            sys_id, cached_at = cached
+            if time.time() - cached_at < self._uid_cache_ttl:
+                return sys_id
+            self._uid_sys_id_cache.pop(uid_or_header, None)
+        return self.extract_sys_id(uid_or_header)
 
     def parse_header(self, full_header: str) -> Dict[str, str]:
         """Parse a full header into components."""


### PR DESCRIPTION
### Motivation

- Search results and composition matches sometimes lacked a reliable system ID (`sys_id`) when the UID alone was used, causing the document view to show "No text available" or fail to open the correct page. 
- Clicking "Browse manuscript" from search results could lose the search state (back navigation returned to a cleared results page). 
- Improve robustness when headers (`raw_header`) are available and speed repeated UID→sys_id resolution by caching mappings.

### Description

- Add a UID→sys_id cache in `GenizahService` with TTL (`_uid_sys_id_cache`, `_uid_cache_ttl`) and implement `cache_uid_sys_id` and `resolve_sys_id` methods to prefer cached mappings. 
- When building search and composition results, prefer `raw_header` (falling back to `uid`) to derive `sys_id`, and store the mapping via `cache_uid_sys_id`. 
- Replace direct calls to `extract_sys_id` in the document page with `resolve_sys_id` so document loading can use cached mappings and more reliable header-derived IDs. 
- Change document viewer back navigation to use browser history via `ui.run_javascript('history.back()')` to preserve client-side search state when returning from a document.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696727683cb0832182c89feb42b0b335)