### PR TITLE
Include author profile data in corrections query

### DIFF
--- a/web/supabase_client.py
+++ b/web/supabase_client.py
@@ -615,10 +615,11 @@ def delete_project(project_id: int) -> Dict:
 # ============================================================================
 
 def get_corrections(sys_id: str = None, author_id: str = None, status: str = None) -> List[Dict]:
-    """Get corrections with optional filters."""
+    """Get corrections with optional filters, including author profile data."""
     try:
         client = get_client()
-        query = client.table('corrections').select('*')
+        # Join with profiles table to get author name
+        query = client.table('corrections').select('*, profiles:author_id(id, full_name, username)')
 
         if sys_id:
             query = query.eq('sys_id', sys_id)


### PR DESCRIPTION
## Summary
Enhanced the `get_corrections()` function to include author profile information (name and username) by joining with the profiles table, improving data completeness for correction records.

## Changes
- Updated the corrections query to perform a join with the profiles table on `author_id`
- Now retrieves author's `full_name` and `username` alongside correction data
- Updated docstring to reflect the inclusion of author profile data

## Implementation Details
- Uses Supabase's relational select syntax: `profiles:author_id(id, full_name, username)`
- This allows callers to access author information without requiring a separate query
- Maintains backward compatibility by including all existing correction fields via `*`

https://claude.ai/code/session_014qGH9JNcGyomhTF3FeauZ1