### PR TITLE
Fix genizah_app.py console window closing immediately

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -9,20 +9,53 @@ import json
 import csv
 from collections import defaultdict
 
-# PyQt6 imports first - needed for error display
-from PyQt6.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,
-                             QLabel, QLineEdit, QPushButton, QTabWidget, QTableWidget,
-                             QTableWidgetItem, QListWidgetItem, QHeaderView, QComboBox, QCheckBox,
-                             QTextEdit, QMessageBox, QProgressBar, QSplitter, QDialog,
-                             QTextBrowser, QFileDialog, QMenu, QGroupBox, QSpinBox, QDoubleSpinBox,
-                             QTreeWidget, QTreeWidgetItem, QListWidget, QPlainTextEdit, QStyle, QFormLayout,
-                             QGridLayout, QToolTip, QProgressDialog, QStackedLayout,
-                             QScrollArea, QFrame, QSlider, QStyleOptionButton, QSizePolicy, QInputDialog,
-                             QToolButton, QGraphicsView, QGraphicsScene, QGraphicsPixmapItem, QGraphicsSimpleTextItem,
-                             QCompleter, QAbstractItemView)
-from PyQt6.QtCore import (Qt, QTimer, QUrl, QSize, pyqtSignal, QThread, QEventLoop, QEvent, QRect, QRectF)
-from PyQt6.QtGui import (QFont, QIcon, QDesktopServices, QPixmap, QImage, QFontMetrics, QTextDocument, QTransform, QPainter, QColor,
-                         QStandardItemModel, QStandardItem, QPalette, QTextCursor, QTextCharFormat, QPen, QBrush, QPainterPath, QCursor)
+def _show_error_fallback(err, title="Error"):
+    """Show error using fallback methods when PyQt6 is not available."""
+    error_msg = f"{title}: {err}"
+    print("\n" + "="*60)
+    print(error_msg)
+    print("="*60)
+    # Try tkinter as fallback
+    try:
+        import tkinter as tk
+        from tkinter import messagebox
+        root = tk.Tk()
+        root.withdraw()
+        messagebox.showerror(title, f"{err}\n\nPlease install missing dependencies.")
+        root.destroy()
+    except:
+        # Last resort - just pause console so user can read the error
+        print("\nPress Enter to exit...")
+        try:
+            input()
+        except:
+            pass
+    sys.exit(1)
+
+# PyQt6 imports - needed for GUI
+_PYQT_ERROR = None
+try:
+    from PyQt6.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,
+                                 QLabel, QLineEdit, QPushButton, QTabWidget, QTableWidget,
+                                 QTableWidgetItem, QListWidgetItem, QHeaderView, QComboBox, QCheckBox,
+                                 QTextEdit, QMessageBox, QProgressBar, QSplitter, QDialog,
+                                 QTextBrowser, QFileDialog, QMenu, QGroupBox, QSpinBox, QDoubleSpinBox,
+                                 QTreeWidget, QTreeWidgetItem, QListWidget, QPlainTextEdit, QStyle, QFormLayout,
+                                 QGridLayout, QToolTip, QProgressDialog, QStackedLayout,
+                                 QScrollArea, QFrame, QSlider, QStyleOptionButton, QSizePolicy, QInputDialog,
+                                 QToolButton, QGraphicsView, QGraphicsScene, QGraphicsPixmapItem, QGraphicsSimpleTextItem,
+                                 QCompleter, QAbstractItemView)
+    from PyQt6.QtCore import (Qt, QTimer, QUrl, QSize, pyqtSignal, QThread, QEventLoop, QEvent, QRect, QRectF)
+    from PyQt6.QtGui import (QFont, QIcon, QDesktopServices, QPixmap, QImage, QFontMetrics, QTextDocument, QTransform, QPainter, QColor,
+                             QStandardItemModel, QStandardItem, QPalette, QTextCursor, QTextCharFormat, QPen, QBrush, QPainterPath, QCursor)
+except ImportError as e:
+    _PYQT_ERROR = e
+
+if _PYQT_ERROR:
+    if __name__ == "__main__":
+        _show_error_fallback(_PYQT_ERROR, "PyQt6 not installed")
+    else:
+        raise _PYQT_ERROR
 
 def _show_import_error_and_exit(err, title="Missing dependency"):
     """Show import error in a message box and exit."""

--- a/genizah_app.py
+++ b/genizah_app.py
@@ -6,20 +6,10 @@ import os
 import re
 import threading
 import json
-import requests
-import urllib3
 import csv
-import openpyxl
-from docx import Document
-from docx.enum.section import WD_ORIENTATION
-from docx.enum.text import WD_PARAGRAPH_ALIGNMENT
-from docx.oxml import OxmlElement
-from docx.oxml.ns import qn
-from docx.shared import RGBColor
-from openpyxl.styles import Alignment, Font, PatternFill
-from openpyxl.cell.rich_text import TextBlock, CellRichText
-from openpyxl.cell.text import InlineFont
+from collections import defaultdict
 
+# PyQt6 imports first - needed for error display
 from PyQt6.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,
                              QLabel, QLineEdit, QPushButton, QTabWidget, QTableWidget,
                              QTableWidgetItem, QListWidgetItem, QHeaderView, QComboBox, QCheckBox,
@@ -34,10 +24,39 @@ from PyQt6.QtCore import (Qt, QTimer, QUrl, QSize, pyqtSignal, QThread, QEventLo
 from PyQt6.QtGui import (QFont, QIcon, QDesktopServices, QPixmap, QImage, QFontMetrics, QTextDocument, QTransform, QPainter, QColor,
                          QStandardItemModel, QStandardItem, QPalette, QTextCursor, QTextCharFormat, QPen, QBrush, QPainterPath, QCursor)
 
+def _show_import_error_and_exit(err, title="Missing dependency"):
+    """Show import error in a message box and exit."""
+    app = QApplication.instance() or QApplication(sys.argv)
+    QMessageBox.critical(None, title, str(err))
+    sys.exit(1)
+
+# Third-party imports with error handling
+_IMPORT_ERROR = None
+try:
+    import requests
+    import urllib3
+    import openpyxl
+    from docx import Document
+    from docx.enum.section import WD_ORIENTATION
+    from docx.enum.text import WD_PARAGRAPH_ALIGNMENT
+    from docx.oxml import OxmlElement
+    from docx.oxml.ns import qn
+    from docx.shared import RGBColor
+    from openpyxl.styles import Alignment, Font, PatternFill
+    from openpyxl.cell.rich_text import TextBlock, CellRichText
+    from openpyxl.cell.text import InlineFont
+except ImportError as import_error:
+    _IMPORT_ERROR = import_error
+
+if _IMPORT_ERROR:
+    if __name__ == "__main__":
+        _show_import_error_and_exit(_IMPORT_ERROR)
+    else:
+        raise _IMPORT_ERROR
+
 from version import APP_VERSION
 
-from collections import defaultdict
-
+# Core module imports with error handling
 _CORE_IMPORT_ERROR = None
 try:
     from genizah_core import Config, MetadataManager, VariantManager, SearchEngine, LabEngine, Indexer, AIManager, ListsManager, tr, save_language, CURRENT_LANG, get_logger, natural_sort_key, load_app_config, save_app_config
@@ -45,15 +64,11 @@ except ImportError as import_error:
     _CORE_IMPORT_ERROR = import_error
 
 if _CORE_IMPORT_ERROR:
-    def _show_core_import_error(err):
-        app = QApplication.instance() or QApplication(sys.argv)
-        QMessageBox.critical(None, "Missing dependency", str(err))
-
     if __name__ == "__main__":
-        _show_core_import_error(_CORE_IMPORT_ERROR)
-        sys.exit(1)
+        _show_import_error_and_exit(_CORE_IMPORT_ERROR)
     else:
         raise _CORE_IMPORT_ERROR
+
 from gui_threads import SearchThread, LabSearchThread, IndexerThread, ShelfmarkLoaderThread, CompositionThread, LabCompositionThread, GroupingThread, AIWorkerThread, StartupThread, EnrichMetadataThread, ExternalResourceThread, UpdateCheckerThread
 from filter_text_dialog import FilterTextDialog
 from column_filter_dialog import ColumnFilterDialog

--- a/genizah_app.py
+++ b/genizah_app.py
@@ -27,7 +27,12 @@ from PyQt6.QtGui import (QFont, QIcon, QDesktopServices, QPixmap, QImage, QFontM
 def _show_import_error_and_exit(err, title="Missing dependency"):
     """Show import error in a message box and exit."""
     app = QApplication.instance() or QApplication(sys.argv)
-    QMessageBox.critical(None, title, str(err))
+    msg = QMessageBox()
+    msg.setIcon(QMessageBox.Icon.Critical)
+    msg.setWindowTitle(title)
+    msg.setText(f"Failed to start application:\n\n{err}\n\nPlease install missing dependencies.")
+    msg.setStandardButtons(QMessageBox.StandardButton.Ok)
+    msg.exec()
     sys.exit(1)
 
 # Third-party imports with error handling
@@ -69,10 +74,21 @@ if _CORE_IMPORT_ERROR:
     else:
         raise _CORE_IMPORT_ERROR
 
-from gui_threads import SearchThread, LabSearchThread, IndexerThread, ShelfmarkLoaderThread, CompositionThread, LabCompositionThread, GroupingThread, AIWorkerThread, StartupThread, EnrichMetadataThread, ExternalResourceThread, UpdateCheckerThread
-from filter_text_dialog import FilterTextDialog
-from column_filter_dialog import ColumnFilterDialog
-from list_filter_dialog import ListFilterDialog
+# Local module imports with error handling
+_LOCAL_IMPORT_ERROR = None
+try:
+    from gui_threads import SearchThread, LabSearchThread, IndexerThread, ShelfmarkLoaderThread, CompositionThread, LabCompositionThread, GroupingThread, AIWorkerThread, StartupThread, EnrichMetadataThread, ExternalResourceThread, UpdateCheckerThread
+    from filter_text_dialog import FilterTextDialog
+    from column_filter_dialog import ColumnFilterDialog
+    from list_filter_dialog import ListFilterDialog
+except ImportError as import_error:
+    _LOCAL_IMPORT_ERROR = import_error
+
+if _LOCAL_IMPORT_ERROR:
+    if __name__ == "__main__":
+        _show_import_error_and_exit(_LOCAL_IMPORT_ERROR)
+    else:
+        raise _LOCAL_IMPORT_ERROR
 
 logger = get_logger(__name__)
 


### PR DESCRIPTION
…t crash

PyQt6 imports are now loaded first so that when third-party imports (openpyxl, docx, etc.) fail, the app can display a readable error message instead of just crashing silently.