### PR TITLE
Fix search results and image display bugs

### DIFF
--- a/genizah_core.py
+++ b/genizah_core.py
@@ -3066,15 +3066,22 @@ class MetadataManager:
 
     # ---------------- Shelfmark Resolution Helpers ----------------
     def _normalize_shelfmark(self, shelfmark: str) -> str:
-        """Normalize shelfmarks: remove ALL non-alphanumeric chars (spaces, dots, etc)."""
+        """Normalize shelfmarks: remove non-alphanumeric chars but preserve dots between digits."""
         if not shelfmark:
             return ""
-        
-        cleaned = re.sub(r'\W+', '', shelfmark).casefold()
-        
+
+        # First, preserve dots that appear between digits (like 120.2) by replacing with a marker
+        temp = re.sub(r'(\d)\.(\d)', r'\1DOTMARKER\2', shelfmark)
+
+        # Remove all other non-alphanumeric characters
+        cleaned = re.sub(r'\W+', '', temp).casefold()
+
+        # Restore the preserved dots
+        cleaned = cleaned.replace('dotmarker', '.')
+
         if cleaned.startswith("ms"):
             cleaned = cleaned[2:]
-            
+
         return cleaned
 
     def _iter_shelfmark_sources(self):

--- a/web/pages/browse.py
+++ b/web/pages/browse.py
@@ -126,41 +126,48 @@ VIEWER_STYLES = '''
 
     /* Metadata header */
     .metadata-header {
-        background: linear-gradient(to right, #166534, #15803d);
+        background: linear-gradient(135deg, #15803d, #166534);
         color: white;
-        padding: 20px 24px;
-        border-radius: 8px;
-        margin-bottom: 16px;
+        padding: 24px 28px;
+        border-radius: 12px;
+        margin-bottom: 20px;
+        box-shadow: 0 4px 12px rgba(22, 101, 52, 0.25);
     }
 
     .shelfmark-title {
-        font-size: 1.75rem;
-        font-weight: 700;
-        margin-bottom: 8px;
+        font-size: 2rem;
+        font-weight: 800;
+        margin-bottom: 12px;
+        text-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+        letter-spacing: 0.5px;
     }
 
     .metadata-row {
         display: flex;
         flex-wrap: wrap;
-        gap: 16px;
+        gap: 20px;
         align-items: center;
-        font-size: 0.95rem;
-        opacity: 0.9;
+        font-size: 1rem;
+        opacity: 0.95;
     }
 
     .metadata-item {
         display: flex;
         align-items: center;
-        gap: 6px;
+        gap: 8px;
+        background: rgba(255, 255, 255, 0.15);
+        padding: 6px 12px;
+        border-radius: 8px;
     }
 
     /* Navigation bar */
     .navigation-bar {
-        background: #f8fafc;
-        border: 1px solid #e2e8f0;
-        border-radius: 8px;
-        padding: 12px 16px;
-        margin-bottom: 16px;
+        background: linear-gradient(to bottom, #f8fafc, #f1f5f9);
+        border: 2px solid #cbd5e1;
+        border-radius: 10px;
+        padding: 16px 20px;
+        margin-bottom: 20px;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
     }
 
     /* Source badge styling */
@@ -483,14 +490,12 @@ def create_browse_page(initial_sys_id: Optional[str] = None, highlight: Optional
 
                     # External links
                     with ui.column().classes('items-end gap-2'):
-                        ktiv_url = f"https://www.nli.org.il/he/discover/manuscripts/hebrew-manuscripts/viewerpage?vid=NNL_ALEPH{page.sys_id}"
-                        ui.link(
-                            tr('Open in Ktiv'),
-                            ktiv_url,
-                            new_tab=True
-                        ).classes('text-white hover:text-green-200 flex items-center gap-1').style(
-                            'text-decoration: none;'
-                        )
+                        ktiv_url = f"https://www.nli.org.il/he/discover/manuscripts/hebrew-manuscripts/itempage?vid=KTIV&scope=KTIV&docId=PNX_MANUSCRIPTS{page.sys_id}"
+                        with ui.link(target=ktiv_url, new_tab=True).classes(
+                            'flex items-center gap-2 px-4 py-2 bg-white bg-opacity-20 hover:bg-opacity-30 rounded-lg transition-all'
+                        ).style('text-decoration: none; color: white;'):
+                            ui.icon('open_in_new', size='sm')
+                            ui.label(tr('Open in Ktiv')).classes('font-semibold')
 
             # === Navigation Bar ===
             with ui.element('div').classes('navigation-bar'):
@@ -550,23 +555,21 @@ def create_browse_page(initial_sys_id: Optional[str] = None, highlight: Optional
                     with ui.element('div').classes('image-viewer-container'):
                         # Image container
                         with ui.element('div').classes('image-container'):
-                            if page.image_url or page.fl_id:
+                            # Determine image URL with fallback logic
+                            img_url = None
+                            if page.image_url and page.image_url.strip():
                                 img_url = page.image_url
-                                if not img_url and page.fl_id:
-                                    digits = re.sub(r"\D", "", str(page.fl_id))
-                                    if digits:
-                                        img_url = f"https://iiif.nli.org.il/IIIFv21/FL{digits}/full/1000,/0/default.jpg"
+                            elif page.fl_id:
+                                digits = re.sub(r"\D", "", str(page.fl_id))
+                                if digits:
+                                    img_url = f"https://iiif.nli.org.il/IIIFv21/FL{digits}/full/max/0/default.jpg"
 
-                                if img_url:
-                                    ui.image(img_url).classes(
-                                        'zoomable-image'
-                                    ).style(
-                                        f'transform: scale({state.zoom_level}); transform-origin: center;'
-                                    ).props('loading="lazy"')
-                                else:
-                                    with ui.element('div').classes('image-loading'):
-                                        ui.icon('image_not_supported', size='4rem')
-                                        ui.label(tr('Image not available')).classes('mt-2')
+                            if img_url:
+                                ui.image(img_url).classes(
+                                    'zoomable-image'
+                                ).style(
+                                    f'transform: scale({state.zoom_level}); transform-origin: center;'
+                                ).props('loading="lazy"')
                             else:
                                 with ui.element('div').classes('image-loading'):
                                     ui.icon('image_not_supported', size='4rem')

--- a/web/pages/document.py
+++ b/web/pages/document.py
@@ -254,7 +254,7 @@ def create_document_page(uid: str):
                 # External links
                 if state.sys_id:
                     with ui.row().classes('gap-2'):
-                        ktiv_url = f"https://www.nli.org.il/he/discover/manuscripts/hebrew-manuscripts/viewerpage?vid=NNL_ALEPH{state.sys_id}"
+                        ktiv_url = f"https://www.nli.org.il/he/discover/manuscripts/hebrew-manuscripts/itempage?vid=KTIV&scope=KTIV&docId=PNX_MANUSCRIPTS{state.sys_id}"
                         ui.link(tr('Open in Ktiv'), ktiv_url, new_tab=True).classes('text-blue-600')
 
                         ui.button(

--- a/web/pages/parallels.py
+++ b/web/pages/parallels.py
@@ -236,38 +236,45 @@ PARALLELS_STYLES = '''
     }
 
     .manuscript-group-card {
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-        border-radius: 8px;
-        border: 1px solid #e2e8f0;
-        margin-bottom: 12px;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+        border-radius: 12px;
+        border: 2px solid #d1fae5;
+        margin-bottom: 16px;
         overflow: hidden;
+        transition: all 0.3s ease;
+    }
+
+    .manuscript-group-card:hover {
+        box-shadow: 0 6px 16px rgba(46, 125, 50, 0.2);
+        border-color: #a7f3d0;
     }
 
     .manuscript-group-header {
-        background: linear-gradient(to right, #f0fdf4, #ffffff);
-        padding: 12px 16px;
+        background: linear-gradient(135deg, #ecfdf5, #d1fae5);
+        padding: 16px 24px;
         cursor: pointer;
         transition: background 0.2s;
     }
 
     .manuscript-group-header:hover {
-        background: linear-gradient(to right, #dcfce7, #f0fdf4);
+        background: linear-gradient(135deg, #dcfce7, #bbf7d0);
     }
 
     .comparison-panel {
-        border-radius: 8px;
-        padding: 16px;
-        min-height: 80px;
+        border-radius: 10px;
+        padding: 20px;
+        min-height: 100px;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
     }
 
     .source-panel {
         background-color: #eff6ff;
-        border: 1px solid #bfdbfe;
+        border: 2px solid #bfdbfe;
     }
 
     .manuscript-panel {
         background-color: #f0fdf4;
-        border: 1px solid #bbf7d0;
+        border: 2px solid #bbf7d0;
     }
 
     .highlight-match {
@@ -573,23 +580,26 @@ def create_parallels_page():
             # Results list - fully inlined for proper context handling
             max_score = max(g.total_score for g in state.grouped_results) if state.grouped_results else 1
 
-            for group in state.grouped_results:
+            for idx, group in enumerate(state.grouped_results):
                 score_style = get_score_badge_style(group.total_score, max_score)
+
+                # Auto-expand first 3 results for quick scanning
+                is_expanded = idx < 3
 
                 with ui.card().classes('w-full manuscript-group-card'):
                     with ui.expansion(
                         text='',
                         icon='menu_book',
-                        value=False
+                        value=is_expanded
                     ).classes('w-full').props('dense header-class=manuscript-group-header'):
                         with ui.row().classes('w-full items-center justify-between'):
-                            with ui.row().classes('items-center gap-3'):
+                            with ui.column().classes('gap-1 flex-1'):
                                 ui.label(group.shelfmark).classes(
-                                    'font-bold text-green-800 text-lg'
+                                    'font-bold text-green-800 text-xl'
                                 )
                                 if group.title:
-                                    ui.label(f"- {group.title[:50]}{'...' if len(group.title) > 50 else ''}").classes(
-                                        'text-gray-600 rtl-text hebrew-text'
+                                    ui.label(f"{group.title[:80]}{'...' if len(group.title) > 80 else ''}").classes(
+                                        'text-gray-600 rtl-text hebrew-text text-sm'
                                     )
 
                             with ui.row().classes('items-center gap-3'):
@@ -635,10 +645,10 @@ def create_parallels_page():
                                             )
                                             with ui.element('div').classes('comparison-panel source-panel'):
                                                 if result.src_snippet:
-                                                    highlighted = highlight_matched_text(result.src_snippet[:600])
+                                                    highlighted = highlight_matched_text(result.src_snippet[:700])
                                                     ui.html(
-                                                        f'<div class="rtl-text hebrew-text text-sm" '
-                                                        f'style="line-height: 1.8">{highlighted}</div>',
+                                                        f'<div class="rtl-text hebrew-text text-base" '
+                                                        f'style="line-height: 2.0; font-size: 1.05rem;">{highlighted}</div>',
                                                         sanitize=False
                                                     )
                                                 else:
@@ -648,14 +658,14 @@ def create_parallels_page():
 
                                         with ui.column().classes('flex-1'):
                                             ui.label(tr('Manuscript text')).classes(
-                                                'text-sm font-medium text-green-700 mb-2'
+                                                'text-sm font-semibold text-green-700 mb-2'
                                             )
                                             with ui.element('div').classes('comparison-panel manuscript-panel'):
                                                 if result.ms_snippet:
-                                                    highlighted = highlight_matched_text(result.ms_snippet[:600])
+                                                    highlighted = highlight_matched_text(result.ms_snippet[:700])
                                                     ui.html(
-                                                        f'<div class="rtl-text hebrew-text text-sm" '
-                                                        f'style="line-height: 1.8">{highlighted}</div>',
+                                                        f'<div class="rtl-text hebrew-text text-base" '
+                                                        f'style="line-height: 2.0; font-size: 1.05rem;">{highlighted}</div>',
                                                         sanitize=False
                                                     )
                                                 else:

--- a/web/pages/search.py
+++ b/web/pages/search.py
@@ -12,11 +12,12 @@ Professional search interface with:
 - Green color theme matching Genizah branding
 """
 
-from nicegui import ui, run
+from nicegui import ui, run, app
 from typing import List, Optional
 import re
 import asyncio
 import html
+import json
 
 from web.services import get_service, SearchResult
 from web.translations import tr, is_rtl
@@ -37,16 +38,69 @@ class SearchState:
     """Holds the search state for the page."""
 
     def __init__(self):
-        self.query: str = ''
-        self.mode: str = 'variants'
-        self.gap: int = 0
+        # Try to restore state from storage
+        stored = app.storage.user.get('search_state', {})
+        self.query: str = stored.get('query', '')
+        self.mode: str = stored.get('mode', 'variants')
+        self.gap: int = stored.get('gap', 0)
         self.results: List[SearchResult] = []
         self.is_searching: bool = False
         self.error: Optional[str] = None
-        self.result_count: int = 0
+        self.result_count: int = stored.get('result_count', 0)
         self.show_advanced: bool = False
-        self.results_per_page: int = 50
-        self.current_page: int = 0
+        self.results_per_page: int = stored.get('results_per_page', 50)
+        self.current_page: int = stored.get('current_page', 0)
+
+        # Restore results from storage if available
+        results_data = stored.get('results', [])
+        if results_data:
+            try:
+                # Reconstruct SearchResult objects
+                from web.services import SearchResult
+                self.results = [
+                    SearchResult(
+                        uid=r['uid'],
+                        sys_id=r.get('sys_id'),
+                        snippet=r.get('snippet'),
+                        display=r.get('display'),
+                        source=r.get('source'),
+                        cross_page=r.get('cross_page', False)
+                    )
+                    for r in results_data
+                ]
+                self.result_count = len(self.results)
+            except Exception:
+                # If restoration fails, start fresh
+                self.results = []
+                self.result_count = 0
+
+    def save_to_storage(self):
+        """Save current state to browser storage."""
+        try:
+            # Convert SearchResult objects to dicts for JSON serialization
+            results_data = [
+                {
+                    'uid': r.uid,
+                    'sys_id': r.sys_id,
+                    'snippet': r.snippet,
+                    'display': r.display,
+                    'source': r.source,
+                    'cross_page': r.cross_page
+                }
+                for r in self.results
+            ]
+
+            app.storage.user['search_state'] = {
+                'query': self.query,
+                'mode': self.mode,
+                'gap': self.gap,
+                'results': results_data,
+                'result_count': self.result_count,
+                'results_per_page': self.results_per_page,
+                'current_page': self.current_page
+            }
+        except Exception as e:
+            print(f"Failed to save search state: {e}")
 
 
 def convert_highlight_markers(text: str) -> str:
@@ -238,11 +292,13 @@ def create_search_page():
             state.results = results
             state.result_count = len(results)
             state.error = None
+            state.save_to_storage()
 
         except Exception as e:
             state.error = str(e)
             state.results = []
             state.result_count = 0
+            state.save_to_storage()
 
         finally:
             state.is_searching = False
@@ -281,6 +337,7 @@ def create_search_page():
         total_pages = (state.result_count + state.results_per_page - 1) // state.results_per_page
         if 0 <= page < total_pages:
             state.current_page = page
+            state.save_to_storage()
             render_results.refresh()
 
     @ui.refreshable
@@ -521,6 +578,7 @@ def create_search_page():
                             def on_rpp_change(e):
                                 state.results_per_page = e.value
                                 state.current_page = 0
+                                state.save_to_storage()
                                 if state.results:
                                     render_results.refresh()
 


### PR DESCRIPTION
Bug fixes:
- Fix search results disappearing when navigating back by persisting state in browser storage
- Fix IIIF image display with improved URL fallback logic
- Fix Ketiv links to point to catalog (itempage) instead of viewer
- Fix shelf number input parsing to preserve dots between digits (e.g., T-S NS 120.2 vs 120.25)

UI improvements:
- Enhanced manuscript viewer with larger prominent headers and better visual hierarchy
- Improved Ktiv link button styling with icon
- Enhanced composition search results for quick scanning:
  * Auto-expand first 3 results
  * Larger text (1.05rem) with better line height
  * Improved card styling with better shadows and borders
  * Increased snippet length to 700 characters
  * Better visual distinction between source and manuscript panels