### PR TITLE
SEED-016: shared/→web layering + bounded browse executor

### DIFF
--- a/shared/browse_service.py
+++ b/shared/browse_service.py
@@ -86,14 +86,26 @@ logger = logging.getLogger(__name__)
 DEFAULT_BROWSE_TIMEOUT = 1.0       # D-17, R-01: lowered 2.0 -> 1.0
 DEFAULT_BROWSE_CORE_TIMEOUT = 2.0  # D-17 NEW per R-01
 
+def _read_int_env(env_var: str, default: int, *, minimum: int = 1) -> int:
+    """Read an int env var at import; fall back to `default` on missing/malformed.
+
+    Never raises on a garbage value (e.g. SEARCH_API_BROWSE_EXECUTOR_WORKERS=abc)
+    -- a bad env var must not crash module import."""
+    raw = os.environ.get(env_var)
+    if not raw:
+        return max(minimum, default)
+    try:
+        return max(minimum, int(raw))
+    except (ValueError, TypeError):
+        return max(minimum, default)
+
+
 # SEED-016 #29: bounded named executor sizing. Read once at module import for the
 # pool (a ThreadPoolExecutor cannot be resized live); the per-request source
 # concurrency cap is derived from the same default. Keep workers modest -- one
 # browse request fans out to at most core(1) + 3 enrichment sources, and the
 # concurrency cap (below) is what actually shields the pool.
-BROWSE_EXECUTOR_MAX_WORKERS = max(
-    1, int(os.environ.get('SEARCH_API_BROWSE_EXECUTOR_WORKERS', '8') or '8'),
-)
+BROWSE_EXECUTOR_MAX_WORKERS = _read_int_env('SEARCH_API_BROWSE_EXECUTOR_WORKERS', 8)
 # Max sync fetches dispatched concurrently across ALL in-flight browse requests.
 # Bounds blast radius so a single request's fan-out (or a stampede) cannot
 # consume the whole pool. Defaults below the pool size so headroom always exists.
@@ -206,6 +218,19 @@ async def _run_sync(func, *args):
     """
     loop = asyncio.get_event_loop()
     return await loop.run_in_executor(_get_browse_executor(), func, *args)
+
+
+def _submit_sync(func, *args):
+    """Submit blocking sync work to the named bounded pool; return the underlying
+    concurrent.futures.Future.
+
+    SEED-016 #29 fix: callers can hang a done-callback on the returned future so
+    a resource (e.g. the source-concurrency semaphore slot) is released only when
+    the EXECUTOR THREAD actually finishes -- not merely when an asyncio.wait_for
+    on the awaiting coroutine times out. asyncio.wait_for cancels the await; it
+    cannot stop a thread already running in the pool.
+    """
+    return _get_browse_executor().submit(func, *args)
 
 
 # ---------------------------------------------------------------------------
@@ -384,19 +409,63 @@ async def _wrap_with_timeout(
 
     SEED-016 #29: the dispatch is gated by the module-level source-concurrency
     semaphore so a single browse request's fan-out cannot consume the whole
-    named pool. The semaphore slot is held for the work's TRUE lifetime
-    (released in finally), so a hung source keeps its slot until the underlying
-    sync call actually returns -- it cannot re-admit more work past the cap.
+    named pool.
+
+    SEED-016 #29 FIX (Codex REQUEST-CHANGES): the semaphore slot is held until the
+    underlying EXECUTOR FUTURE actually completes -- NOT merely until the awaiting
+    coroutine's asyncio.wait_for times out. `wait_for` only cancels the await; it
+    cannot stop a thread already running in the pool. Releasing the slot on
+    timeout would free a concurrency slot while the worker thread is still busy,
+    re-admitting work past the cap and defeating the saturation guard. So we:
+      - acquire the slot,
+      - submit the blocking work and get its concurrent.futures.Future,
+      - release the slot from the FUTURE's done-callback (fires exactly once when
+        the thread truly finishes; scheduled back onto the loop because
+        asyncio.Semaphore is not thread-safe),
+      - keep asyncio.wait_for as the CALLER-facing timeout (the coroutine still
+        returns promptly on timeout; the slot just stays occupied until the real
+        work returns).
 
     R-PR-05: this is the SOLE place that catches inner sync-helper failures.
     `_pgp_sync` / `_fjms_sync` / `_nli_sync` no longer have inner try/except
     blocks -- they let exceptions propagate so this wrapper can emit
     'enrichment_failed' warnings (instead of silently nulling out the source).
     """
+    loop = asyncio.get_event_loop()
     sem = _get_browse_semaphore()
     await sem.acquire()
+
+    # Release the slot from the executor future's completion path so it is held
+    # for the work's TRUE lifetime, even if the caller-facing wait_for below
+    # times out and cancels the await. add_done_callback fires exactly once.
+    released = False
+
+    def _release_once() -> None:
+        nonlocal released
+        if not released:
+            released = True
+            sem.release()
+
+    def _on_future_done(_f) -> None:
+        # Runs on the worker thread once the blocking call truly finishes.
+        # asyncio.Semaphore is not thread-safe, so hop back to the loop. If the
+        # loop is already closed (e.g. a timed-out source's thread finishing
+        # after the request's loop tore down -- only happens in short-lived test
+        # loops; production runs a single long-lived loop), there is nothing left
+        # to release into, so swallow the closed-loop error.
+        try:
+            loop.call_soon_threadsafe(_release_once)
+        except RuntimeError:
+            pass
+
+    future = _submit_sync(sync_func, *args)
+    future.add_done_callback(_on_future_done)
+
     try:
-        return await asyncio.wait_for(_run_sync(sync_func, *args), timeout=timeout)
+        # wrap_future binds the concurrent future to this loop; cancelling the
+        # await on timeout does NOT cancel the running thread (so the slot stays
+        # held until the thread finishes and the done-callback releases it).
+        return await asyncio.wait_for(asyncio.wrap_future(future), timeout=timeout)
     except asyncio.TimeoutError:
         warnings_list.append({'code': 'enrichment_timeout', 'source': source_name})
         return None
@@ -404,8 +473,6 @@ async def _wrap_with_timeout(
         logger.exception('enrichment source %s failed', source_name)
         warnings_list.append({'code': 'enrichment_failed', 'source': source_name})
         return None
-    finally:
-        sem.release()
 
 
 # ---------------------------------------------------------------------------

--- a/shared/browse_service.py
+++ b/shared/browse_service.py
@@ -5,11 +5,21 @@ Mirrors web/pages/browse_enrichment.py:load_enrichment but returns data
 instead of mutating per-page UI state. Importable from shared/ -- does NOT import
 nicegui or any UI module.
 
+Layering contract (SEED-016 #3):
+- This module lives in shared/ and MUST NOT import from web/ at runtime. The
+  core-fetch path used to do `from web.services import get_service` inline,
+  which inverted the layering (shared -> web). The dependency is now INVERTED:
+  the caller (web/search_api.py) constructs the browse-page provider and passes
+  it INTO fetch_browse_bundle via the `service` parameter. shared/ stays
+  framework- and web-agnostic.
+- The only `web.*` symbol referenced here is the `BrowsePage` return type, kept
+  under `TYPE_CHECKING` so it never runs at import or call time.
+
 Statelessness contract (D-22):
-- Reads via web.services.get_service() (process-singleton WebDataService)
-  and `state.meta_mgr` indirectly through the service wrapper.
-- MUST NOT touch any per-session/refinement state (last results, current
-  query, browser storage, request cookies, or any UI-coupled state object).
+- The injected provider is the process-singleton WebDataService (a structural
+  BrowsePageProvider). MUST NOT touch any per-session/refinement state (last
+  results, current query, browser storage, request cookies, or any UI-coupled
+  state object).
 
 Per-source policy (D-15, D-16, R-01):
 - Core fetch is mandatory; timeout -> APIError('core_timeout', http_status=504).
@@ -20,12 +30,12 @@ Per-source policy (D-15, D-16, R-01):
 - Per-source exception -> null slot + 'enrichment_failed' warning; logged via
   logger.exception. Response stays 200.
 
-R-PR-02 (cross-AI review 2026-04-29): _fetch_core uses WebDataService
-(web/services.py) so the returned BrowsePage is fully hydrated with
-shelfmark/title/library_code/library_name/fl_id/volume_ie/volumes -- fields
-Plan 01's serialize_browse_payload reads via attribute access. Earlier draft
-called the raw core resolver directly, which returns a minimal dict from
-genizah_core.py:8246 missing all metadata; that path was a guaranteed
+R-PR-02 (cross-AI review 2026-04-29): _fetch_core uses the injected
+BrowsePageProvider (WebDataService in production) so the returned BrowsePage is
+fully hydrated with shelfmark/title/library_code/library_name/fl_id/volume_ie/
+volumes -- fields Plan 01's serialize_browse_payload reads via attribute access.
+Earlier draft called the raw core resolver directly, which returns a minimal
+dict from genizah_core.py:8246 missing all metadata; that path was a guaranteed
 500-on-success bug.
 
 R-PR-05 (cross-AI review 2026-04-29): per-source helpers (_pgp_sync,
@@ -35,19 +45,34 @@ exceptions. _wrap_with_timeout owns ALL warning emission -- both timeout
 real service errors as silent nulls, breaking D-16's partial-failure
 visibility contract.
 
-Operational note (R-09): asyncio.wait_for() cancels the awaiting coroutine but
-NOT the underlying executor thread doing sync sidecar I/O. If a sidecar SQLite
-read genuinely hangs, the default ThreadPoolExecutor (max_workers ~ 32) can
-saturate. Phase 80/81 should consider exposing executor pool depth on
-/internal/health for monitoring.
+Bounded executor (SEED-016 #29): the enrichment + core fan-out runs sync sidecar
+I/O on a MODULE-LEVEL NAMED ThreadPoolExecutor (`_BROWSE_EXECUTOR`), not the
+event loop's default executor. asyncio.wait_for() cancels the awaiting coroutine
+but NOT the underlying executor thread doing sync sidecar I/O, so a genuinely
+hung sidecar still occupies its worker thread until it returns. To stop one hung
+source from starving the others (and from saturating the default loop executor
+shared with the rest of the app), this module:
+  - owns a dedicated, named, size-bounded pool (`BROWSE_EXECUTOR_MAX_WORKERS`,
+    env-overridable via SEARCH_API_BROWSE_EXECUTOR_WORKERS), and
+  - caps the number of concurrently-dispatched sync fetches via an
+    asyncio.Semaphore (`BROWSE_SOURCE_CONCURRENCY`), so the pool can never be
+    fully consumed by a single browse request's fan-out.
+A timed-out source returns its worker to the pool only when the underlying sync
+call actually finishes; the semaphore slot is likewise held for the work's true
+lifetime (released in a finally), so a hung source cannot re-admit more work
+past the cap. `shutdown_browse_executor()` provides deterministic teardown for
+tests and process exit.
 """
 from __future__ import annotations
 
 import asyncio
+import atexit
 import logging
 import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, Optional, Protocol, TYPE_CHECKING
 
 from shared.api_errors import APIError
 
@@ -61,20 +86,105 @@ logger = logging.getLogger(__name__)
 DEFAULT_BROWSE_TIMEOUT = 1.0       # D-17, R-01: lowered 2.0 -> 1.0
 DEFAULT_BROWSE_CORE_TIMEOUT = 2.0  # D-17 NEW per R-01
 
+# SEED-016 #29: bounded named executor sizing. Read once at module import for the
+# pool (a ThreadPoolExecutor cannot be resized live); the per-request source
+# concurrency cap is derived from the same default. Keep workers modest -- one
+# browse request fans out to at most core(1) + 3 enrichment sources, and the
+# concurrency cap (below) is what actually shields the pool.
+BROWSE_EXECUTOR_MAX_WORKERS = max(
+    1, int(os.environ.get('SEARCH_API_BROWSE_EXECUTOR_WORKERS', '8') or '8'),
+)
+# Max sync fetches dispatched concurrently across ALL in-flight browse requests.
+# Bounds blast radius so a single request's fan-out (or a stampede) cannot
+# consume the whole pool. Defaults below the pool size so headroom always exists.
+BROWSE_SOURCE_CONCURRENCY = max(1, BROWSE_EXECUTOR_MAX_WORKERS - 1)
 
-@dataclass
-class BrowseEnrichmentBundle:
-    """Pure-data result of /api/browse enrichment fan-out.
 
-    `page` is a hydrated `web.services.BrowsePage` dataclass instance with
-    shelfmark/title/library_code/library_name/fl_id/volume_ie/volumes
-    populated by WebDataService.get_browse_page (R-PR-02). It is the
-    dataclass directly -- not a dict and not an attribute-access shim.
+class BrowsePageProvider(Protocol):
+    """Structural type for the injected core-fetch provider (SEED-016 #3).
+
+    WebDataService (web/services.py) satisfies this without importing it here.
+    Only the two methods _fetch_core needs are declared.
     """
-    page: Optional['BrowsePage']  # web.services.BrowsePage | None
-    pgp: Optional[dict]   # Plus key 'page_section_text' for serializer D-10.
-    fjms: Optional[dict]  # {source_names, has_measurements, has_visual_suggestions}
-    nli: Optional[dict]   # {physical_metadata, folio}
+
+    def get_browse_page(
+        self, sys_id: str, *, p_num: Optional[int] = ..., volume_ie: Optional[str] = ...,
+    ) -> Optional['BrowsePage']:
+        ...
+
+    def get_browse_page_by_fl(
+        self, fl_id: str, *, sys_id: Optional[str] = ...,
+    ) -> Optional['BrowsePage']:
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Module-level named bounded executor (SEED-016 #29)
+# ---------------------------------------------------------------------------
+
+_executor_lock = threading.Lock()
+_BROWSE_EXECUTOR: Optional[ThreadPoolExecutor] = None
+# asyncio.Semaphore is bound to a running loop; build it lazily on first use so
+# import-time has no event loop dependency. Guarded by _executor_lock.
+_BROWSE_SEMAPHORE: Optional[asyncio.Semaphore] = None
+
+
+def _get_browse_executor() -> ThreadPoolExecutor:
+    """Return the process-wide named browse executor, creating it on first use."""
+    global _BROWSE_EXECUTOR
+    if _BROWSE_EXECUTOR is None:
+        with _executor_lock:
+            if _BROWSE_EXECUTOR is None:
+                _BROWSE_EXECUTOR = ThreadPoolExecutor(
+                    max_workers=BROWSE_EXECUTOR_MAX_WORKERS,
+                    thread_name_prefix='browse-enrich',
+                )
+    return _BROWSE_EXECUTOR
+
+
+def _get_browse_semaphore() -> asyncio.Semaphore:
+    """Return the per-process source-concurrency semaphore, building it lazily.
+
+    asyncio.Semaphore binds to the loop that constructs it; in production a
+    single loop runs the server so one semaphore is correct. Tests using
+    asyncio.run() get a fresh loop each call -- reset_browse_executor_state()
+    drops the cached semaphore so the next loop rebuilds it.
+    """
+    global _BROWSE_SEMAPHORE
+    if _BROWSE_SEMAPHORE is None:
+        with _executor_lock:
+            if _BROWSE_SEMAPHORE is None:
+                _BROWSE_SEMAPHORE = asyncio.Semaphore(BROWSE_SOURCE_CONCURRENCY)
+    return _BROWSE_SEMAPHORE
+
+
+def shutdown_browse_executor(wait: bool = False) -> None:
+    """Shut the named browse executor down (tests / process exit).
+
+    Idempotent. After shutdown the next _get_browse_executor() rebuilds a fresh
+    pool, so this is safe to call between test cases.
+    """
+    global _BROWSE_EXECUTOR, _BROWSE_SEMAPHORE
+    with _executor_lock:
+        ex = _BROWSE_EXECUTOR
+        _BROWSE_EXECUTOR = None
+        _BROWSE_SEMAPHORE = None
+    if ex is not None:
+        ex.shutdown(wait=wait)
+
+
+def reset_browse_executor_state() -> None:
+    """Drop the cached semaphore (and pool) WITHOUT waiting -- test helper.
+
+    Use between asyncio.run() calls so a stale loop-bound semaphore is not
+    reused on a fresh loop.
+    """
+    shutdown_browse_executor(wait=False)
+
+
+# Deterministic teardown at interpreter exit so the named pool's threads do not
+# linger (and so test runners that import this module get a clean shutdown).
+atexit.register(shutdown_browse_executor)
 
 
 def _read_timeout(env_var: str, default: float) -> float:
@@ -89,23 +199,28 @@ def _read_timeout(env_var: str, default: float) -> float:
 
 
 async def _run_sync(func, *args):
-    """Run blocking sync work in the default executor."""
+    """Run blocking sync work on the NAMED bounded browse executor (SEED-016 #29).
+
+    Replaces the previous run_in_executor(None, ...) which used the event loop's
+    default (unbounded-ish, app-shared) ThreadPoolExecutor.
+    """
     loop = asyncio.get_event_loop()
-    return await loop.run_in_executor(None, func, *args)
+    return await loop.run_in_executor(_get_browse_executor(), func, *args)
 
 
 # ---------------------------------------------------------------------------
-# Core fetch (R-01: now timed; R-PR-02: uses WebDataService for hydration)
+# Core fetch (R-01: now timed; R-PR-02: uses injected provider for hydration)
 # ---------------------------------------------------------------------------
 
 async def _fetch_core(
+    service: BrowsePageProvider,
     sys_id: str,
     p_num: Optional[int],
     volume_ie: Optional[str],
     fl_id: Optional[str],
     timeout: float,
 ) -> Optional['BrowsePage']:
-    """Resolve core BrowsePage via WebDataService (R-PR-02).
+    """Resolve core BrowsePage via the injected provider (R-PR-02 / SEED-016 #3).
 
     Returns the hydrated `web.services.BrowsePage` dataclass (with shelfmark,
     title, library_code, library_name, fl_id, volume_ie, volumes populated)
@@ -114,14 +229,11 @@ async def _fetch_core(
     Timeout -> APIError('core_timeout', 504). None return propagates so the
     handler can map to 404 'manuscript_page_not_found'.
     """
-    from web.services import get_service  # late import; web.services is process-singleton
-
-    svc = get_service()
 
     def _sync():
         if fl_id:
-            return svc.get_browse_page_by_fl(fl_id, sys_id=sys_id)
-        return svc.get_browse_page(
+            return service.get_browse_page_by_fl(fl_id, sys_id=sys_id)
+        return service.get_browse_page(
             sys_id, p_num=p_num, volume_ie=volume_ie,
         )
 
@@ -138,10 +250,25 @@ async def _fetch_core(
             http_status=504,
         )
 
-    # WebDataService returns a hydrated BrowsePage dataclass instance OR None.
+    # The provider returns a hydrated BrowsePage dataclass instance OR None.
     # No attribute-access shim wrapping -- Plan 01's serializer reads
     # dataclass attributes directly off the BrowsePage.
     return result
+
+
+@dataclass
+class BrowseEnrichmentBundle:
+    """Pure-data result of /api/browse enrichment fan-out.
+
+    `page` is a hydrated `web.services.BrowsePage` dataclass instance with
+    shelfmark/title/library_code/library_name/fl_id/volume_ie/volumes
+    populated by the provider's get_browse_page (R-PR-02). It is the
+    dataclass directly -- not a dict and not an attribute-access shim.
+    """
+    page: Optional['BrowsePage']  # web.services.BrowsePage | None
+    pgp: Optional[dict]   # Plus key 'page_section_text' for serializer D-10.
+    fjms: Optional[dict]  # {source_names, has_measurements, has_visual_suggestions}
+    nli: Optional[dict]   # {physical_metadata, folio}
 
 
 # ---------------------------------------------------------------------------
@@ -251,14 +378,23 @@ async def _wrap_with_timeout(
     sync_func, args: tuple, source_name: str,
     timeout: float, warnings_list: list,
 ) -> Optional[Any]:
-    """Run sync_func(*args) in executor under a timeout. On timeout/exception,
-    append a structured warning to warnings_list and return None.
+    """Run sync_func(*args) on the bounded executor under a timeout + concurrency
+    cap. On timeout/exception, append a structured warning to warnings_list and
+    return None.
+
+    SEED-016 #29: the dispatch is gated by the module-level source-concurrency
+    semaphore so a single browse request's fan-out cannot consume the whole
+    named pool. The semaphore slot is held for the work's TRUE lifetime
+    (released in finally), so a hung source keeps its slot until the underlying
+    sync call actually returns -- it cannot re-admit more work past the cap.
 
     R-PR-05: this is the SOLE place that catches inner sync-helper failures.
     `_pgp_sync` / `_fjms_sync` / `_nli_sync` no longer have inner try/except
     blocks -- they let exceptions propagate so this wrapper can emit
     'enrichment_failed' warnings (instead of silently nulling out the source).
     """
+    sem = _get_browse_semaphore()
+    await sem.acquire()
     try:
         return await asyncio.wait_for(_run_sync(sync_func, *args), timeout=timeout)
     except asyncio.TimeoutError:
@@ -268,6 +404,8 @@ async def _wrap_with_timeout(
         logger.exception('enrichment source %s failed', source_name)
         warnings_list.append({'code': 'enrichment_failed', 'source': source_name})
         return None
+    finally:
+        sem.release()
 
 
 # ---------------------------------------------------------------------------
@@ -276,12 +414,17 @@ async def _wrap_with_timeout(
 
 async def fetch_browse_bundle(
     *,
+    service: BrowsePageProvider,
     sys_id: str,
     p_num: Optional[int] = None,
     volume_ie: Optional[str] = None,
     fl_id: Optional[str] = None,
 ) -> tuple[BrowseEnrichmentBundle, list]:
     """Fan out: core + PGP + FJMS + NLI. Pure-data return.
+
+    SEED-016 #3: `service` is an injected BrowsePageProvider (WebDataService in
+    production). This module no longer imports web.services -- the caller owns
+    the dependency. This keeps shared/ from importing web/.
 
     R-PR-04: signature does NOT accept a `uid` parameter. Plan 03's
     `_validate_locator` parses uid into effective `{p_num, volume_ie, fl_id}`
@@ -291,29 +434,18 @@ async def fetch_browse_bundle(
     R-PR-09 note: `text_cap` is NOT a parameter here either -- the serializer
     applies the cap at envelope-build time, not at fetch time.
 
-    R-09 note: asyncio.wait_for cancels the await but NOT the executor thread.
-    Hung sidecars CAN starve the default executor pool under sustained load.
-    A single logger.debug at entry exposes worker count for ops triage.
+    SEED-016 #29 note: sync sidecar I/O runs on the named, bounded
+    _BROWSE_EXECUTOR with a source-concurrency cap. asyncio.wait_for cancels the
+    await but NOT the executor thread; the bounded pool + cap stop one hung
+    source from starving the others.
     """
     warnings_list: list = []
-
-    # R-09 monitoring breadcrumb (cheap; sub-microsecond).
-    try:
-        loop = asyncio.get_event_loop()
-        executor = getattr(loop, '_default_executor', None)
-        worker_count = getattr(executor, '_max_workers', None) if executor else None
-        logger.debug(
-            'browse_bundle entry sys_id=%s p_num=%s volume_ie=%s fl_id=%s executor_max_workers=%s',
-            sys_id, p_num, volume_ie, fl_id, worker_count,
-        )
-    except Exception:
-        pass  # never let the breadcrumb crash a real request
 
     timeout = _read_timeout('SEARCH_API_BROWSE_TIMEOUT', DEFAULT_BROWSE_TIMEOUT)
     core_timeout = _read_timeout('SEARCH_API_BROWSE_CORE_TIMEOUT', DEFAULT_BROWSE_CORE_TIMEOUT)
 
     # 1. Core fetch -- mandatory + timed. Returns hydrated BrowsePage or None.
-    page = await _fetch_core(sys_id, p_num, volume_ie, fl_id, core_timeout)
+    page = await _fetch_core(service, sys_id, p_num, volume_ie, fl_id, core_timeout)
     if page is None:
         return BrowseEnrichmentBundle(None, None, None, None), warnings_list
 

--- a/shared/parallels_service.py
+++ b/shared/parallels_service.py
@@ -4,11 +4,21 @@
 Mirrors shared/browse_service.py (Phase 79 D-23 extraction precedent): pure-data
 async fan-out, importable from shared/, with no UI-framework dependency.
 
+Layering contract (SEED-016 #3):
+- This module lives in shared/ and MUST NOT import from web/ at runtime. It used
+  to do `from web.state import state` inline (twice) to reach the process-
+  singleton SearchEngine + MetadataManager, which inverted the layering
+  (shared -> web). The dependency is now INVERTED: the caller
+  (web/search_api.py) passes `searcher` (a CompositionSearcher) and `meta_mgr`
+  (a UidComponentParser) INTO fetch_parallels_results. shared/ stays framework-
+  and web-agnostic.
+
 Statelessness contract (D-20 inherited from Phase 78 / D-22 inherited from Phase 79):
-- Reads via the process-singleton SearchEngine (web.state).
-- MUST NOT touch any per-session UI state -- last-results caches, parallels-results
-  caches, current-search-query, browser-storage, request-cookies, or any UI-coupled
-  page state. Verified by grep at acceptance time.
+- The injected searcher/meta_mgr are the process-singletons (formerly read off
+  web.state). MUST NOT touch any per-session UI state -- last-results caches,
+  parallels-results caches, current-search-query, browser-storage,
+  request-cookies, or any UI-coupled page state. Verified by grep at acceptance
+  time.
 
 D-07 cap policy: main_results capped at 200 groups (one group per sys_id) AFTER
 sorting groups desc by aggregate_score (sum of per-row final_score within group).
@@ -38,9 +48,32 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Protocol
 
 logger = logging.getLogger(__name__)
+
+
+class CompositionSearcher(Protocol):
+    """Structural type for the injected SearchEngine (SEED-016 #3).
+
+    The process-singleton SearchEngine (genizah_core.py) satisfies this without
+    importing it here. Only the one method fetch_parallels_results needs is
+    declared. Kept loose (**kwargs) so the real engine's wider signature is
+    compatible.
+    """
+
+    def search_composition_logic(self, *args, **kwargs) -> dict:
+        ...
+
+
+class UidComponentParser(Protocol):
+    """Structural type for the injected MetadataManager (SEED-016 #3).
+
+    Only the parse method _group_parallels_by_sys_id needs is declared.
+    """
+
+    def parse_full_id_components(self, uid_or_header: str) -> dict:
+        ...
 
 
 # D-07 hardcoded group cap -- no env override in v7.10 per CONTEXT deferred ideas.
@@ -96,6 +129,7 @@ async def _run_sync(func, *args, **kwargs):
 
 def _cap_main_results_by_group(
     main_results: list[dict],
+    meta_mgr: UidComponentParser,
     cap: int = PARALLELS_GROUP_CAP,
 ) -> tuple[list[dict], bool]:
     """Apply D-07 group cap.
@@ -108,6 +142,9 @@ def _cap_main_results_by_group(
     Returns (capped_rows, truncated_flag). truncated_flag=True iff raw group
     count exceeded `cap`.
 
+    SEED-016 #3: `meta_mgr` is injected by the caller (was read off web.state).
+    _group_parallels_by_sys_id needs it to parse uid components.
+
     NOTE: This cap applies ONLY to main_results. filtered_results is NOT capped
     in v7.10 -- see ParallelsResultBundle docstring for rationale.
     """
@@ -115,12 +152,9 @@ def _cap_main_results_by_group(
         return [], False
 
     # Late import to keep service import-time fast and avoid circular imports.
-    # _group_parallels_by_sys_id needs meta_mgr to parse uid components -- use
-    # the process-singleton from web.state.
     from shared.search_serializer import _group_parallels_by_sys_id
-    from web.state import state as _state
 
-    groups = _group_parallels_by_sys_id(main_results, meta_mgr=_state.meta_mgr)
+    groups = _group_parallels_by_sys_id(main_results, meta_mgr=meta_mgr)
 
     if len(groups) <= cap:
         return main_results, False
@@ -150,6 +184,8 @@ def _cap_main_results_by_group(
 
 async def fetch_parallels_results(
     *,
+    searcher: CompositionSearcher,
+    meta_mgr: UidComponentParser,
     text: str,
     chunk_size: int,
     mode: str,
@@ -164,7 +200,16 @@ async def fetch_parallels_results(
     inputs and only translates them to search_composition_logic's call shape
     + applies the D-07 group cap on the way out.
 
+    SEED-016 #3: `searcher` (SearchEngine) and `meta_mgr` (MetadataManager) are
+    injected by the caller (web/search_api.py) -- this module no longer imports
+    web.state. Keeps shared/ from importing web/.
+
     Args:
+        searcher: process-singleton SearchEngine exposing
+                  search_composition_logic. Injected by the caller.
+        meta_mgr: process-singleton MetadataManager exposing
+                  parse_full_id_components (used by the group cap). Injected by
+                  the caller.
         text: composition source. Mapped to search_composition_logic's
               `full_text` arg. The handler has already stripped + length-
               capped this.
@@ -197,11 +242,8 @@ async def fetch_parallels_results(
     # high-frequency filtering when the caller did not specify a threshold.
     effective_max_freq = float('inf') if max_freq is None else float(max_freq)
 
-    # Late import -- process-singleton SearchEngine. Same pattern as Phase 79.
-    from web.state import state
-
     def _sync_call() -> dict:
-        return state.searcher.search_composition_logic(
+        return searcher.search_composition_logic(
             full_text=text,
             chunk_size=chunk_size,
             max_freq=effective_max_freq,
@@ -229,7 +271,7 @@ async def fetch_parallels_results(
     # if load testing reveals large filtered payloads.
 
     # D-07 cap on main groups only.
-    capped_main, truncated = _cap_main_results_by_group(main_results)
+    capped_main, truncated = _cap_main_results_by_group(main_results, meta_mgr)
 
     # Boundary options for envelope echo (D-06 inherited from Phase 77).
     boundary_options = {

--- a/tests/test_seed016_layering_executor.py
+++ b/tests/test_seed016_layering_executor.py
@@ -402,6 +402,122 @@ def test_browse_slow_source_times_out_without_starving_others(monkeypatch):
     )
 
 
+def test_timed_out_source_holds_slot_until_blocking_call_returns(monkeypatch):
+    """SEED-016 #29 (Codex REQUEST-CHANGES): a source whose coroutine TIMES OUT
+    must keep its concurrency slot until the underlying blocking function ACTUALLY
+    returns -- not merely until asyncio.wait_for cancels the await.
+
+    With BROWSE_SOURCE_CONCURRENCY = 1 we run two enrichment sources serialized by
+    the one slot. The first (slow) source blocks past its per-source timeout. We
+    prove the second source CANNOT begin executing its blocking body while the
+    first is still running (slot held despite the timeout), and that it DOES
+    proceed once the first blocking function returns.
+
+    This is the gap the prior `..._without_starving_others` test missed: that one
+    only asserts the coroutine returned quickly, which the buggy
+    release-in-finally version also satisfied.
+    """
+    # Cap concurrency to a single slot and rebuild the semaphore on this loop.
+    monkeypatch.setattr(bs, 'BROWSE_SOURCE_CONCURRENCY', 1)
+    bs.reset_browse_executor_state()
+    # Slow source's per-source timeout is short; the slow body runs much longer.
+    monkeypatch.setenv('SEARCH_API_BROWSE_TIMEOUT', '0.2')
+
+    slow_started = threading.Event()
+    slow_may_finish = threading.Event()
+    slow_returned = threading.Event()
+    second_started = threading.Event()
+
+    # Records: did the second source begin its blocking body BEFORE the slow
+    # source's blocking body returned? If the slot was wrongly freed on timeout,
+    # the second source starts while slow_returned is still unset -> True (bug).
+    observed = {'second_started_before_slow_returned': None}
+
+    def _slow_pgp(*a, **k):
+        slow_started.set()
+        # Block well past the 0.2s coroutine timeout; only finish on command.
+        slow_may_finish.wait(timeout=5.0)
+        slow_returned.set()
+        return {'page_section_text': 'late'}
+
+    def _second_fjms(*a, **k):
+        second_started.set()
+        # Observe whether the slow source had already returned (slot truly freed)
+        # at the instant we were admitted.
+        observed['second_started_before_slow_returned'] = not slow_returned.is_set()
+        return {'source_names': ['CUL'], 'has_measurements': False,
+                'has_visual_suggestions': False}
+
+    def _noop_nli(*a, **k):
+        return {'physical_metadata': None, 'folio': None}
+
+    monkeypatch.setattr(bs, '_pgp_sync', _slow_pgp)
+    monkeypatch.setattr(bs, '_fjms_sync', _second_fjms)
+    monkeypatch.setattr(bs, '_nli_sync', _noop_nli)
+
+    provider = _FakeProvider()
+
+    async def _run():
+        task = asyncio.ensure_future(
+            bs.fetch_browse_bundle(service=provider, sys_id='99001', p_num=3)
+        )
+        # Wait until the slow source is running (it holds the only slot).
+        for _ in range(200):
+            if slow_started.is_set():
+                break
+            await asyncio.sleep(0.01)
+        assert slow_started.is_set(), 'slow source never started'
+
+        # Give the slow coroutine time to TIME OUT (0.2s) and then some. If the
+        # buggy finally-release were in place, the freed slot would let the
+        # second source begin its body here, while the slow body is still blocked.
+        await asyncio.sleep(0.6)
+        assert not second_started.is_set(), (
+            'second source acquired the slot while the timed-out source was '
+            'still running its blocking call -- the concurrency slot was freed '
+            'on coroutine timeout instead of on real completion (SEED-016 #29 '
+            'regression)'
+        )
+
+        # Now let the slow blocking function return; the done-callback releases
+        # the slot and the second source must proceed.
+        slow_may_finish.set()
+        bundle, warnings = await asyncio.wait_for(task, timeout=5.0)
+        return bundle, warnings
+
+    bundle, warnings = asyncio.run(_run())
+
+    # The slow source timed out -> null + warning; the second source resolved.
+    assert bundle.pgp is None
+    assert any(
+        w.get('code') == 'enrichment_timeout' and w.get('source') == 'pgp'
+        for w in warnings
+    ), f'expected enrichment_timeout/pgp; got {warnings!r}'
+    assert bundle.fjms is not None and bundle.fjms['source_names'] == ['CUL']
+    # And when it finally ran, the slow body had already returned (slot freed only
+    # after real completion).
+    assert observed['second_started_before_slow_returned'] is False, (
+        'second source ran before the slow blocking call returned'
+    )
+
+
+def test_browse_executor_workers_env_parse_does_not_raise_on_garbage():
+    """_read_int_env falls back to the default on malformed input instead of
+    raising at import (secondary nit)."""
+    assert bs._read_int_env('SEARCH_API_BROWSE_EXECUTOR_WORKERS_NONEXISTENT', 8) == 8
+    import os as _os
+    _os.environ['_BS_TEST_GARBAGE_INT'] = 'not-a-number'
+    try:
+        assert bs._read_int_env('_BS_TEST_GARBAGE_INT', 8) == 8
+        _os.environ['_BS_TEST_GARBAGE_INT'] = '3'
+        assert bs._read_int_env('_BS_TEST_GARBAGE_INT', 8) == 3
+        _os.environ['_BS_TEST_GARBAGE_INT'] = '0'
+        # Clamped to the minimum (1).
+        assert bs._read_int_env('_BS_TEST_GARBAGE_INT', 8) == 1
+    finally:
+        _os.environ.pop('_BS_TEST_GARBAGE_INT', None)
+
+
 def test_shutdown_browse_executor_is_idempotent_and_rebuilds():
     ex1 = bs._get_browse_executor()
     bs.shutdown_browse_executor(wait=True)

--- a/tests/test_seed016_layering_executor.py
+++ b/tests/test_seed016_layering_executor.py
@@ -1,0 +1,410 @@
+# -*- coding: utf-8 -*-
+"""SEED-016 -- shared/ -> web/ layering decoupling + bounded browse executor.
+
+Two findings, two test groups:
+
+#3 (layering): shared/browse_service.py and shared/parallels_service.py must not
+   import from web/ at runtime. Proven by
+   (a) a SOURCE guard (AST) that no `from web.` / `import web.` appears outside
+       a TYPE_CHECKING block, and
+   (b) BEHAVIOR tests that call the shared functions with INJECTED FAKES while
+       web.state / web.services are POISONED in sys.modules -- so any latent
+       runtime reach into web/ would raise. A plain "imports without web" test
+       is too weak here because the imports were already late; poisoning proves
+       the call path itself is decoupled.
+
+#29 (bounded executor): browse enrichment fan-out must run on a module-level
+   NAMED, size-bounded executor with a source-concurrency cap, and one slow
+   source must time out WITHOUT starving the others.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import os
+import pathlib
+import sys
+import threading
+import time
+
+import pytest
+
+import shared.browse_service as bs
+import shared.parallels_service as ps
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _web_imports_outside_type_checking(module_path: pathlib.Path) -> list[str]:
+    """Return offending `web.*` import statements that are NOT under a
+    `if TYPE_CHECKING:` block. Empty list == clean."""
+    src = module_path.read_text(encoding='utf-8')
+    tree = ast.parse(src)
+
+    # Collect line ranges of all `if TYPE_CHECKING:` bodies so we can exempt
+    # imports inside them (those never execute at runtime).
+    type_checking_ranges: list[tuple[int, int]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.If):
+            test = node.test
+            is_tc = (
+                (isinstance(test, ast.Name) and test.id == 'TYPE_CHECKING')
+                or (isinstance(test, ast.Attribute) and test.attr == 'TYPE_CHECKING')
+            )
+            if is_tc:
+                start = node.body[0].lineno
+                end = getattr(node, 'end_lineno', node.body[-1].lineno)
+                type_checking_ranges.append((start, end))
+
+    def _in_tc(lineno: int) -> bool:
+        return any(s <= lineno <= e for s, e in type_checking_ranges)
+
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            mod = node.module or ''
+            if (mod == 'web' or mod.startswith('web.')) and not _in_tc(node.lineno):
+                offenders.append(f'line {node.lineno}: from {mod} import ...')
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if (alias.name == 'web' or alias.name.startswith('web.')) and not _in_tc(node.lineno):
+                    offenders.append(f'line {node.lineno}: import {alias.name}')
+    return offenders
+
+
+class _FakeBrowsePage:
+    """Structural stand-in for web.services.BrowsePage (attribute access only)."""
+
+    def __init__(self, sys_id='99001', p_num=3, fl_id='FL1'):
+        self.sys_id = sys_id
+        self.p_num = p_num
+        self.fl_id = fl_id
+
+
+class _FakeProvider:
+    """Satisfies shared.browse_service.BrowsePageProvider structurally."""
+
+    def __init__(self, page=None):
+        self._page = page if page is not None else _FakeBrowsePage()
+        self.calls: list[tuple] = []
+
+    def get_browse_page(self, sys_id, *, p_num=None, volume_ie=None):
+        self.calls.append(('get_browse_page', sys_id, p_num, volume_ie))
+        return self._page
+
+    def get_browse_page_by_fl(self, fl_id, *, sys_id=None):
+        self.calls.append(('get_browse_page_by_fl', fl_id, sys_id))
+        return self._page
+
+
+class _FakeSearcher:
+    def __init__(self, result):
+        self._result = result
+        self.calls = 0
+
+    def search_composition_logic(self, *args, **kwargs):
+        self.calls += 1
+        return self._result
+
+
+class _FakeMeta:
+    def parse_full_id_components(self, uid_or_header):
+        # 'h_<sys>_IE..' -> sys_id second token; else stable id.
+        if uid_or_header and uid_or_header.startswith('h_'):
+            parts = uid_or_header.split('_')
+            return {'sys_id': parts[1] if len(parts) > 1 else 'unknown'}
+        return {'sys_id': 'sysA'}
+
+
+class _PoisonWeb:
+    """Context manager: replace web.state / web.services in sys.modules with
+    objects that raise on ANY attribute access, proving the code under test
+    never reaches into web/ at runtime."""
+
+    _TARGETS = ('web.state', 'web.services')
+
+    def __init__(self):
+        self._saved: dict[str, object] = {}
+
+    def __enter__(self):
+        class _Boom:
+            def __getattr__(self, name):
+                raise AssertionError(
+                    f'shared/ reached into web.* at runtime (attr {name!r}) '
+                    '-- SEED-016 #3 layering regression'
+                )
+
+        for name in self._TARGETS:
+            self._saved[name] = sys.modules.get(name)
+            sys.modules[name] = _Boom()  # type: ignore[assignment]
+        return self
+
+    def __exit__(self, *exc):
+        for name, mod in self._saved.items():
+            if mod is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = mod
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _reset_browse_executor():
+    """Each asyncio.run() builds a fresh loop; drop the loop-bound semaphore +
+    pool before/after so a stale loop binding is never reused."""
+    bs.reset_browse_executor_state()
+    yield
+    bs.reset_browse_executor_state()
+
+
+# ---------------------------------------------------------------------------
+# #3 -- SOURCE guard (AST)
+# ---------------------------------------------------------------------------
+
+def test_browse_service_has_no_runtime_web_import():
+    offenders = _web_imports_outside_type_checking(
+        _REPO_ROOT / 'shared' / 'browse_service.py'
+    )
+    assert offenders == [], (
+        'shared/browse_service.py imports web.* outside TYPE_CHECKING '
+        f'(SEED-016 #3 regression): {offenders!r}'
+    )
+
+
+def test_parallels_service_has_no_runtime_web_import():
+    offenders = _web_imports_outside_type_checking(
+        _REPO_ROOT / 'shared' / 'parallels_service.py'
+    )
+    assert offenders == [], (
+        'shared/parallels_service.py imports web.* outside TYPE_CHECKING '
+        f'(SEED-016 #3 regression): {offenders!r}'
+    )
+
+
+# ---------------------------------------------------------------------------
+# #3 -- BEHAVIOR: call with injected fakes while web.* is poisoned
+# ---------------------------------------------------------------------------
+
+def test_browse_bundle_runs_with_web_poisoned(monkeypatch):
+    """fetch_browse_bundle resolves the page through the INJECTED provider while
+    web.state / web.services are poisoned -- proving real decoupling."""
+    # Keep sidecars silent so the test is offline + fast.
+    monkeypatch.setattr(bs, '_pgp_sync', lambda *a, **k: None)
+    monkeypatch.setattr(bs, '_fjms_sync', lambda *a, **k: None)
+    monkeypatch.setattr(bs, '_nli_sync', lambda *a, **k: None)
+
+    provider = _FakeProvider()
+
+    async def _run():
+        with _PoisonWeb():
+            bundle, warnings = await bs.fetch_browse_bundle(
+                service=provider, sys_id='99001', p_num=3,
+            )
+        return bundle, warnings
+
+    bundle, warnings = asyncio.run(_run())
+    assert bundle.page is provider._page
+    assert provider.calls and provider.calls[0][0] == 'get_browse_page'
+    assert warnings == []
+
+
+def test_browse_bundle_fl_id_routes_to_by_fl(monkeypatch):
+    monkeypatch.setattr(bs, '_pgp_sync', lambda *a, **k: None)
+    monkeypatch.setattr(bs, '_fjms_sync', lambda *a, **k: None)
+    monkeypatch.setattr(bs, '_nli_sync', lambda *a, **k: None)
+    provider = _FakeProvider()
+
+    async def _run():
+        with _PoisonWeb():
+            return await bs.fetch_browse_bundle(
+                service=provider, sys_id='99001', fl_id='FLZ',
+            )
+
+    bundle, _ = asyncio.run(_run())
+    assert provider.calls[0][0] == 'get_browse_page_by_fl'
+    assert provider.calls[0][1] == 'FLZ'
+
+
+def test_parallels_runs_with_web_poisoned():
+    """fetch_parallels_results uses INJECTED searcher + meta_mgr while web.* is
+    poisoned -- proving real decoupling."""
+    main_rows = [
+        {'uid': 'IE1_P1_FL1', 'raw_header': 'h_sysA_IE1_P1_FL1', 'score': 5.0,
+         'final_score': 5.0},
+    ]
+    searcher = _FakeSearcher({'main': main_rows, 'filtered': [], 'boundary_stats': None})
+    meta = _FakeMeta()
+
+    async def _run():
+        with _PoisonWeb():
+            return await ps.fetch_parallels_results(
+                searcher=searcher, meta_mgr=meta,
+                text='hello world', chunk_size=3, mode='exact',
+            )
+
+    bundle = asyncio.run(_run())
+    assert searcher.calls == 1
+    assert bundle.main_results == main_rows
+    assert bundle.truncated_to_200 is False
+
+
+def test_parallels_group_cap_with_injected_meta():
+    """Group cap path consumes the injected meta_mgr (not web.state)."""
+    rows = []
+    for i in range(250):
+        rows.append({
+            'uid': f'IE{i}_P1_FL{i}',
+            'raw_header': f'h_sys{i}_IE{i}_P1_FL{i}',
+            'score': float(250 - i), 'final_score': float(250 - i),
+        })
+    searcher = _FakeSearcher({'main': rows, 'filtered': [], 'boundary_stats': None})
+    meta = _FakeMeta()
+
+    async def _run():
+        with _PoisonWeb():
+            return await ps.fetch_parallels_results(
+                searcher=searcher, meta_mgr=meta,
+                text='hello', chunk_size=3, mode='exact',
+            )
+
+    bundle = asyncio.run(_run())
+    assert bundle.truncated_to_200 is True
+    assert len(bundle.main_results) == ps.PARALLELS_GROUP_CAP
+
+
+# ---------------------------------------------------------------------------
+# #29 -- bounded NAMED executor
+# ---------------------------------------------------------------------------
+
+def test_browse_executor_is_named_and_bounded():
+    ex = bs._get_browse_executor()
+    assert ex is bs._get_browse_executor(), 'executor must be a process singleton'
+    assert ex._max_workers == bs.BROWSE_EXECUTOR_MAX_WORKERS
+    # Threads carry the descriptive prefix.
+    assert ex._thread_name_prefix == 'browse-enrich'
+    # NOT the event loop's default executor.
+    assert bs.BROWSE_EXECUTOR_MAX_WORKERS >= 1
+
+
+def test_browse_executor_workers_env_override(monkeypatch):
+    """The pool size honors SEARCH_API_BROWSE_EXECUTOR_WORKERS at import time.
+
+    We can't re-import cheaply mid-suite, so assert the parsing contract on a
+    re-derived value instead (the module read os.environ at import)."""
+    # Sanity: the constant matches the parse rule for the current env (or default 8).
+    raw = os.environ.get('SEARCH_API_BROWSE_EXECUTOR_WORKERS')
+    expected = max(1, int(raw)) if raw else 8
+    assert bs.BROWSE_EXECUTOR_MAX_WORKERS == expected
+    # The source-concurrency cap is strictly below the pool (headroom invariant)
+    # unless the pool is size 1.
+    if bs.BROWSE_EXECUTOR_MAX_WORKERS > 1:
+        assert bs.BROWSE_SOURCE_CONCURRENCY < bs.BROWSE_EXECUTOR_MAX_WORKERS
+
+
+def test_browse_source_concurrency_is_capped(monkeypatch):
+    """At most BROWSE_SOURCE_CONCURRENCY sync fetches run at once across the
+    fan-out. Instrument the sync helpers to record peak concurrency."""
+    peak = 0
+    current = 0
+    lock = threading.Lock()
+    barrier_release = threading.Event()
+
+    def _make_tracked(_name):
+        def _fn(*a, **k):
+            nonlocal peak, current
+            with lock:
+                current += 1
+                peak = max(peak, current)
+            # Hold long enough that all dispatched sources overlap.
+            barrier_release.wait(timeout=2.0)
+            with lock:
+                current -= 1
+            return None
+        return _fn
+
+    monkeypatch.setattr(bs, '_pgp_sync', _make_tracked('pgp'))
+    monkeypatch.setattr(bs, '_fjms_sync', _make_tracked('fjms'))
+    monkeypatch.setattr(bs, '_nli_sync', _make_tracked('nli'))
+    # Force the cap down to 1 for a crisp assertion.
+    monkeypatch.setattr(bs, 'BROWSE_SOURCE_CONCURRENCY', 1)
+    # Generous per-source timeout so the cap (not the timeout) governs.
+    monkeypatch.setenv('SEARCH_API_BROWSE_TIMEOUT', '5.0')
+
+    provider = _FakeProvider()
+
+    async def _run():
+        # Release the barrier shortly after dispatch so serialized sources finish.
+        async def _releaser():
+            await asyncio.sleep(0.3)
+            barrier_release.set()
+        rel = asyncio.ensure_future(_releaser())
+        bundle, warnings = await bs.fetch_browse_bundle(
+            service=provider, sys_id='99001', p_num=3,
+        )
+        await rel
+        return bundle, warnings
+
+    asyncio.run(_run())
+    assert peak == 1, f'source concurrency cap=1 violated; peak was {peak}'
+
+
+def test_browse_slow_source_times_out_without_starving_others(monkeypatch):
+    """One slow source hits enrichment_timeout; the fast sources still resolve.
+
+    Cap is the default (>1) so the three sources fan out concurrently."""
+    monkeypatch.setenv('SEARCH_API_BROWSE_TIMEOUT', '0.2')
+
+    def _slow_pgp(*a, **k):
+        time.sleep(1.5)  # exceeds the 0.2s timeout
+        return {'page_section_text': 'late'}
+
+    def _fast_fjms(*a, **k):
+        return {'source_names': ['CUL'], 'has_measurements': False,
+                'has_visual_suggestions': False}
+
+    def _fast_nli(*a, **k):
+        return {'physical_metadata': None, 'folio': None}
+
+    monkeypatch.setattr(bs, '_pgp_sync', _slow_pgp)
+    monkeypatch.setattr(bs, '_fjms_sync', _fast_fjms)
+    monkeypatch.setattr(bs, '_nli_sync', _fast_nli)
+
+    provider = _FakeProvider()
+
+    async def _run():
+        t0 = time.monotonic()
+        bundle, warnings = await bs.fetch_browse_bundle(
+            service=provider, sys_id='99001', p_num=3,
+        )
+        return bundle, warnings, time.monotonic() - t0
+
+    bundle, warnings, elapsed = asyncio.run(_run())
+
+    # Fast sources resolved.
+    assert bundle.fjms is not None and bundle.fjms['source_names'] == ['CUL']
+    assert bundle.nli is not None
+    # Slow source timed out -> null slot + structured warning.
+    assert bundle.pgp is None
+    assert any(
+        w.get('code') == 'enrichment_timeout' and w.get('source') == 'pgp'
+        for w in warnings
+    ), f'expected enrichment_timeout/pgp; got {warnings!r}'
+    # gather returned at ~the timeout, NOT at the slow source's 1.5s -- the fast
+    # sources were not starved by the slow one.
+    assert elapsed < 1.0, (
+        f'fan-out blocked on the slow source ({elapsed:.2f}s) -- starvation'
+    )
+
+
+def test_shutdown_browse_executor_is_idempotent_and_rebuilds():
+    ex1 = bs._get_browse_executor()
+    bs.shutdown_browse_executor(wait=True)
+    bs.shutdown_browse_executor(wait=True)  # idempotent, no raise
+    ex2 = bs._get_browse_executor()
+    assert ex2 is not ex1, 'a fresh pool must be built after shutdown'

--- a/web/search_api.py
+++ b/web/search_api.py
@@ -54,6 +54,10 @@ from web.api_hardening import (
 from shared.api_errors import APIError
 # Phase 79 imports.
 from shared.browse_service import fetch_browse_bundle, _read_timeout
+# SEED-016 #3: the browse core-fetch provider is injected by the caller (here),
+# inverting the former shared/ -> web/ import. web.services is the web layer's
+# own dependency, so importing it from web/search_api.py respects layering.
+from web.services import get_service
 from shared.search_serializer import serialize_browse_payload, serialize_parallels_payload
 # Phase 80 imports.
 from shared.parallels_service import fetch_parallels_results, ParallelsResultBundle
@@ -1331,6 +1335,7 @@ def init_search_api(app_override: Optional[FastAPI] = None, path_prefix: str = '
         #    fetch_browse_bundle raises APIError('core_timeout', 504) on
         #    core timeout; otherwise returns a bundle (page may be None).
         bundle, warnings_list = await fetch_browse_bundle(
+            service=get_service(),  # SEED-016 #3: inject the browse-page provider.
             sys_id=loc.sys_id,
             p_num=loc.effective_p_num,
             volume_ie=loc.effective_volume_ie,
@@ -1541,6 +1546,10 @@ def init_search_api(app_override: Optional[FastAPI] = None, path_prefix: str = '
             try:
                 _par_task = asyncio.ensure_future(
                     fetch_parallels_results(
+                        # SEED-016 #3: inject the SearchEngine + MetadataManager
+                        # singletons (was read off web.state inside shared/).
+                        searcher=state.searcher,
+                        meta_mgr=state.meta_mgr,
                         text=text,
                         chunk_size=req.chunk_size,
                         mode=req.mode,


### PR DESCRIPTION
## SEED-016 — two findings, behavior held identical

### #3 — `shared/` must stop importing `web/` (layering violation)
The dependency is **inverted** with explicit signatures (no vague provider, no hidden fallback):

- **`shared/browse_service.py`** — `fetch_browse_bundle` / `_fetch_core` now take an injected `service` parameter (structural `BrowsePageProvider` Protocol). The runtime `from web.services import get_service` is gone. `BrowsePage` remains a `TYPE_CHECKING`-only return-type annotation (no runtime import).
- **`shared/parallels_service.py`** — `fetch_parallels_results` now takes injected `searcher` (`CompositionSearcher`) + `meta_mgr` (`UidComponentParser`); both inline `from web.state import state` (entrypoint + `_cap_main_results_by_group`) are gone.
- **`web/search_api.py`** (callers) — browse injects `get_service()`; parallels injects `state.searcher` / `state.meta_mgr`. `get_service` imported at module level in the web layer (respects layering).

### #29 — bounded browse enrichment executor (BROWSE ONLY)
- Module-level **named** `ThreadPoolExecutor(thread_name_prefix='browse-enrich')`, size from `SEARCH_API_BROWSE_EXECUTOR_WORKERS` (default 8).
- `asyncio.Semaphore` **source-concurrency cap** (`BROWSE_SOURCE_CONCURRENCY`, default pool−1) so one request's fan-out can't consume the pool; slot held for the work's true lifetime (released in `finally`).
- `shutdown_browse_executor()` for deterministic teardown (atexit + test helper).
- `wait_for` kept as a coroutine timeout (it can't cancel the thread); the bounded pool + cap are what stop a hung source from starving the others.
- Parallels concurrency model untouched (it already has the heavy semaphore in `web/search_api.py`) — out of scope.

### Tests — `tests/test_seed016_layering_executor.py`
- **AST source guard**: no `from web.` / `import web.` outside `TYPE_CHECKING` in either shared module.
- **Real decoupling (behavior)**: calls the shared fns with **injected fakes** while `web.state` / `web.services` are **poisoned** in `sys.modules` (any latent reach into `web/` raises).
- **Bounded executor**: named/singleton pool; concurrency cap=1 enforced (peak==1); one slow source times out (`enrichment_timeout`) while fast sources resolve and the fan-out returns at ~the timeout (no starvation); idempotent shutdown + rebuild.

### Verification
- `tests/test_seed016_layering_executor.py` — 11 passed
- `tests/test_browse_api.py` `tests/test_parallels_api.py` — 80 passed / 2 skipped (env-gated real-corpus)
- `tests/test_search_api_v2.py` — 93 passed / 6 skipped
- `tests/test_search_serializer.py` `tests/test_shared_service.py` — 98 passed
- `ruff check` on all 4 changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GnvGb31t729NCZbnUQXS6