### PR TITLE
Add "Remember Me" login feature for desktop and web apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Genizah Search Pro will be documented in this file.
 
 ---
 
+## [5.4.1] - 2026-02-03
+
+### Enhancement: "Remember Me" Login Feature (Desktop)
+
+The desktop application now supports saving login credentials securely, so users don't need to re-enter their email and password after each software update.
+
+- **"Remember me" checkbox**: New checkbox in the login dialog to opt-in to credential saving
+- **Secure storage**: Password stored in Windows Credential Manager (via `keyring` library) - not in plain text files
+- **Persistent across updates**: Credentials survive software updates since they're stored in user profile, not application folder
+- **Easy to disable**: Uncheck "Remember me" to clear saved credentials
+
+---
+
 ## [5.4.0] - 2026-02-03
 
 ### New Feature: Library/Holding Institution Display

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,20 @@ All notable changes to Genizah Search Pro will be documented in this file.
 
 ## [5.4.1] - 2026-02-03
 
-### Enhancement: "Remember Me" Login Feature (Desktop)
+### Enhancement: "Remember Me" Login Feature
 
-The desktop application now supports saving login credentials securely, so users don't need to re-enter their email and password after each software update.
+Both the desktop and web applications now support saving login credentials.
 
+#### Desktop Application
 - **"Remember me" checkbox**: New checkbox in the login dialog to opt-in to credential saving
 - **Secure storage**: Password stored in Windows Credential Manager (via `keyring` library) - not in plain text files
 - **Persistent across updates**: Credentials survive software updates since they're stored in user profile, not application folder
 - **Easy to disable**: Uncheck "Remember me" to clear saved credentials
+
+#### Web Application
+- **"Remember me" checkbox**: New checkbox in the login dialog
+- **Email remembered**: Email address saved in browser localStorage for convenience
+- **Session persistence**: Login session already persists via Supabase cookies
 
 ---
 

--- a/corrections_ui.py
+++ b/corrections_ui.py
@@ -52,8 +52,22 @@ class LoginDialog(QDialog):
         super().__init__(parent)
         self.client = client or get_corrections_client()
         self.setWindowTitle(tr("Login to Corrections System"))
-        self.resize(400, 250)
+        self.resize(400, 280)
         self.init_ui()
+        self._load_saved_credentials()
+
+    def _load_saved_credentials(self):
+        """Load saved credentials and pre-fill the form."""
+        try:
+            if hasattr(self.client, 'get_saved_login_credentials'):
+                email, password = self.client.get_saved_login_credentials()
+                if email:
+                    self.email_input.setText(email)
+                    self.remember_checkbox.setChecked(True)
+                    if password:
+                        self.password_input.setText(password)
+        except Exception as e:
+            logger.debug(f"Could not load saved credentials: {e}")
 
     def init_ui(self):
         layout = QVBoxLayout(self)
@@ -77,6 +91,11 @@ class LoginDialog(QDialog):
         form.addWidget(self.password_input, 1, 1)
 
         layout.addLayout(form)
+
+        # Remember me checkbox
+        self.remember_checkbox = QCheckBox(tr("Remember me"))
+        self.remember_checkbox.setToolTip(tr("Save login credentials for next time"))
+        layout.addWidget(self.remember_checkbox)
 
         # Forgot password link
         forgot_link = QLabel(f'<a href="#">{tr("Forgot password?")}</a>')
@@ -123,6 +142,14 @@ class LoginDialog(QDialog):
         success, message = self.client.login(email, password)
 
         if success:
+            # Save or clear credentials based on "Remember me" checkbox
+            if hasattr(self.client, 'save_login_credentials'):
+                if self.remember_checkbox.isChecked():
+                    self.client.save_login_credentials(email, password)
+                else:
+                    # Clear saved credentials if user unchecked "Remember me"
+                    if hasattr(self.client, 'clear_saved_login_credentials'):
+                        self.client.clear_saved_login_credentials()
             self.login_success.emit(self.client.current_user)
             self.accept()
         else:

--- a/genizah_translations.py
+++ b/genizah_translations.py
@@ -1036,6 +1036,8 @@ TRANSLATIONS = {
     "Please enter email and password": "אנא הזן אימייל וסיסמה",
     "Logging in...": "מתחבר...",
     "Login Failed": "ההתחברות נכשלה",
+    "Remember me": "זכור אותי",
+    "Save login credentials for next time": "שמור את פרטי ההתחברות לפעם הבאה",
     "Forgot password?": "שכחת סיסמה?",
     "Forgot Password": "שכחתי סיסמה",
     "Enter your email address:": "הזן את כתובת האימייל שלך:",

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ nicegui
 supabase
 gotrue
 python-dotenv
+keyring

--- a/supabase_corrections_client.py
+++ b/supabase_corrections_client.py
@@ -29,6 +29,13 @@ except ImportError:
     Client = None
     AuthApiError = Exception
 
+try:
+    import keyring
+    KEYRING_AVAILABLE = True
+except ImportError:
+    keyring = None
+    KEYRING_AVAILABLE = False
+
 logger = logging.getLogger(__name__)
 
 
@@ -351,6 +358,104 @@ class SupabaseCorrectionsClient:
 
         except Exception as e:
             logger.warning(f"Failed to save credentials: {e}")
+
+    # =========================================================================
+    # LOGIN CREDENTIALS STORAGE (for "Remember Me" feature)
+    # =========================================================================
+    # Service name for keyring - used to identify the application
+    KEYRING_SERVICE = "GenizahSearch"
+    KEYRING_EMAIL_KEY = "saved_email"
+
+    def save_login_credentials(self, email: str, password: str) -> bool:
+        """
+        Save login credentials securely using keyring.
+        Email is saved to credentials file, password to system keyring.
+        Returns True if successful, False otherwise.
+        """
+        try:
+            # Save email to credentials file
+            if self.credentials_file.exists():
+                with open(self.credentials_file, 'r') as f:
+                    data = json.load(f)
+            else:
+                data = {}
+
+            data['saved_email'] = email
+            data['remember_me'] = True
+
+            with open(self.credentials_file, 'w') as f:
+                json.dump(data, f)
+
+            # Save password to system keyring (secure storage)
+            if KEYRING_AVAILABLE:
+                keyring.set_password(self.KEYRING_SERVICE, email, password)
+                logger.info(f"Login credentials saved for {email}")
+                return True
+            else:
+                logger.warning("keyring not available, password not saved")
+                return False
+
+        except Exception as e:
+            logger.warning(f"Failed to save login credentials: {e}")
+            return False
+
+    def get_saved_login_credentials(self) -> Tuple[Optional[str], Optional[str]]:
+        """
+        Get saved login credentials.
+        Returns (email, password) tuple, or (None, None) if not saved.
+        """
+        try:
+            if not self.credentials_file.exists():
+                return None, None
+
+            with open(self.credentials_file, 'r') as f:
+                data = json.load(f)
+
+            email = data.get('saved_email')
+            remember_me = data.get('remember_me', False)
+
+            if not email or not remember_me:
+                return None, None
+
+            # Get password from system keyring
+            password = None
+            if KEYRING_AVAILABLE:
+                try:
+                    password = keyring.get_password(self.KEYRING_SERVICE, email)
+                except Exception as e:
+                    logger.debug(f"Could not retrieve password from keyring: {e}")
+
+            return email, password
+
+        except Exception as e:
+            logger.warning(f"Failed to get saved credentials: {e}")
+            return None, None
+
+    def clear_saved_login_credentials(self):
+        """Clear saved login credentials."""
+        try:
+            # Remove from credentials file
+            if self.credentials_file.exists():
+                with open(self.credentials_file, 'r') as f:
+                    data = json.load(f)
+
+                email = data.pop('saved_email', None)
+                data.pop('remember_me', None)
+
+                with open(self.credentials_file, 'w') as f:
+                    json.dump(data, f)
+
+                # Remove from keyring
+                if KEYRING_AVAILABLE and email:
+                    try:
+                        keyring.delete_password(self.KEYRING_SERVICE, email)
+                    except Exception:
+                        pass  # Password may not exist in keyring
+
+            logger.info("Saved login credentials cleared")
+
+        except Exception as e:
+            logger.warning(f"Failed to clear saved credentials: {e}")
 
     def _load_cache(self):
         """Load cached community data from disk."""

--- a/version.py
+++ b/version.py
@@ -1,3 +1,3 @@
 """Centralized version definition for the Genizah Search Pro application."""
 
-APP_VERSION = "5.4.0"
+APP_VERSION = "5.4.1"

--- a/web/auth_state.py
+++ b/web/auth_state.py
@@ -200,6 +200,10 @@ def create_login_dialog():
     """
     from web.translations import tr
 
+    # Keys for browser storage (localStorage)
+    REMEMBER_EMAIL_KEY = 'genizah_remember_email'
+    REMEMBER_CHECKED_KEY = 'genizah_remember_checked'
+
     dialog = ui.dialog()  # Removed 'persistent' to allow Esc to close
 
     with dialog, ui.card().classes('w-96 p-6').style('background: var(--bg-card); color: var(--text-primary);'):
@@ -213,7 +217,25 @@ def create_login_dialog():
                 with ui.column().classes('w-full gap-4'):
                     login_email = ui.input(tr('Email')).classes('w-full').props('outlined')
                     login_password = ui.input(tr('Password'), password=True).classes('w-full').props('outlined')
+
+                    # Remember me checkbox
+                    remember_me = ui.checkbox(tr('Remember me')).classes('w-full')
+
                     login_error = ui.label('').classes('text-red-500 text-sm hidden')
+
+                    # Load saved email from browser storage
+                    def load_saved_email():
+                        try:
+                            saved_email = app.storage.browser.get(REMEMBER_EMAIL_KEY, '')
+                            was_checked = app.storage.browser.get(REMEMBER_CHECKED_KEY, False)
+                            if saved_email and was_checked:
+                                login_email.value = saved_email
+                                remember_me.value = True
+                        except Exception:
+                            pass  # Browser storage may not be available
+
+                    # Load saved email when dialog opens
+                    dialog.on('show', load_saved_email)
 
                     async def handle_login():
                         login_error.classes('hidden', remove='visible')
@@ -227,6 +249,16 @@ def create_login_dialog():
                             login_error.text = result["error"]
                             login_error.classes('visible', remove='hidden')
                         else:
+                            # Save or clear email based on "Remember me" checkbox
+                            try:
+                                if remember_me.value:
+                                    app.storage.browser[REMEMBER_EMAIL_KEY] = login_email.value
+                                    app.storage.browser[REMEMBER_CHECKED_KEY] = True
+                                else:
+                                    app.storage.browser.pop(REMEMBER_EMAIL_KEY, None)
+                                    app.storage.browser.pop(REMEMBER_CHECKED_KEY, None)
+                            except Exception:
+                                pass  # Browser storage may not be available
                             dialog.close()
                             ui.navigate.reload()
 


### PR DESCRIPTION
## Summary
Implements a "Remember Me" feature for both the desktop and web applications, allowing users to save their login credentials for convenience while maintaining security best practices.

## Key Changes

### Desktop Application (corrections_ui.py & supabase_corrections_client.py)
- Added "Remember me" checkbox to the login dialog
- Implemented secure credential storage using the `keyring` library (Windows Credential Manager integration)
- Email saved to local credentials file; password stored in system keyring (not plain text)
- Credentials persist across software updates since they're stored in user profile
- Added methods to save, retrieve, and clear saved credentials
- Pre-fills login form with saved email and password on dialog open

### Web Application (web/auth_state.py)
- Added "Remember me" checkbox to the login dialog
- Email address saved to browser localStorage for convenience
- Session persistence already handled via Supabase cookies
- Loads saved email when login dialog opens

### Supporting Changes
- Updated version to 5.4.1
- Added `keyring` to requirements.txt for secure password storage
- Added Hebrew translations for new UI strings
- Updated CHANGELOG.md with feature documentation
- Increased login dialog height to accommodate new checkbox

## Implementation Details
- **Security**: Desktop app uses system keyring for password storage, not plain text files
- **Graceful degradation**: Web app works without localStorage; desktop app logs warnings if keyring unavailable
- **User control**: Users can uncheck "Remember me" to clear saved credentials
- **Error handling**: Wrapped credential operations in try-catch blocks with appropriate logging

https://claude.ai/code/session_015byDYKzqf7SeJBBnxun587