### PR TITLE
Fix version comparison for different length version strings

### DIFF
--- a/gui_threads.py
+++ b/gui_threads.py
@@ -341,6 +341,11 @@ class UpdateCheckerThread(QThread):
                 curr_v = [int(x) for x in self.current_version.replace('v','').split('.') if x.isdigit()]
                 remote_v = [int(x) for x in tag.replace('v','').split('.') if x.isdigit()]
 
+                # Normalize version lists to same length (pad with zeros)
+                max_len = max(len(curr_v), len(remote_v))
+                curr_v.extend([0] * (max_len - len(curr_v)))
+                remote_v.extend([0] * (max_len - len(remote_v)))
+
                 if remote_v > curr_v:
                     self.finished_signal.emit(True, tag, html_url, self.is_manual)
                 else:


### PR DESCRIPTION
## Summary
Fixed a bug in the version comparison logic where version strings with different numbers of components (e.g., "1.0" vs "1.0.0") were not being compared correctly.

## Changes
- Added normalization of version lists to ensure both current and remote version arrays have the same length before comparison
- Pad shorter version lists with zeros to match the length of the longer list
- This ensures semantic version comparison works correctly regardless of how many version components are present

## Details
The previous implementation would compare version tuples of different lengths, which could lead to incorrect comparison results. For example, comparing `[1, 0]` with `[1, 0, 0]` would fail to recognize them as equivalent versions. By padding both lists to the same length with zeros, the comparison now correctly handles versions with varying component counts (e.g., "v1.0" vs "v1.0.0").