### PR TITLE
SEED-018 (non-core): export-utils move + candidate_grid glyph de-dup

### DIFF
--- a/GenizahSearchPro.spec
+++ b/GenizahSearchPro.spec
@@ -6,7 +6,7 @@ from PyInstaller.utils.hooks import collect_all
 # (@pytest.mark.packaging — release CI only).  Removed from production datas;
 # the packaging smoke test is responsible for adding the fixture to its own
 # on-the-fly build when needed.
-datas = [('icon.ico', '.'), ('Help.html', '.'), ('oxford_full_db.json', '.'), ('libraries.csv', '.'), ('ie_volume_map.json', '.'), ('bodleian_master_index.csv', '.'), ('pgp_tag_translations.py', '.'), ('shared_export_utils.py', '.'), ('shared', 'shared'), ('libraries_translations.db', '.'), ('fist_data\\fjms_enrichment.db', 'fist_data'), ('fist_data\\visual_similarity.db', 'fist_data'), ('fist_data\\vs_manifest.txt', 'fist_data'), ('nli_data\\nli_crossref.db', 'nli_data'), ('pgp_data\\pgp.db', 'pgp_data'), ('fgp_data\\fgp_transcriptions.db', 'fgp_data')]
+datas = [('icon.ico', '.'), ('Help.html', '.'), ('oxford_full_db.json', '.'), ('libraries.csv', '.'), ('ie_volume_map.json', '.'), ('bodleian_master_index.csv', '.'), ('pgp_tag_translations.py', '.'), ('shared_export_utils.py', '.'), ('shared\\export_utils.py', 'shared'), ('shared', 'shared'), ('libraries_translations.db', '.'), ('fist_data\\fjms_enrichment.db', 'fist_data'), ('fist_data\\visual_similarity.db', 'fist_data'), ('fist_data\\vs_manifest.txt', 'fist_data'), ('nli_data\\nli_crossref.db', 'nli_data'), ('pgp_data\\pgp.db', 'pgp_data'), ('fgp_data\\fgp_transcriptions.db', 'fgp_data')]
 binaries = []
 hiddenimports = ['tantivy', 'numpy', 'PIL', 'fitz', 'pymupdf', 'openpyxl', 'defusedxml']
 tmp_ret = collect_all('tantivy')

--- a/build_app.bat
+++ b/build_app.bat
@@ -25,6 +25,7 @@ python -m PyInstaller --noconfirm --noconsole --onedir --clean ^
  --add-data "bodleian_master_index.csv;." ^
  --add-data "pgp_tag_translations.py;." ^
  --add-data "shared_export_utils.py;." ^
+ --add-data "shared\export_utils.py;shared" ^
  --add-data "shared;shared" ^
  --add-data "libraries_translations.db;." ^
  --add-data "fist_data\fjms_enrichment.db;fist_data" ^

--- a/shared/export_utils.py
+++ b/shared/export_utils.py
@@ -1,0 +1,422 @@
+# -*- coding: utf-8 -*-
+"""
+Shared Export Utilities for GenizahSearch.
+
+This module provides unified text processing and export utilities used by both
+the Desktop application (genizah_app.py) and the Web application (export_service.py).
+
+This consolidates previously duplicated code to ensure consistent behavior across platforms.
+"""
+
+import re
+from typing import Optional
+
+
+# ============================================================================
+# Text Sanitization for Excel
+# ============================================================================
+
+def sanitize_text_for_excel(text: Optional[str], max_length: int = 32700) -> str:
+    """
+    Sanitize text for safe use in Excel cells.
+
+    Uses a whitelist approach to keep only characters valid in XML 1.0,
+    handles formula injection prevention, and respects Excel cell limits.
+
+    This unified function combines the best practices from both Desktop and Web:
+    - Whitelist approach for XML safety (from Web)
+    - Formula injection prevention (from Desktop)
+    - Cell length limit (from Desktop)
+
+    Args:
+        text: The text to sanitize
+        max_length: Maximum cell length (Excel limit is ~32767)
+
+    Returns:
+        Sanitized text safe for Excel cells
+    """
+    if not text:
+        return ""
+
+    t = str(text)
+
+    # Whitelist approach: Keep only printable characters valid in XML 1.0
+    # Ranges: tab (\t), U+0020-U+007E (printable ASCII, excluding DEL 0x7F),
+    # U+0080-U+D7FF (extended chars including Hebrew), U+E000-U+FFFD
+    t = "".join(
+        ch for ch in t
+        if ch == "\t" or (0x20 <= ord(ch) <= 0x7E) or (0x80 <= ord(ch) <= 0xD7FF) or (0xE000 <= ord(ch) <= 0xFFFD)
+    )
+
+    # Handle malicious formulas that could execute when opened in Excel
+    # Prefix with single quote to prevent formula interpretation
+    t = t.strip()
+    if t.startswith(('=', '+', '-', '@')):
+        t = "'" + t
+
+    # Excel cell character limit (~32767, use 32700 for safety margin)
+    if len(t) > max_length:
+        t = t[:max_length] + "..."
+
+    return t
+
+
+def coerce_img_page_cell(value):
+    """Return ``value`` as ``int`` when it's a pure integer string; else as a
+    sanitized string.
+
+    The Image/Page column on the main search-results sheet usually holds a
+    page number (``'5'``, ``'42'``) but can also hold non-numeric folio
+    markers (``'5r'``, ``'12-14'``, ``'fol. 3v'``). Smoke verification
+    round 6 (2026-05-21): writing ``str('5')`` triggers Excel's green
+    "Number stored as text" warning. Return an ``int`` so Excel recognizes
+    it as numeric; non-numeric values fall through to the sanitized string
+    path unchanged.
+
+    Returns:
+        int when the trimmed value is a pure decimal integer (including a
+        leading minus sign);
+        sanitized string otherwise (empty string for empty / None input).
+    """
+    if value is None:
+        return ''
+    if isinstance(value, bool):
+        # bool is an int subclass — keep as-is to avoid silently coercing
+        # ``True``/``False`` into ``1``/``0``.
+        return sanitize_text_for_excel(str(value))
+    if isinstance(value, int):
+        return value
+    s = str(value).strip()
+    if not s:
+        return ''
+    if s.isdigit() or (s.startswith('-') and len(s) > 1 and s[1:].isdigit()):
+        try:
+            return int(s)
+        except (TypeError, ValueError):
+            pass
+    return sanitize_text_for_excel(s)
+
+
+def clean_text_single_line(text: Optional[str]) -> str:
+    """
+    Replace line breaks with spaces and normalize whitespace.
+    Useful for Excel cells where we want continuous text.
+
+    Args:
+        text: The text to clean
+
+    Returns:
+        Text with newlines replaced by spaces and collapsed whitespace
+    """
+    if not text:
+        return ""
+    text = text.replace('\r\n', ' ').replace('\n', ' ').replace('\r', ' ')
+    # Collapse multiple spaces
+    while '  ' in text:
+        text = text.replace('  ', ' ')
+    return text.strip()
+
+
+def remove_highlight_markers(text: Optional[str]) -> str:
+    """
+    Remove * markers used for highlighting in snippets.
+
+    Args:
+        text: Text possibly containing * highlight markers
+
+    Returns:
+        Text with markers removed
+    """
+    if not text:
+        return ""
+    return text.replace('*', '')
+
+
+# ============================================================================
+# Expanded context for DOCX / TXT exports (Phase 105 EXPUX-04)
+# ============================================================================
+
+# DOCX/TXT show fuller matched-passage context than the ±60-char on-screen
+# snippet, capped so a multi-thousand-word PDF page cannot bloat the document.
+EXPORT_CONTEXT_CAP = 2000
+
+# XML 1.0 forbids the C0 control chars except tab (\x09) / LF (\x0a) / CR (\x0d).
+# lxml/python-docx (and openpyxl) raise "All strings must be XML compatible …"
+# when these reach a cell/run. Full PDF / Tantivy page text routinely carries
+# NULs and form-feeds (\x0c page breaks), which the old ±60-char snippet avoided.
+_XML_ILLEGAL_RE = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
+
+
+def strip_xml_illegal_chars(text: Optional[str]) -> str:
+    """Replace XML-illegal C0 control chars with a space (keeps tab/LF/CR).
+
+    Used before handing export text to python-docx/lxml so a NUL or form-feed
+    in extracted page text cannot abort the whole export. Replacing with a
+    space (not '') avoids fusing the words that flanked the control char.
+    """
+    if text is None:
+        return ""
+    return _XML_ILLEGAL_RE.sub(' ', str(text))
+
+
+def _matched_terms_from_hl(raw_file_hl: Optional[str]) -> list:
+    """Return the highlighted (matched) substrings from a ``*``-marked snippet.
+
+    Odd-indexed parts of a ``*``-split are the highlighted spans. Returns them
+    deduped, stripped, non-empty, longest-first (so a single alternation regex
+    marks maximal spans before their substrings).
+    """
+    if not raw_file_hl:
+        return []
+    parts = str(raw_file_hl).split('*')
+    terms = [parts[i].strip() for i in range(1, len(parts), 2) if parts[i].strip()]
+    seen = set()
+    uniq = []
+    for t in terms:
+        if t not in seen:
+            seen.add(t)
+            uniq.append(t)
+    uniq.sort(key=len, reverse=True)
+    return uniq
+
+
+def build_expanded_context(full_text: Optional[str],
+                           raw_file_hl: Optional[str],
+                           cap: int = EXPORT_CONTEXT_CAP) -> str:
+    """Phase 105 EXPUX-04: a wider, highlighted context window for DOCX/TXT.
+
+    Recovers the matched term(s) from ``raw_file_hl`` (text between ``*``
+    markers), locates the first occurrence in ``full_text``, builds a window of
+    ``<= cap`` chars centred on it, and re-inserts ``*`` markers around every
+    in-window occurrence of the matched term(s). Truncation is flagged with
+    leading/trailing ellipses.
+
+    Fallback (NO regression): if ``full_text`` is empty, or no matched term can
+    be located inside it (e.g. normalization mismatch), the original
+    ``raw_file_hl`` snippet is returned unchanged.
+    """
+    ft = str(full_text or "")
+    hl = str(raw_file_hl or "")
+    if not ft.strip():
+        return hl
+    terms = _matched_terms_from_hl(hl)
+    if not terms:
+        return hl
+
+    first_pos = None
+    for t in terms:
+        idx = ft.find(t)
+        if idx != -1 and (first_pos is None or idx < first_pos):
+            first_pos = idx
+    if first_pos is None:
+        return hl  # matched term not present in full_text -> safe fallback
+
+    if cap and cap > 0 and len(ft) > cap:
+        half = cap // 2
+        start = max(0, first_pos - half)
+        end = min(len(ft), start + cap)
+        start = max(0, end - cap)  # re-extend left if we clipped the right edge
+        window = ft[start:end]
+    else:
+        start = 0
+        end = len(ft)
+        window = ft
+
+    # Strip XML-illegal control chars from the page text (full_text often has
+    # NULs / form-feeds the ±60 snippet avoided) so DOCX/TXT export can't abort,
+    # then drop stray source ``*`` so they aren't mistaken for highlight markers.
+    window = strip_xml_illegal_chars(window).replace('*', ' ')
+    pattern = re.compile("|".join(re.escape(t) for t in terms))
+    marked = pattern.sub(lambda m: f"*{m.group(0)}*", window)
+
+    prefix = "… " if start > 0 else ""
+    suffix = " …" if end < len(ft) else ""
+    return prefix + marked + suffix
+
+
+# ============================================================================
+# Rich-text snippet rendering (Phase 94 D-14)
+# ============================================================================
+
+def build_rich_snippet_cell(text, sanitize_fn=None):
+    """Render snippet text with ``*``-bracketed highlights as openpyxl rich text.
+
+    Phase 94 D-14: extracted from desktop's ``write_rich_cell`` inner helper at
+    ``genizah_app.py:18000`` so web's main-sheet Snippet column can adopt the
+    same red+bold highlight rendering. Both apps consume this helper
+    identically; the sanitize callback lets desktop pass its
+    ``self._sanitize_for_excel`` and web pass the module-level
+    ``sanitize_text_for_excel``.
+
+    Args:
+        text: snippet text containing ``*foo*`` markers for highlighted runs.
+        sanitize_fn: optional callable applied BEFORE splitting on ``*``.
+            Typically :func:`sanitize_text_for_excel` from this module. Pass
+            ``None`` to skip sanitization (caller has already sanitized).
+
+    Returns:
+        - ``str`` (the sanitized text) when no ``*`` markers present.
+        - :class:`openpyxl.cell.rich_text.CellRichText` when markers present:
+          odd-indexed parts (between markers) become red+bold; even-indexed
+          parts (outside markers) become normal black.
+        - Empty string ``''`` when text is empty / None.
+
+    Sub-sheets (Manuscripts, Bibliography) should NOT use this helper —
+    Phase 94 D-14 limits rich-text to the main-sheet Snippet column only.
+
+    Sanitize-first ordering (T-94-01 mitigation): the sanitize callback
+    runs BEFORE the ``*``-split so that formula-injection prefix
+    (``"'="`` for ``'='``-leading text) is preserved into the first split
+    part rather than getting interleaved with highlight markers.
+    """
+    if not text:
+        return ''
+    safe_text = sanitize_fn(text) if sanitize_fn else str(text)
+    if '*' not in safe_text:
+        return safe_text
+
+    # Late import: openpyxl rich-text is a hot dependency we don't want to
+    # pay on import for callers that never render snippets.
+    from openpyxl.cell.rich_text import CellRichText, TextBlock
+    from openpyxl.cell.text import InlineFont
+
+    font_red = InlineFont(color='FF0000', b=True)
+    font_normal = InlineFont(color='000000', b=False)
+
+    parts = safe_text.split('*')
+    rich = CellRichText()
+    for i, part in enumerate(parts):
+        if not part:
+            continue
+        # Odd indices = highlighted (between markers); even indices = plain.
+        if i % 2 == 1:
+            rich.append(TextBlock(font_red, part))
+        else:
+            rich.append(TextBlock(font_normal, part))
+    return rich
+
+
+# ============================================================================
+# Filename Sanitization
+# ============================================================================
+
+def make_safe_filename(
+    text: str,
+    default: str = "genizah",
+    max_length: int = 50,
+    preserve_hebrew: bool = True
+) -> str:
+    """
+    Create a filesystem-safe filename from text.
+
+    This unified function works for both cache filenames and export filenames.
+
+    Args:
+        text: The text to convert to a filename
+        default: Default name if text is empty or invalid
+        max_length: Maximum filename length (excluding extension)
+        preserve_hebrew: If True, keep Hebrew characters; if False, use ASCII-only
+
+    Returns:
+        A safe filename string
+    """
+    if not text:
+        return default
+
+    if preserve_hebrew:
+        # Keep Hebrew, alphanumeric, underscore, hyphen, space
+        # Pattern: \w includes [a-zA-Z0-9_], plus Hebrew range U+0590-U+05FF
+        safe = re.sub(r"[^\w\u0590-\u05FF\s-]", "", text)
+        # Replace spaces with underscores
+        safe = re.sub(r"\s+", "_", safe).strip("_")
+    else:
+        # Strict ASCII-only mode (for cache filenames, prevents path traversal)
+        safe = re.sub(r'[^a-zA-Z0-9_\-]', '_', text)
+
+    # Truncate to max length
+    safe = safe[:max_length]
+
+    return safe.strip("_") or default
+
+
+def sanitize_cache_filename(ref: str) -> str:
+    """
+    Sanitize a reference string to create a safe cache filename.
+
+    Uses a strict whitelist approach: only alphanumeric characters, underscores,
+    and hyphens are allowed. This prevents path traversal attacks.
+
+    Args:
+        ref: Reference string to sanitize
+
+    Returns:
+        Safe filename string for caching
+    """
+    return make_safe_filename(ref, default="cache", preserve_hebrew=False)
+
+
+# ============================================================================
+# Content-Disposition Header Encoding
+# ============================================================================
+
+def encode_filename_for_header(filename: str) -> str:
+    """
+    Encode filename for HTTP Content-Disposition header.
+    Uses RFC 5987 encoding for non-ASCII characters (e.g., Hebrew).
+
+    Args:
+        filename: The filename to encode
+
+    Returns:
+        Properly formatted Content-Disposition header value
+    """
+    from urllib.parse import quote
+
+    try:
+        filename.encode('ascii')
+        # Pure ASCII - simple format
+        return f'attachment; filename="{filename}"'
+    except UnicodeEncodeError:
+        # Contains non-ASCII - use RFC 5987 format
+        encoded = quote(filename, safe='')
+        return f"attachment; filename*=UTF-8''{encoded}"
+
+
+# ============================================================================
+# Search Term Utilities
+# ============================================================================
+
+def extract_search_terms(query: str) -> list:
+    """
+    Extract meaningful search terms from a query string.
+    Filters out special operators used in advanced search syntax.
+
+    Args:
+        query: The search query string
+
+    Returns:
+        List of search terms without operators
+    """
+    if not query:
+        return []
+    return [
+        t.strip() for t in query.split()
+        if t.strip() and not t.startswith(('=', '?', '~', '/', '$', '#'))
+    ]
+
+
+def contains_any_term(text: str, terms: list) -> bool:
+    """
+    Check if text contains any of the given search terms (case-insensitive).
+
+    Args:
+        text: Text to search in
+        terms: List of terms to look for
+
+    Returns:
+        True if any term is found in text
+    """
+    if not text or not terms:
+        return False
+    text_lower = text.lower()
+    return any(term.lower() in text_lower for term in terms)

--- a/shared_export_utils.py
+++ b/shared_export_utils.py
@@ -1,422 +1,50 @@
 # -*- coding: utf-8 -*-
 """
-Shared Export Utilities for GenizahSearch.
+Compatibility shim for the relocated Shared Export Utilities.
 
-This module provides unified text processing and export utilities used by both
-the Desktop application (genizah_app.py) and the Web application (export_service.py).
+SEED-018 (#44/M5): the implementation moved to ``shared/export_utils.py`` so the
+module lives under the ``shared/`` package alongside its siblings. This root-level
+module is retained as a thin re-export shim so the ~12 existing call sites that do
+``import shared_export_utils`` or ``from shared_export_utils import X`` keep working
+unchanged. Zero behavior change — every public name is re-exported from
+``shared.export_utils``.
 
-This consolidates previously duplicated code to ensure consistent behavior across platforms.
+New code should import from ``shared.export_utils`` directly.
 """
 
-import re
-from typing import Optional
-
-
-# ============================================================================
-# Text Sanitization for Excel
-# ============================================================================
-
-def sanitize_text_for_excel(text: Optional[str], max_length: int = 32700) -> str:
-    """
-    Sanitize text for safe use in Excel cells.
-
-    Uses a whitelist approach to keep only characters valid in XML 1.0,
-    handles formula injection prevention, and respects Excel cell limits.
-
-    This unified function combines the best practices from both Desktop and Web:
-    - Whitelist approach for XML safety (from Web)
-    - Formula injection prevention (from Desktop)
-    - Cell length limit (from Desktop)
-
-    Args:
-        text: The text to sanitize
-        max_length: Maximum cell length (Excel limit is ~32767)
-
-    Returns:
-        Sanitized text safe for Excel cells
-    """
-    if not text:
-        return ""
-
-    t = str(text)
-
-    # Whitelist approach: Keep only printable characters valid in XML 1.0
-    # Ranges: tab (\t), U+0020-U+007E (printable ASCII, excluding DEL 0x7F),
-    # U+0080-U+D7FF (extended chars including Hebrew), U+E000-U+FFFD
-    t = "".join(
-        ch for ch in t
-        if ch == "\t" or (0x20 <= ord(ch) <= 0x7E) or (0x80 <= ord(ch) <= 0xD7FF) or (0xE000 <= ord(ch) <= 0xFFFD)
-    )
-
-    # Handle malicious formulas that could execute when opened in Excel
-    # Prefix with single quote to prevent formula interpretation
-    t = t.strip()
-    if t.startswith(('=', '+', '-', '@')):
-        t = "'" + t
-
-    # Excel cell character limit (~32767, use 32700 for safety margin)
-    if len(t) > max_length:
-        t = t[:max_length] + "..."
-
-    return t
-
-
-def coerce_img_page_cell(value):
-    """Return ``value`` as ``int`` when it's a pure integer string; else as a
-    sanitized string.
-
-    The Image/Page column on the main search-results sheet usually holds a
-    page number (``'5'``, ``'42'``) but can also hold non-numeric folio
-    markers (``'5r'``, ``'12-14'``, ``'fol. 3v'``). Smoke verification
-    round 6 (2026-05-21): writing ``str('5')`` triggers Excel's green
-    "Number stored as text" warning. Return an ``int`` so Excel recognizes
-    it as numeric; non-numeric values fall through to the sanitized string
-    path unchanged.
-
-    Returns:
-        int when the trimmed value is a pure decimal integer (including a
-        leading minus sign);
-        sanitized string otherwise (empty string for empty / None input).
-    """
-    if value is None:
-        return ''
-    if isinstance(value, bool):
-        # bool is an int subclass — keep as-is to avoid silently coercing
-        # ``True``/``False`` into ``1``/``0``.
-        return sanitize_text_for_excel(str(value))
-    if isinstance(value, int):
-        return value
-    s = str(value).strip()
-    if not s:
-        return ''
-    if s.isdigit() or (s.startswith('-') and len(s) > 1 and s[1:].isdigit()):
-        try:
-            return int(s)
-        except (TypeError, ValueError):
-            pass
-    return sanitize_text_for_excel(s)
-
-
-def clean_text_single_line(text: Optional[str]) -> str:
-    """
-    Replace line breaks with spaces and normalize whitespace.
-    Useful for Excel cells where we want continuous text.
-
-    Args:
-        text: The text to clean
-
-    Returns:
-        Text with newlines replaced by spaces and collapsed whitespace
-    """
-    if not text:
-        return ""
-    text = text.replace('\r\n', ' ').replace('\n', ' ').replace('\r', ' ')
-    # Collapse multiple spaces
-    while '  ' in text:
-        text = text.replace('  ', ' ')
-    return text.strip()
-
-
-def remove_highlight_markers(text: Optional[str]) -> str:
-    """
-    Remove * markers used for highlighting in snippets.
-
-    Args:
-        text: Text possibly containing * highlight markers
-
-    Returns:
-        Text with markers removed
-    """
-    if not text:
-        return ""
-    return text.replace('*', '')
-
-
-# ============================================================================
-# Expanded context for DOCX / TXT exports (Phase 105 EXPUX-04)
-# ============================================================================
-
-# DOCX/TXT show fuller matched-passage context than the ±60-char on-screen
-# snippet, capped so a multi-thousand-word PDF page cannot bloat the document.
-EXPORT_CONTEXT_CAP = 2000
-
-# XML 1.0 forbids the C0 control chars except tab (\x09) / LF (\x0a) / CR (\x0d).
-# lxml/python-docx (and openpyxl) raise "All strings must be XML compatible …"
-# when these reach a cell/run. Full PDF / Tantivy page text routinely carries
-# NULs and form-feeds (\x0c page breaks), which the old ±60-char snippet avoided.
-_XML_ILLEGAL_RE = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
-
-
-def strip_xml_illegal_chars(text: Optional[str]) -> str:
-    """Replace XML-illegal C0 control chars with a space (keeps tab/LF/CR).
-
-    Used before handing export text to python-docx/lxml so a NUL or form-feed
-    in extracted page text cannot abort the whole export. Replacing with a
-    space (not '') avoids fusing the words that flanked the control char.
-    """
-    if text is None:
-        return ""
-    return _XML_ILLEGAL_RE.sub(' ', str(text))
-
-
-def _matched_terms_from_hl(raw_file_hl: Optional[str]) -> list:
-    """Return the highlighted (matched) substrings from a ``*``-marked snippet.
-
-    Odd-indexed parts of a ``*``-split are the highlighted spans. Returns them
-    deduped, stripped, non-empty, longest-first (so a single alternation regex
-    marks maximal spans before their substrings).
-    """
-    if not raw_file_hl:
-        return []
-    parts = str(raw_file_hl).split('*')
-    terms = [parts[i].strip() for i in range(1, len(parts), 2) if parts[i].strip()]
-    seen = set()
-    uniq = []
-    for t in terms:
-        if t not in seen:
-            seen.add(t)
-            uniq.append(t)
-    uniq.sort(key=len, reverse=True)
-    return uniq
-
-
-def build_expanded_context(full_text: Optional[str],
-                           raw_file_hl: Optional[str],
-                           cap: int = EXPORT_CONTEXT_CAP) -> str:
-    """Phase 105 EXPUX-04: a wider, highlighted context window for DOCX/TXT.
-
-    Recovers the matched term(s) from ``raw_file_hl`` (text between ``*``
-    markers), locates the first occurrence in ``full_text``, builds a window of
-    ``<= cap`` chars centred on it, and re-inserts ``*`` markers around every
-    in-window occurrence of the matched term(s). Truncation is flagged with
-    leading/trailing ellipses.
-
-    Fallback (NO regression): if ``full_text`` is empty, or no matched term can
-    be located inside it (e.g. normalization mismatch), the original
-    ``raw_file_hl`` snippet is returned unchanged.
-    """
-    ft = str(full_text or "")
-    hl = str(raw_file_hl or "")
-    if not ft.strip():
-        return hl
-    terms = _matched_terms_from_hl(hl)
-    if not terms:
-        return hl
-
-    first_pos = None
-    for t in terms:
-        idx = ft.find(t)
-        if idx != -1 and (first_pos is None or idx < first_pos):
-            first_pos = idx
-    if first_pos is None:
-        return hl  # matched term not present in full_text -> safe fallback
-
-    if cap and cap > 0 and len(ft) > cap:
-        half = cap // 2
-        start = max(0, first_pos - half)
-        end = min(len(ft), start + cap)
-        start = max(0, end - cap)  # re-extend left if we clipped the right edge
-        window = ft[start:end]
-    else:
-        start = 0
-        end = len(ft)
-        window = ft
-
-    # Strip XML-illegal control chars from the page text (full_text often has
-    # NULs / form-feeds the ±60 snippet avoided) so DOCX/TXT export can't abort,
-    # then drop stray source ``*`` so they aren't mistaken for highlight markers.
-    window = strip_xml_illegal_chars(window).replace('*', ' ')
-    pattern = re.compile("|".join(re.escape(t) for t in terms))
-    marked = pattern.sub(lambda m: f"*{m.group(0)}*", window)
-
-    prefix = "… " if start > 0 else ""
-    suffix = " …" if end < len(ft) else ""
-    return prefix + marked + suffix
-
-
-# ============================================================================
-# Rich-text snippet rendering (Phase 94 D-14)
-# ============================================================================
-
-def build_rich_snippet_cell(text, sanitize_fn=None):
-    """Render snippet text with ``*``-bracketed highlights as openpyxl rich text.
-
-    Phase 94 D-14: extracted from desktop's ``write_rich_cell`` inner helper at
-    ``genizah_app.py:18000`` so web's main-sheet Snippet column can adopt the
-    same red+bold highlight rendering. Both apps consume this helper
-    identically; the sanitize callback lets desktop pass its
-    ``self._sanitize_for_excel`` and web pass the module-level
-    ``sanitize_text_for_excel``.
-
-    Args:
-        text: snippet text containing ``*foo*`` markers for highlighted runs.
-        sanitize_fn: optional callable applied BEFORE splitting on ``*``.
-            Typically :func:`sanitize_text_for_excel` from this module. Pass
-            ``None`` to skip sanitization (caller has already sanitized).
-
-    Returns:
-        - ``str`` (the sanitized text) when no ``*`` markers present.
-        - :class:`openpyxl.cell.rich_text.CellRichText` when markers present:
-          odd-indexed parts (between markers) become red+bold; even-indexed
-          parts (outside markers) become normal black.
-        - Empty string ``''`` when text is empty / None.
-
-    Sub-sheets (Manuscripts, Bibliography) should NOT use this helper —
-    Phase 94 D-14 limits rich-text to the main-sheet Snippet column only.
-
-    Sanitize-first ordering (T-94-01 mitigation): the sanitize callback
-    runs BEFORE the ``*``-split so that formula-injection prefix
-    (``"'="`` for ``'='``-leading text) is preserved into the first split
-    part rather than getting interleaved with highlight markers.
-    """
-    if not text:
-        return ''
-    safe_text = sanitize_fn(text) if sanitize_fn else str(text)
-    if '*' not in safe_text:
-        return safe_text
-
-    # Late import: openpyxl rich-text is a hot dependency we don't want to
-    # pay on import for callers that never render snippets.
-    from openpyxl.cell.rich_text import CellRichText, TextBlock
-    from openpyxl.cell.text import InlineFont
-
-    font_red = InlineFont(color='FF0000', b=True)
-    font_normal = InlineFont(color='000000', b=False)
-
-    parts = safe_text.split('*')
-    rich = CellRichText()
-    for i, part in enumerate(parts):
-        if not part:
-            continue
-        # Odd indices = highlighted (between markers); even indices = plain.
-        if i % 2 == 1:
-            rich.append(TextBlock(font_red, part))
-        else:
-            rich.append(TextBlock(font_normal, part))
-    return rich
-
-
-# ============================================================================
-# Filename Sanitization
-# ============================================================================
-
-def make_safe_filename(
-    text: str,
-    default: str = "genizah",
-    max_length: int = 50,
-    preserve_hebrew: bool = True
-) -> str:
-    """
-    Create a filesystem-safe filename from text.
-
-    This unified function works for both cache filenames and export filenames.
-
-    Args:
-        text: The text to convert to a filename
-        default: Default name if text is empty or invalid
-        max_length: Maximum filename length (excluding extension)
-        preserve_hebrew: If True, keep Hebrew characters; if False, use ASCII-only
-
-    Returns:
-        A safe filename string
-    """
-    if not text:
-        return default
-
-    if preserve_hebrew:
-        # Keep Hebrew, alphanumeric, underscore, hyphen, space
-        # Pattern: \w includes [a-zA-Z0-9_], plus Hebrew range U+0590-U+05FF
-        safe = re.sub(r"[^\w\u0590-\u05FF\s-]", "", text)
-        # Replace spaces with underscores
-        safe = re.sub(r"\s+", "_", safe).strip("_")
-    else:
-        # Strict ASCII-only mode (for cache filenames, prevents path traversal)
-        safe = re.sub(r'[^a-zA-Z0-9_\-]', '_', text)
-
-    # Truncate to max length
-    safe = safe[:max_length]
-
-    return safe.strip("_") or default
-
-
-def sanitize_cache_filename(ref: str) -> str:
-    """
-    Sanitize a reference string to create a safe cache filename.
-
-    Uses a strict whitelist approach: only alphanumeric characters, underscores,
-    and hyphens are allowed. This prevents path traversal attacks.
-
-    Args:
-        ref: Reference string to sanitize
-
-    Returns:
-        Safe filename string for caching
-    """
-    return make_safe_filename(ref, default="cache", preserve_hebrew=False)
-
-
-# ============================================================================
-# Content-Disposition Header Encoding
-# ============================================================================
-
-def encode_filename_for_header(filename: str) -> str:
-    """
-    Encode filename for HTTP Content-Disposition header.
-    Uses RFC 5987 encoding for non-ASCII characters (e.g., Hebrew).
-
-    Args:
-        filename: The filename to encode
-
-    Returns:
-        Properly formatted Content-Disposition header value
-    """
-    from urllib.parse import quote
-
-    try:
-        filename.encode('ascii')
-        # Pure ASCII - simple format
-        return f'attachment; filename="{filename}"'
-    except UnicodeEncodeError:
-        # Contains non-ASCII - use RFC 5987 format
-        encoded = quote(filename, safe='')
-        return f"attachment; filename*=UTF-8''{encoded}"
-
-
-# ============================================================================
-# Search Term Utilities
-# ============================================================================
-
-def extract_search_terms(query: str) -> list:
-    """
-    Extract meaningful search terms from a query string.
-    Filters out special operators used in advanced search syntax.
-
-    Args:
-        query: The search query string
-
-    Returns:
-        List of search terms without operators
-    """
-    if not query:
-        return []
-    return [
-        t.strip() for t in query.split()
-        if t.strip() and not t.startswith(('=', '?', '~', '/', '$', '#'))
-    ]
-
-
-def contains_any_term(text: str, terms: list) -> bool:
-    """
-    Check if text contains any of the given search terms (case-insensitive).
-
-    Args:
-        text: Text to search in
-        terms: List of terms to look for
-
-    Returns:
-        True if any term is found in text
-    """
-    if not text or not terms:
-        return False
-    text_lower = text.lower()
-    return any(term.lower() in text_lower for term in terms)
+from shared.export_utils import *  # noqa: F401,F403  (re-export public surface)
+
+# Explicit re-export so ``from shared_export_utils import X`` resolves the same
+# symbols as ``shared.export_utils`` even for names a star-import might skip, and
+# so static tooling / introspection sees the public surface on this shim too.
+from shared.export_utils import (  # noqa: F401
+    EXPORT_CONTEXT_CAP,
+    build_expanded_context,
+    build_rich_snippet_cell,
+    clean_text_single_line,
+    coerce_img_page_cell,
+    contains_any_term,
+    encode_filename_for_header,
+    extract_search_terms,
+    make_safe_filename,
+    remove_highlight_markers,
+    sanitize_cache_filename,
+    sanitize_text_for_excel,
+    strip_xml_illegal_chars,
+)
+
+__all__ = [
+    "EXPORT_CONTEXT_CAP",
+    "build_expanded_context",
+    "build_rich_snippet_cell",
+    "clean_text_single_line",
+    "coerce_img_page_cell",
+    "contains_any_term",
+    "encode_filename_for_header",
+    "extract_search_terms",
+    "make_safe_filename",
+    "remove_highlight_markers",
+    "sanitize_cache_filename",
+    "sanitize_text_for_excel",
+    "strip_xml_illegal_chars",
+]

--- a/tests/test_export_utils_shim.py
+++ b/tests/test_export_utils_shim.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+"""SEED-018 (#44/M5): verify the root ``shared_export_utils`` compatibility shim
+re-exports the same public surface as the relocated ``shared.export_utils``.
+
+The implementation moved under ``shared/`` and the root module became a thin
+re-export shim so existing ``import shared_export_utils`` / ``from
+shared_export_utils import X`` call sites keep working unchanged. These tests pin
+that contract: same symbols, same objects, zero behavior change.
+"""
+
+import importlib
+
+import pytest
+
+# The public names every caller relies on (the documented surface).
+_EXPECTED_PUBLIC = [
+    "build_rich_snippet_cell",
+    "sanitize_text_for_excel",
+    "remove_highlight_markers",
+    "sanitize_cache_filename",
+    "coerce_img_page_cell",
+    "build_expanded_context",
+    "clean_text_single_line",
+    "strip_xml_illegal_chars",
+    "make_safe_filename",
+    "encode_filename_for_header",
+    "extract_search_terms",
+    "contains_any_term",
+    "EXPORT_CONTEXT_CAP",
+]
+
+
+@pytest.fixture(scope="module")
+def mods():
+    shim = importlib.import_module("shared_export_utils")
+    impl = importlib.import_module("shared.export_utils")
+    return shim, impl
+
+
+def test_expected_public_names_present_in_impl(mods):
+    _, impl = mods
+    missing = [name for name in _EXPECTED_PUBLIC if not hasattr(impl, name)]
+    assert not missing, f"shared.export_utils missing expected public names: {missing}"
+
+
+def test_shim_re_exports_all_expected_names(mods):
+    shim, _ = mods
+    missing = [name for name in _EXPECTED_PUBLIC if not hasattr(shim, name)]
+    assert not missing, f"shim missing re-exported names: {missing}"
+
+
+def test_shim_and_impl_expose_same_objects(mods):
+    """Every expected public name must resolve to the SAME object in both modules
+    (the shim re-exports, it does not redefine)."""
+    shim, impl = mods
+    for name in _EXPECTED_PUBLIC:
+        assert getattr(shim, name) is getattr(impl, name), (
+            f"{name!r} differs between shim and shared.export_utils"
+        )
+
+
+def test_shim_public_surface_matches_impl(mods):
+    """The shim's non-underscore public attribute set must match the impl's
+    (modulo import machinery), so no public symbol silently drops on relocation."""
+    shim, impl = mods
+
+    def public_callables_and_consts(m):
+        names = set()
+        for name in dir(m):
+            if name.startswith("_"):
+                continue
+            obj = getattr(m, name)
+            # Skip re-imported modules (e.g. ``re``) — only compare the module's
+            # own functions/constants.
+            if getattr(obj, "__module__", None) in ("shared.export_utils", None) or not callable(obj):
+                names.add(name)
+        return names
+
+    impl_public = public_callables_and_consts(impl)
+    shim_public = public_callables_and_consts(shim)
+    # Every public symbol exported by the impl must be reachable on the shim.
+    missing = impl_public - shim_public
+    # Allow imported helpers (like ``re``, ``Optional``) to differ; only require
+    # the documented surface to be fully present.
+    expected = set(_EXPECTED_PUBLIC)
+    assert expected.issubset(shim_public), f"shim missing: {expected - shim_public}"
+    assert expected.issubset(impl_public), f"impl missing: {expected - impl_public}"
+
+
+def test_shim_behavior_matches_impl(mods):
+    """Smoke a couple of functions through both entry points to confirm identical
+    behavior (they are the same object, but this guards against future drift)."""
+    shim, impl = mods
+    assert shim.remove_highlight_markers("a*b*c") == impl.remove_highlight_markers("a*b*c") == "abc"
+    assert shim.sanitize_cache_filename("../etc/passwd") == impl.sanitize_cache_filename("../etc/passwd")
+    assert shim.coerce_img_page_cell("5") == impl.coerce_img_page_cell("5") == 5

--- a/web/components/candidate_grid.py
+++ b/web/components/candidate_grid.py
@@ -52,6 +52,12 @@ from web.translations import tr, get_language, is_rtl
 _TITLE_TRUNCATE_AT = 80
 """Characters at which to truncate candidate titles before appending '...'."""
 
+# SEED-018 (#33): derive the table triage glyphs from the single source of truth
+# in shared.joins_lab.TRIAGE_ICONS instead of a hardcoded {"yes": "✓", ...} dict,
+# matching the _TRIAGE_COLORS derivation below. Keeps card icons and table glyphs
+# in sync with the shared join-triage vocabulary.
+_TRIAGE_GLYPHS = {k: v["glyph"] for k, v in TRIAGE_ICONS.items()}
+
 _MAX_RENDERED_CANDIDATES = 200
 """Defensive cap — kept as a safety net but no longer the PRIMARY render bound.
 
@@ -360,7 +366,7 @@ def _make_table_rows(
             dims = "—"
         material = m.get("material") or "—"
         verdict = _get_verdict(c.sys_id)
-        triage_glyph = {"yes": "✓", "maybe": "?", "no": "✗"}.get(verdict, "")
+        triage_glyph = _TRIAGE_GLYPHS.get(verdict, "")
         snippet = getattr(c, "snippet", None) or ""
         if len(snippet) > 80:
             snippet = snippet[:80] + "..."


### PR DESCRIPTION
SEED-018 NON-CORE slice (code cleanup). Mechanical refactors, **zero behavior change**.

## #44/M5 — move `shared_export_utils.py` under `shared/` with a root shim
- Full implementation moved to `shared/export_utils.py`.
- Root `shared_export_utils.py` is now a thin re-export shim (`from shared.export_utils import *` + explicit re-export of the public names + `__all__`), so existing `import shared_export_utils` / `from shared_export_utils import X` call sites (~12) keep working unchanged — no caller edits.
- `build_app.bat` and `GenizahSearchPro.spec` add an explicit `shared/export_utils.py` data entry (the `shared/` dir was already bundled wholesale; the root shim entry is retained too).
- New `tests/test_export_utils_shim.py` asserts the shim and `shared.export_utils` expose the SAME objects across the documented public surface.

**Public symbols re-exported by the shim:** `build_rich_snippet_cell`, `sanitize_text_for_excel`, `remove_highlight_markers`, `sanitize_cache_filename`, `coerce_img_page_cell`, `build_expanded_context`, `clean_text_single_line`, `strip_xml_illegal_chars`, `make_safe_filename`, `encode_filename_for_header`, `extract_search_terms`, `contains_any_term`, `EXPORT_CONTEXT_CAP`.

## #33 (web part only) — de-dup triage glyph map in `web/components/candidate_grid.py`
- The hardcoded `{"yes": "✓", "maybe": "?", "no": "✗"}` table glyph map now derives from the shared `shared.joins_lab.TRIAGE_ICONS` source of truth (`_TRIAGE_GLYPHS = {k: v["glyph"] ...}`), mirroring the existing `_TRIAGE_COLORS` derivation. Glyphs are byte-identical, so no behavior change.
- Desktop `_TRIAGE_GLYPH` and the correction-status dicts in `genizah_app.py` are **untouched** (core slice, different concept).

## Tests / lint
- `tests/test_export_utils_shim.py`: 5 passed.
- candidate_grid suite (`test_candidate_grid/surface/triage/filters/pagination`): 87 passed, 18 xpassed.
- export-utils caller tests (`test_expux_expanded_context`, `test_shared_rich_snippet`, `test_local_export_csv_txt_docx`, `test_local_export_xlsx`, `test_smoke_round2_export_gaps`): 126 passed, 1 skipped.
- `test_join_workbench_vs.py::test_triage_glyphs_are_check_and_cross` (desktop, unaffected): passed.
- `ruff check` on all changed files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GnvGb31t729NCZbnUQXS6