### PR TITLE
Add HTML mockups for UI redesign options

### DIFF
--- a/web/mockups/expert-dense-ui.html
+++ b/web/mockups/expert-dense-ui.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Genizah Search Pro - ממשק חוקרים ותיק</title>
+  <style>
+    :root {
+      --bg: #f1f5f9;
+      --panel: #ffffff;
+      --border: #cbd5f5;
+      --muted: #475569;
+      --accent: #0f172a;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: "Noto Sans Hebrew", "Assistant", "Rubik", sans-serif;
+      background: var(--bg);
+      color: #0f172a;
+    }
+    header {
+      background: var(--accent);
+      color: #fff;
+      padding: 12px 20px;
+      display: grid;
+      grid-template-columns: 1fr auto;
+      align-items: center;
+      gap: 12px;
+    }
+    header .query {
+      display: grid;
+      grid-template-columns: 1.6fr 0.5fr 0.5fr 0.7fr 0.7fr;
+      gap: 8px;
+    }
+    header input, header select {
+      padding: 6px 8px;
+      border-radius: 6px;
+      border: none;
+      font-size: 0.85rem;
+    }
+    header button {
+      background: #22c55e;
+      border: none;
+      color: #0f172a;
+      padding: 6px 12px;
+      border-radius: 6px;
+      font-weight: 700;
+    }
+    main {
+      display: grid;
+      grid-template-columns: 2.2fr 2fr 1.3fr;
+      gap: 12px;
+      padding: 12px;
+      height: calc(100vh - 56px);
+    }
+    .panel {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 10px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      min-height: 0;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.82rem;
+    }
+    th, td {
+      border-bottom: 1px solid var(--border);
+      padding: 6px 4px;
+      text-align: right;
+    }
+    th { color: var(--muted); font-weight: 600; }
+    .mono { font-family: "Courier New", monospace; }
+    .actions {
+      display: flex;
+      gap: 6px;
+      flex-wrap: wrap;
+    }
+    .actions button {
+      border: 1px solid var(--border);
+      background: #fff;
+      padding: 4px 8px;
+      border-radius: 6px;
+      font-size: 0.8rem;
+    }
+    .hint {
+      font-size: 0.75rem;
+      color: var(--muted);
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="query">
+      <input value="?מועד" />
+      <select>
+        <option>Variants (?)</option>
+        <option>Exact (=)</option>
+        <option>Fuzzy (~)</option>
+        <option>Regex (/)</option>
+      </select>
+      <input value="Gap 1" />
+      <input value="Cambridge" />
+      <input value="רשימה: מסמכי מיסוי" />
+    </div>
+    <button>RUN</button>
+  </header>
+
+  <main>
+    <section class="panel">
+      <div class="actions">
+        <button>ייצוא CSV</button>
+        <button>ייצוא Word</button>
+        <button>שמור לרשימה</button>
+        <button>Lab Mode</button>
+      </div>
+      <table>
+        <thead>
+          <tr>
+            <th>סימון מדף</th>
+            <th>שפה</th>
+            <th>תקופה</th>
+            <th>עמוד</th>
+            <th>קטע</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="mono">TS 12.345</td>
+            <td>עברית</td>
+            <td>מאה 11</td>
+            <td>2r</td>
+            <td>...מועד התפילה...</td>
+          </tr>
+          <tr>
+            <td class="mono">ENY 4.56</td>
+            <td>ערבית־יהודית</td>
+            <td>מאה 12</td>
+            <td>7v</td>
+            <td>...מועד המסחר...</td>
+          </tr>
+          <tr>
+            <td class="mono">BODL 1123</td>
+            <td>עברית</td>
+            <td>מאה 11</td>
+            <td>1r</td>
+            <td>...תאריך ומועד...</td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="hint">טיפ: Ctrl+F לסינון מהיר • Alt+R לייצוא • / להחלפת מצב חיפוש</div>
+    </section>
+
+    <section class="panel">
+      <strong>טקסט מלא (מודגש)</strong>
+      <div style="overflow:auto; line-height:1.9;">
+        ...מצאנו את <mark>המועד</mark> לפעולה זו במכתב מן הגניזה...
+      </div>
+      <strong>תצוגת תמונה</strong>
+      <div style="background:#0f172a; color:#fff; border-radius:8px; height:220px; display:flex; align-items:center; justify-content:center;">IIIF Viewer</div>
+    </section>
+
+    <section class="panel">
+      <strong>מטא־דאטה קומפקטי</strong>
+      <div class="hint">Catalog: Neubauer Part 5</div>
+      <div class="hint">Repository: Bodleian</div>
+      <div class="hint">Script: Hebrew square</div>
+      <div class="hint">Links: NLI / Cambridge / IIIF</div>
+      <div class="hint">Personal List: מסמכי מיסוי</div>
+    </section>
+  </main>
+</body>
+</html>

--- a/web/mockups/living-library.html
+++ b/web/mockups/living-library.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Genizah Search Pro - ספריית גניזה חיה</title>
+  <style>
+    :root {
+      --bg: #f5f1eb;
+      --panel: #ffffff;
+      --accent: #b45309;
+      --muted: #6b7280;
+      --border: #e5e7eb;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: "Noto Sans Hebrew", "Assistant", "Rubik", sans-serif;
+      background: var(--bg);
+      color: #111827;
+    }
+    header {
+      background: linear-gradient(120deg, #92400e, #b45309);
+      color: #fff;
+      padding: 28px 32px;
+    }
+    header h1 { margin: 0 0 8px; font-size: 1.8rem; }
+    header p { margin: 0; opacity: 0.9; }
+    .stats {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 12px;
+      margin-top: 18px;
+    }
+    .stat {
+      background: rgba(255,255,255,0.12);
+      padding: 10px 12px;
+      border-radius: 10px;
+      font-size: 0.85rem;
+    }
+    main {
+      display: grid;
+      grid-template-columns: 260px 1fr 280px;
+      gap: 16px;
+      padding: 20px;
+    }
+    .panel {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 16px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+    .facet-group {
+      border-top: 1px dashed var(--border);
+      padding-top: 12px;
+    }
+    .facet-group h3 { margin: 0 0 8px; font-size: 0.95rem; }
+    .facet-group label { font-size: 0.85rem; color: var(--muted); }
+    .cards {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+      gap: 14px;
+    }
+    .card {
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 12px;
+      background: #fff;
+      display: grid;
+      gap: 8px;
+    }
+    .thumb {
+      height: 120px;
+      background: #f3f4f6;
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--muted);
+    }
+    .tags {
+      display: flex;
+      gap: 6px;
+      flex-wrap: wrap;
+      font-size: 0.75rem;
+    }
+    .tag {
+      background: #fef3c7;
+      color: #92400e;
+      padding: 3px 8px;
+      border-radius: 999px;
+    }
+    .preview {
+      background: #111827;
+      color: #fff;
+      border-radius: 14px;
+      padding: 16px;
+      min-height: 200px;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>ספריית הגניזה החיה</h1>
+    <p>קטלוג חזותי המשלב מטא־דאטה, תמונות IIIF, ורשימות מחקר אישיות.</p>
+    <div class="stats">
+      <div class="stat">1.1M דפים מתועתקים</div>
+      <div class="stat">16 אוספים</div>
+      <div class="stat">שליפת IIIF בזמן אמת</div>
+      <div class="stat">רשימות אישיות פעילות</div>
+    </div>
+  </header>
+
+  <main>
+    <aside class="panel">
+      <h2>סינון קטלוג</h2>
+      <div class="facet-group">
+        <h3>שפה</h3>
+        <label><input type="checkbox" checked /> עברית</label><br />
+        <label><input type="checkbox" /> ערבית־יהודית</label><br />
+        <label><input type="checkbox" /> ארמית</label>
+      </div>
+      <div class="facet-group">
+        <h3>תקופה</h3>
+        <label><input type="checkbox" checked /> מאה 10-11</label><br />
+        <label><input type="checkbox" /> מאה 12</label><br />
+        <label><input type="checkbox" /> מאה 13+</label>
+      </div>
+      <div class="facet-group">
+        <h3>רשימות אישיות</h3>
+        <label><input type="checkbox" checked /> תפילות שבת</label><br />
+        <label><input type="checkbox" /> חוזים מסחריים</label>
+      </div>
+      <div class="facet-group">
+        <h3>אוסף</h3>
+        <label><input type="checkbox" checked /> Cambridge</label><br />
+        <label><input type="checkbox" /> NLI</label>
+      </div>
+    </aside>
+
+    <section class="panel">
+      <div class="cards">
+        <div class="card">
+          <div class="thumb">תמונה IIIF</div>
+          <strong>TS 12.345</strong>
+          <div class="tags">
+            <span class="tag">עברית</span>
+            <span class="tag">מאה 11</span>
+          </div>
+          <div>קטע תפילה עם נוסח ייחודי.</div>
+        </div>
+        <div class="card">
+          <div class="thumb">תמונה IIIF</div>
+          <strong>ENY 4.56</strong>
+          <div class="tags">
+            <span class="tag">ערבית־יהודית</span>
+            <span class="tag">מאה 12</span>
+          </div>
+          <div>מכתב מסחרי מן השוק הפאטימי.</div>
+        </div>
+        <div class="card">
+          <div class="thumb">תמונה IIIF</div>
+          <strong>BODL 1123</strong>
+          <div class="tags">
+            <span class="tag">Neubauer</span>
+            <span class="tag">מאה 11</span>
+          </div>
+          <div>אוסף קודיקולוגי עשיר.</div>
+        </div>
+      </div>
+    </section>
+
+    <aside class="panel">
+      <h2>תצוגה מהירה</h2>
+      <div class="preview">IIIF Viewer</div>
+      <p>טקסט מדוגם עם הדגשות והקשרים.</p>
+      <button style="background: var(--accent); color:#fff; border:none; padding:10px; border-radius:8px;">פתח מסמך מלא</button>
+    </aside>
+  </main>
+</body>
+</html>

--- a/web/mockups/research-workbench.html
+++ b/web/mockups/research-workbench.html
@@ -1,0 +1,270 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Genizah Search Pro - שולחן עבודה מחקרי</title>
+  <style>
+    :root {
+      --bg: #f6f7fb;
+      --panel: #ffffff;
+      --accent: #0f766e;
+      --accent-2: #1e40af;
+      --muted: #64748b;
+      --border: #e2e8f0;
+      --highlight: #fef08a;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: "Noto Sans Hebrew", "Assistant", "Rubik", sans-serif;
+      background: var(--bg);
+      color: #0f172a;
+    }
+    header {
+      background: #0f172a;
+      color: #fff;
+      padding: 16px 24px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    header .title {
+      font-size: 1.1rem;
+      font-weight: 700;
+    }
+    header .actions {
+      display: flex;
+      gap: 12px;
+      align-items: center;
+    }
+    header .chip {
+      background: rgba(255,255,255,0.1);
+      border: 1px solid rgba(255,255,255,0.2);
+      padding: 6px 10px;
+      border-radius: 999px;
+      font-size: 0.85rem;
+    }
+    main {
+      display: grid;
+      grid-template-columns: 320px 1fr 1.2fr;
+      gap: 16px;
+      padding: 20px;
+      height: calc(100vh - 64px);
+    }
+    .panel {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 16px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      min-height: 0;
+    }
+    .panel h2 {
+      margin: 0;
+      font-size: 1rem;
+    }
+    .section {
+      border-top: 1px dashed var(--border);
+      padding-top: 12px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+    label {
+      font-size: 0.85rem;
+      color: var(--muted);
+    }
+    input, select {
+      padding: 8px 10px;
+      border-radius: 8px;
+      border: 1px solid var(--border);
+      font-size: 0.95rem;
+      width: 100%;
+    }
+    .chips {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+    }
+    .chip-outline {
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      padding: 4px 8px;
+      font-size: 0.8rem;
+      color: var(--muted);
+    }
+    .button {
+      background: var(--accent);
+      color: #fff;
+      padding: 10px 14px;
+      border: none;
+      border-radius: 10px;
+      font-weight: 600;
+      cursor: pointer;
+      width: 100%;
+    }
+    .results {
+      overflow: auto;
+      gap: 10px;
+    }
+    .result-card {
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 12px;
+      display: grid;
+      gap: 8px;
+    }
+    .result-card .meta {
+      font-size: 0.8rem;
+      color: var(--muted);
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+    .viewer {
+      overflow: auto;
+      gap: 14px;
+    }
+    .image-box {
+      background: #0f172a;
+      border-radius: 12px;
+      height: 260px;
+      position: relative;
+      color: #fff;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .toolbar {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+    .toolbar button {
+      padding: 6px 10px;
+      border-radius: 8px;
+      border: 1px solid var(--border);
+      background: #fff;
+      cursor: pointer;
+    }
+    .highlight {
+      background: var(--highlight);
+      padding: 2px 4px;
+      border-radius: 4px;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="title">Genizah Search Pro • שולחן עבודה מחקרי</div>
+    <div class="actions">
+      <span class="chip">Lab Mode פעיל</span>
+      <span class="chip">IIIF מחובר</span>
+      <span class="chip">עברית/אנגלית</span>
+    </div>
+  </header>
+  <main>
+    <section class="panel">
+      <h2>חיפוש מתקדם</h2>
+      <label>שאילתא</label>
+      <input placeholder="טקסט עברי לחיפוש" value="=ברוך אתה" />
+      <label>מצב</label>
+      <select>
+        <option>Exact (=)</option>
+        <option>Variants (?)</option>
+        <option>Fuzzy (~)</option>
+        <option>Regex (/)</option>
+      </select>
+      <label>Gap</label>
+      <input type="number" value="2" />
+      <div class="section">
+        <h2>סינון</h2>
+        <label>תקופה</label>
+        <select>
+          <option>מאה 10-11</option>
+          <option>מאה 12</option>
+        </select>
+        <label>אוסף</label>
+        <select>
+          <option>NLI</option>
+          <option>Cambridge</option>
+        </select>
+        <label>רשימה אישית</label>
+        <select>
+          <option>החיבורים שלי</option>
+        </select>
+      </div>
+      <div class="section">
+        <h2>קיצורים</h2>
+        <div class="chips">
+          <span class="chip-outline">= Exact</span>
+          <span class="chip-outline">? Variants</span>
+          <span class="chip-outline">~ Fuzzy</span>
+          <span class="chip-outline">/ Regex</span>
+          <span class="chip-outline"># Shelfmark</span>
+        </div>
+      </div>
+      <button class="button">הרץ חיפוש</button>
+    </section>
+
+    <section class="panel results">
+      <h2>תוצאות (124)</h2>
+      <div class="result-card">
+        <strong>TS 12.345</strong>
+        <div class="meta">
+          <span>עברית</span>
+          <span>מאה 11</span>
+          <span>עמוד 2</span>
+        </div>
+        <div>...<span class="highlight">ברוך</span> אתה ה' אלוהינו...</div>
+      </div>
+      <div class="result-card">
+        <strong>ENY 4.56</strong>
+        <div class="meta">
+          <span>ערבית יהודית</span>
+          <span>מאה 12</span>
+          <span>עמוד 7</span>
+        </div>
+        <div>...<span class="highlight">ברוך</span> אתה עליון...</div>
+      </div>
+      <div class="result-card">
+        <strong>BODL 1123</strong>
+        <div class="meta">
+          <span>Neubauer Part 5</span>
+          <span>מאה 11</span>
+          <span>עמוד 1</span>
+        </div>
+        <div>...נוסח תפילה <span class="highlight">ברוך</span>...</div>
+      </div>
+    </section>
+
+    <section class="panel viewer">
+      <h2>מסמך נבחר: TS 12.345</h2>
+      <div class="toolbar">
+        <button>ייצוא</button>
+        <button>שמור לרשימה</button>
+        <button>ציטוט</button>
+        <button>פריטים דומים</button>
+      </div>
+      <div class="image-box">IIIF Viewer</div>
+      <div class="section">
+        <h2>תמלול</h2>
+        <div>
+          ...<span class="highlight">ברוך</span> אתה ה' אלוהינו מלך העולם...
+        </div>
+      </div>
+      <div class="section">
+        <h2>מטא-דאטה</h2>
+        <div class="meta">
+          <span>Cambridge University Library</span>
+          <span>דף 2, recto</span>
+          <span>Catalog: Neubauer</span>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/web/mockups/task-driven-research.html
+++ b/web/mockups/task-driven-research.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Genizah Search Pro - מחקר ממוקד משימה</title>
+  <style>
+    :root {
+      --bg: #f8fafc;
+      --panel: #ffffff;
+      --accent: #2563eb;
+      --muted: #6b7280;
+      --border: #e2e8f0;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: "Noto Sans Hebrew", "Assistant", "Rubik", sans-serif;
+      background: var(--bg);
+      color: #0f172a;
+    }
+    header {
+      padding: 20px 28px;
+      background: #0f172a;
+      color: #fff;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .wizard {
+      max-width: 1100px;
+      margin: 20px auto;
+      background: var(--panel);
+      border-radius: 16px;
+      border: 1px solid var(--border);
+      padding: 24px;
+      display: grid;
+      gap: 20px;
+    }
+    .steps {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+    .step {
+      background: #e0e7ff;
+      color: #3730a3;
+      padding: 6px 12px;
+      border-radius: 999px;
+      font-size: 0.85rem;
+    }
+    .flow {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 16px;
+    }
+    .card {
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 16px;
+      background: #fff;
+      display: grid;
+      gap: 10px;
+    }
+    .card h3 { margin: 0; }
+    .button {
+      background: var(--accent);
+      color: #fff;
+      border: none;
+      padding: 10px 14px;
+      border-radius: 8px;
+      font-weight: 600;
+    }
+    .task-panel {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 20px;
+    }
+    .task-panel .panel {
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 16px;
+      background: #fff;
+    }
+    .progress {
+      height: 8px;
+      background: #e2e8f0;
+      border-radius: 999px;
+      overflow: hidden;
+    }
+    .progress span {
+      display: block;
+      height: 100%;
+      width: 45%;
+      background: var(--accent);
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <strong>Genizah Search Pro • מחקר ממוקד משימה</strong>
+    <span>שלב 2 מתוך 4</span>
+  </header>
+
+  <section class="wizard">
+    <div class="steps">
+      <span class="step">1. הגדרת יעד</span>
+      <span class="step">2. סינון</span>
+      <span class="step">3. בדיקת תוצאות</span>
+      <span class="step">4. ייצוא ושמירה</span>
+    </div>
+    <div class="progress"><span></span></div>
+
+    <div class="flow">
+      <div class="card">
+        <h3>מציאת מקבילות</h3>
+        <p>הפעל Lab Mode וסריקה עמוקה לטקסטים מקבילים.</p>
+        <button class="button">המשך למסלול</button>
+      </div>
+      <div class="card">
+        <h3>חיפוש טקסט קלאסי</h3>
+        <p>בחר מצב חיפוש (Exact / Variants) והתחל איסוף תוצאות.</p>
+        <button class="button">המשך למסלול</button>
+      </div>
+      <div class="card">
+        <h3>בניית קורפוס אישי</h3>
+        <p>שמור מסמכים לרשימות אישיות והוסף תגיות מחקר.</p>
+        <button class="button">המשך למסלול</button>
+      </div>
+    </div>
+
+    <div class="task-panel">
+      <div class="panel">
+        <h3>שלב 2: סינון</h3>
+        <label>תקופה</label>
+        <input placeholder="מאה 10-11" />
+        <label>שפה</label>
+        <input placeholder="עברית, ערבית־יהודית" />
+        <label>אוסף</label>
+        <input placeholder="Cambridge, NLI" />
+      </div>
+      <div class="panel">
+        <h3>תצוגה מהירה</h3>
+        <p>20 תוצאות עומדות בקריטריונים. ניתן לעבור לשלב הבא.</p>
+        <button class="button">הצג תוצאות</button>
+      </div>
+    </div>
+  </section>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide standalone visual examples to evaluate and discuss several UI redesign directions for the Genizah Search front end.

### Description
- Add four static, RTL Hebrew HTML mockups under `web/mockups`: `research-workbench.html`, `living-library.html`, `task-driven-research.html`, and `expert-dense-ui.html`.
- Each mockup is self-contained HTML/CSS (no JavaScript) and includes layout, controls, IIIF placeholders and example content to illustrate the proposed designs.

### Testing
- Served the `web/mockups` directory with `python -m http.server` and ran a Playwright script to open each mockup and capture screenshots, producing four PNG artifacts; the script completed successfully.
- No unit tests were required for these static examples and no additional automated test failures occurred.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69688a5b29a08321ae09e2ffe541af3e)