### PR TITLE
Fix citation footer RTL layout by reordering elements

### DIFF
--- a/web/main.py
+++ b/web/main.py
@@ -1524,10 +1524,10 @@ def create_layout():
         with ui.row().classes('w-full items-center justify-center gap-2 py-2 px-4 flex-wrap'):
             # Copy button
             ui.button(icon='content_copy', on_click=lambda: ui.run_javascript(f'navigator.clipboard.writeText("{full_citation}"); alert("{tr("Citation copied!")}")')).props('flat dense size=xs').classes('opacity-70 hover:opacity-100').tooltip(tr('Copy citation'))
+            # Hebrew label (hidden on mobile) - comes before citation for correct RTL order
+            ui.label(tr('When publishing material from this site, please cite:')).classes('text-xs opacity-80 citation-hebrew-label')
             # Citation link (English, LTR)
             ui.link(full_citation, 'https://doi.org/10.5281/zenodo.17734473', new_tab=True).classes('text-xs font-medium citation-link').style('direction: ltr; text-decoration: none;')
-            # Hebrew label (hidden on mobile)
-            ui.label(tr('When publishing material from this site, please cite:')).classes('text-xs opacity-80 citation-hebrew-label')
             # Close button
             ui.button(icon='close', on_click=lambda: ui.run_javascript('localStorage.setItem("citation_footer_dismissed", "true"); document.querySelector(".citation-footer").style.display = "none";')).props('flat dense size=xs').classes('opacity-50 hover:opacity-100').tooltip(tr('Dismiss'))
 


### PR DESCRIPTION
## Summary
Reordered the citation footer elements to ensure correct right-to-left (RTL) text display for Hebrew and other RTL languages.

## Changes
- Moved the Hebrew label element before the citation link in the DOM
- This ensures proper visual ordering when RTL text direction is applied, as the label now appears to the right of the citation link (correct for RTL layouts)
- Updated the comment to clarify the purpose of the reordering

## Implementation Details
The citation footer contains multiple elements (copy button, label, citation link, close button) arranged in a flexbox row. For RTL languages like Hebrew, the visual order depends on both the DOM order and CSS `direction` property. By placing the label before the citation link in the DOM, the layout now correctly displays with the label on the right side of the citation when RTL styling is applied.

https://claude.ai/code/session_01LCo9HheT6NR9QtMff1kGyM