### PR TITLE
SEED-013 + 018-core: guards + cleanup

### DIFF
--- a/desktop/result_dialog.py
+++ b/desktop/result_dialog.py
@@ -1954,8 +1954,8 @@ class ResultDialog(QDialog):
                     flags |= re.MULTILINE
                 regex = re.compile(pattern_str, flags)
                 text = regex.sub(r'*\g<0>*', text)
-            except re.error:
-                pass
+            except re.error as _re_exc:
+                logger.debug("result_dialog: invalid highlight regex %r: %s", pattern_str, _re_exc)
         return text
 
     def open_external_link(self):
@@ -2199,8 +2199,8 @@ class ResultDialog(QDialog):
                     flags |= re.MULTILINE
                 regex = re.compile(pattern_str, flags)
                 ms_raw = regex.sub(r'*\g<0>*', ms_raw)
-            except re.error:
-                pass
+            except re.error as _re_exc:
+                logger.debug("result_dialog: invalid highlight regex %r: %s", pattern_str, _re_exc)
 
         # Phase 999.4: route through gutter helper (source_text = raw `ms_raw`)
         apply_line_numbered_text(
@@ -2423,7 +2423,8 @@ class ResultDialog(QDialog):
                 regex = re.compile(pattern_str, flags)
                 highlighted_text = regex.sub(r'*\g<0>*', raw_text)
                 raw_text = highlighted_text
-            except re.error: pass
+            except re.error as _re_exc:
+                logger.debug("result_dialog: invalid highlight regex %r: %s", pattern_str, _re_exc)
 
         # Phase 999.4: route through gutter helper (source_text = raw `raw_text`)
         apply_line_numbered_text(

--- a/genizah_app.py
+++ b/genizah_app.py
@@ -5354,6 +5354,8 @@ class GenizahGUI(QMainWindow):
     # ── Visual Similarity ────────────────────────────────────────────
 
     _VS_SERVER_URL = "https://genizahsearch.com"
+    # Network timeout (seconds) for the synchronous Visual Similarity server fallback.
+    _VS_SERVER_HTTP_TIMEOUT = 15
 
     def _browse_view_visual_similarity(self):
         """REROUTED (Phase 109, D-10): open the Join Workbench with the Visual source auto-loaded."""
@@ -5944,7 +5946,7 @@ class GenizahGUI(QMainWindow):
         try:
             import urllib.request
             url = f'{self._VS_SERVER_URL}/api/visual_suggestions/{sys_id}?limit=200'
-            with urllib.request.urlopen(url, timeout=15) as resp:
+            with urllib.request.urlopen(url, timeout=self._VS_SERVER_HTTP_TIMEOUT) as resp:
                 data = json.loads(resp.read().decode())
             self._vs_cache.store(sys_id, data)
             return {s['alma_id'] for s in data}
@@ -17829,7 +17831,7 @@ class GenizahGUI(QMainWindow):
                 _lab_corpus_scope = self.corpus_scope_combo.currentData() or "genizah"
             self.search_thread = LabSearchThread(self.lab_engine, query, mode, gap, deep_scan=deep, scan_limit=limit, corpus_scope=_lab_corpus_scope)
         else:
-            text_position = [None, 'start', 'end', 'line_start', 'line_end'][self.text_position_combo.currentIndex()]
+            text_position = self._text_position_from_index(self.text_position_combo.currentIndex())
             # Phase 95 smoke-fix (item 2): read corpus scope from pre-search dropdown.
             _corpus_scope = "genizah"
             if hasattr(self, 'corpus_scope_combo'):
@@ -18391,7 +18393,10 @@ class GenizahGUI(QMainWindow):
             else:
                 _modes = ['literal', 'variants', None, 'fuzzy', 'Regex', 'Title', 'Shelfmark']
                 mode_val = _modes[mode_idx] if mode_idx < len(_modes) else 'literal'
-            text_position = [None, 'start', 'end', 'line_start', 'line_end'][self.text_position_combo.currentIndex()] if hasattr(self, 'text_position_combo') else None
+            text_position = (
+                self._text_position_from_index(self.text_position_combo.currentIndex())
+                if hasattr(self, 'text_position_combo') else None
+            )
             step = RefinementStep(
                 query=self.query_input.text().strip(),
                 mode=mode_val or 'exact',
@@ -19017,10 +19022,34 @@ class GenizahGUI(QMainWindow):
         except Exception:
             pass
 
+    @staticmethod
+    def _local_filter_state_index(states, value):
+        """Return the index of ``value`` in ``states``, or 0 if unknown.
+
+        Guards against a corrupt restored session leaving the LOCAL filter
+        state at a value not in ``states`` (which would otherwise raise
+        ValueError from list.index on the next cycle).
+        """
+        return states.index(value) if value in states else 0
+
+    # Text-position options for the search text_position_combo, in combo order.
+    _TEXT_POSITION_OPTS = [None, 'start', 'end', 'line_start', 'line_end']
+
+    @classmethod
+    def _text_position_from_index(cls, i):
+        """Map a combo index to its text-position option, or None if out of range.
+
+        QComboBox.currentIndex() returns -1 when nothing is selected; a bare
+        list subscript would then silently return the LAST element
+        ('line_end'). Returns None for -1 / any out-of-range index.
+        """
+        opts = cls._TEXT_POSITION_OPTS
+        return opts[i] if 0 <= i < len(opts) else None
+
     def _toggle_local_filter_search(self):
         """Cycle the LOCAL filter state for the Search surface (D-10 / D-39)."""
         states = ['all', 'only_local', 'no_local']
-        cur = states.index(self._local_filter_state_search)
+        cur = self._local_filter_state_index(states, self._local_filter_state_search)
         self._local_filter_state_search = states[(cur + 1) % 3]
         self._update_local_filter_btn_search()
         self._apply_results_table_filters()
@@ -19029,7 +19058,7 @@ class GenizahGUI(QMainWindow):
     def _toggle_local_filter_composition(self):
         """Cycle the LOCAL filter state for the Composition surface (D-10 / D-39)."""
         states = ['all', 'only_local', 'no_local']
-        cur = states.index(self._local_filter_state_composition)
+        cur = self._local_filter_state_index(states, self._local_filter_state_composition)
         self._local_filter_state_composition = states[(cur + 1) % 3]
         self._update_local_filter_btn_composition()
         self._apply_comp_tree_filters()
@@ -19038,7 +19067,7 @@ class GenizahGUI(QMainWindow):
     def _toggle_local_filter_parallels(self):
         """Cycle the LOCAL filter state for the Parallels surface (D-10 / D-39)."""
         states = ['all', 'only_local', 'no_local']
-        cur = states.index(self._local_filter_state_parallels)
+        cur = self._local_filter_state_index(states, self._local_filter_state_parallels)
         self._local_filter_state_parallels = states[(cur + 1) % 3]
         self._update_local_filter_btn_parallels()
         self._apply_comp_tree_filters()

--- a/genizah_core.py
+++ b/genizah_core.py
@@ -724,7 +724,11 @@ class LabEngine:
                 with open(Config.LAB_WEIGHTS_FILE, 'r', encoding='utf-8') as f:
                     self.dynamic_rank_map = json.load(f)
             except Exception:
-                pass  # Dynamic weights file corrupt or unreadable; use defaults
+                # Dynamic weights file corrupt or unreadable; keep defaults.
+                logging.getLogger(__name__).warning(
+                    'Failed to load dynamic weights from %s; using defaults',
+                    Config.LAB_WEIGHTS_FILE, exc_info=True,
+                )
 
         self._reload_lab_index()
         # CR-02 FIX: open LOCAL LAB side-index at startup so LAB-mode
@@ -1720,7 +1724,10 @@ class LabEngine:
                                 rec['chunk_hits'].append((i, chunk_text, match_score, ms_snip))
                             elif match_score > rec['chunk_hits'][_existing_idx][2]:
                                 rec['chunk_hits'][_existing_idx] = (i, chunk_text, match_score, ms_snip)
-                    except (KeyError, IndexError, TypeError): pass
+                    except (KeyError, IndexError, TypeError) as _dedup_exc:
+                        logging.getLogger(__name__).debug(
+                            "lab_composition_search: skipped chunk-hit dedup entry: %r", _dedup_exc
+                        )
         except InterruptedError:
             was_interrupted = True
 
@@ -1857,11 +1864,15 @@ class LabEngine:
                                         _rec['chunk_hits'][_existing_llb] = (
                                             _i, _chunk_text, _match_score, _ms_snip
                                         )
-                            except (KeyError, IndexError, TypeError):
-                                pass
+                            except (KeyError, IndexError, TypeError) as _dedup_llb_exc:
+                                logging.getLogger(__name__).debug(
+                                    "lab_composition_search: skipped LOCAL-LAB chunk-hit dedup entry: %r",
+                                    _dedup_llb_exc,
+                                )
             except Exception as _local_lab_exc:
-                LOGGER.warning(
-                    "lab_composition_search: LOCAL LAB scan failed: %r", _local_lab_exc
+                logging.getLogger(__name__).warning(
+                    "lab_composition_search: LOCAL LAB scan failed: %r", _local_lab_exc,
+                    exc_info=True,
                 )
 
         # (Part 3: Result Processing) - runs even if interrupted to return partial results
@@ -2284,7 +2295,6 @@ def _strip_library_prefix(query: str) -> str:
 class Config:
     """Static paths and limits used by the application and by bundled binaries."""
 
-#    @staticmethod
     def _pick_writable_dir(primary: str, fallback: str) -> str:
         """
         Prefer primary; if we cannot create/write there, use fallback.
@@ -2305,7 +2315,6 @@ class Config:
         os.makedirs(fallback, exist_ok=True)
         return fallback
 
-#    @staticmethod
     def _get_documents_dir() -> str:
         """Best-effort Documents directory (Windows-aware), falling back to home."""
         documents_dir = None
@@ -3819,6 +3828,13 @@ class _BoundedLRUCache:
 # ==============================================================================
 #  METADATA MANAGER
 # ==============================================================================
+# Per-operation network timeouts (seconds). Named so each remote dependency can
+# be tuned independently rather than sharing one opaque literal.
+MARC_FUTURE_TIMEOUT = 15          # await fetch_marc_data() future result
+NLI_IIIF_FUTURE_TIMEOUT = 15      # await fetch_iiif_manifest() future result
+EXTERNAL_IIIF_HTTP_TIMEOUT = 5    # external IIIF manifest GET (Figgy/CUDL etc.)
+
+
 class MetadataManager:
     def _make_session(self):
         return requests.Session()
@@ -4601,7 +4617,7 @@ class MetadataManager:
 
         # Await MARC result first (needed for external IIIF logic below)
         try:
-            marc_data = marc_future.result(timeout=15)
+            marc_data = marc_future.result(timeout=MARC_FUTURE_TIMEOUT)
         except Exception:
             marc_data = {}  # Network/parse failure; proceed with empty metadata
         current_meta['marc'] = marc_data
@@ -4744,7 +4760,7 @@ class MetadataManager:
 
         # Await NLI IIIF manifest (submitted concurrently with MARC above)
         try:
-            nli_iiif_data = iiif_future.result(timeout=15)
+            nli_iiif_data = iiif_future.result(timeout=NLI_IIIF_FUTURE_TIMEOUT)
         except Exception:
             nli_iiif_data = {}  # Network/parse failure; proceed with empty metadata
         if nli_iiif_data.get('canvas_map'):
@@ -4901,7 +4917,7 @@ class MetadataManager:
             # 260421 follow-up (L81 lag): 10s was overkill — Figgy/CUDL
             # normally respond in <2s. Shorten so a slow external host
             # does not gate the whole browse navigation.
-            resp = session.get(manifest_url, timeout=5)
+            resp = session.get(manifest_url, timeout=EXTERNAL_IIIF_HTTP_TIMEOUT)
             if resp.status_code == 200:
                 data = resp.json()
 
@@ -7123,6 +7139,12 @@ def _expand_inline_alternation(pattern_str: str) -> str:
 # ==============================================================================
 #  SEARCH ENGINE
 # ==============================================================================
+# Reciprocal Rank Fusion constant (D-08 Codex P0): BM25 scores from two
+# independent indexes are not comparable, so LOCAL + Genizah hits are fused by
+# rank. k=60 is the Cormack/Clarke (2009) default.
+RRF_K = 60
+
+
 class SearchEngine:
     """Run searches, build queries, and provide browsing utilities."""
     def __init__(self, meta_mgr, variants_mgr):
@@ -7664,7 +7686,7 @@ class SearchEngine:
             "full_header": full_header,
         }
 
-    def _rrf_merge(self, genizah_hits, local_hits, k: int = 60, limit=None):
+    def _rrf_merge(self, genizah_hits, local_hits, k: int = RRF_K, limit=None):
         """Reciprocal Rank Fusion merger (D-08 Codex P0). BM25 scores from two
         independent indexes are NOT comparable; RRF fuses by rank (Cormack/Clarke 2009).
 
@@ -9377,7 +9399,7 @@ class SearchEngine:
                 )
                 local_hits = []
             if local_hits:
-                deduped = self._rrf_merge(deduped, local_hits, k=60)
+                deduped = self._rrf_merge(deduped, local_hits, k=RRF_K)
         # End Phase 95 D-08 LOCAL merge.
 
         # --- Apply Exclusion Filter (NOT Filter) ---

--- a/gui_threads.py
+++ b/gui_threads.py
@@ -19,7 +19,7 @@ def _prevent_sleep():
             ES_SYSTEM_REQUIRED = 0x00000001
             ctypes.windll.kernel32.SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED)
         except Exception:
-            pass
+            logger.debug("_prevent_sleep: SetThreadExecutionState failed", exc_info=True)
 
 
 def _allow_sleep():
@@ -29,7 +29,7 @@ def _allow_sleep():
             ES_CONTINUOUS = 0x80000000
             ctypes.windll.kernel32.SetThreadExecutionState(ES_CONTINUOUS)
         except Exception:
-            pass
+            logger.debug("_allow_sleep: SetThreadExecutionState failed", exc_info=True)
 
 class IndexerThread(QThread):
     """Build or refresh the index without blocking the UI."""

--- a/tests/test_audit_2026_06_23_guards.py
+++ b/tests/test_audit_2026_06_23_guards.py
@@ -1,0 +1,228 @@
+# -*- coding: utf-8 -*-
+"""Guards & exception-hygiene regressions for the 2026-06-23 audit (SEED-013).
+
+Covers:
+  #12  GenizahGUI._local_filter_state_index — unknown restored state -> 0
+       (no ValueError from list.index on the next filter cycle).
+  #13  GenizahGUI._text_position_from_index — combo currentIndex() == -1 or
+       out-of-range -> None (no silent last-element 'line_end' wrap).
+  #7   Silent swallows now log + fall back:
+         - LabEngine corrupt dynamic-weights file -> logs WARNING, keeps defaults.
+         - chunk-hit dedup / LOCAL-LAB dedup / LOCAL-LAB scan swallows now log
+           (verified at the source level — these branches are deep inside
+           lab_composition_search and only fire mid-search against a live index).
+         - desktop/result_dialog regex-highlight re.error sites now log.
+
+The #12/#13 helpers are @staticmethod / @classmethod, so they are exercised off
+the class WITHOUT building a QApplication (importing genizah_app under the
+conftest-set offscreen Qt platform is enough). The deep dedup branches are
+asserted structurally via AST so this file is CI-safe (no widget construction).
+"""
+from __future__ import annotations
+
+import ast
+import logging
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+# ---------------------------------------------------------------------------
+# #12 — _local_filter_state_index normalizes unknown -> default (0)
+# ---------------------------------------------------------------------------
+def _gui_cls():
+    import genizah_app
+    return genizah_app.GenizahGUI
+
+
+STATES = ['all', 'only_local', 'no_local']
+
+
+@pytest.mark.parametrize("value,expected", [
+    ('all', 0),
+    ('only_local', 1),
+    ('no_local', 2),
+])
+def test_local_filter_state_index_known(value, expected):
+    assert _gui_cls()._local_filter_state_index(STATES, value) == expected
+
+
+@pytest.mark.parametrize("value", ['', 'bogus', None, 'ALL', 42])
+def test_local_filter_state_index_unknown_returns_default_not_raises(value):
+    # A corrupt restored session value must normalize to 0, never raise.
+    assert _gui_cls()._local_filter_state_index(STATES, value) == 0
+
+
+def test_local_filter_state_index_cycle_is_safe_from_corrupt_value():
+    # Simulate the cycle arithmetic with a corrupt stored value.
+    cur = _gui_cls()._local_filter_state_index(STATES, 'corrupt')
+    nxt = STATES[(cur + 1) % 3]
+    assert nxt == 'only_local'  # 0 -> 1
+
+
+# ---------------------------------------------------------------------------
+# #13 — _text_position_from_index guards -1 / out-of-range -> None
+# ---------------------------------------------------------------------------
+def test_text_position_from_index_minus_one_is_none():
+    # QComboBox.currentIndex() == -1 (no selection) must NOT wrap to 'line_end'.
+    assert _gui_cls()._text_position_from_index(-1) is None
+
+
+@pytest.mark.parametrize("i,expected", [
+    (0, None),          # the explicit None option
+    (1, 'start'),
+    (2, 'end'),
+    (3, 'line_start'),
+    (4, 'line_end'),
+])
+def test_text_position_from_index_valid(i, expected):
+    assert _gui_cls()._text_position_from_index(i) == expected
+
+
+@pytest.mark.parametrize("i", [5, 99, -2, -100])
+def test_text_position_from_index_out_of_range_is_none(i):
+    assert _gui_cls()._text_position_from_index(i) is None
+
+
+# ---------------------------------------------------------------------------
+# #7 — LabEngine corrupt dynamic-weights file: log WARNING, keep defaults
+# ---------------------------------------------------------------------------
+def test_corrupt_dynamic_weights_logs_and_falls_back(caplog):
+    import genizah_core as gc
+    with patch.object(gc.LabEngine, '_reload_lab_index'), \
+         patch.object(gc.LabEngine, 'reload_local_lab_index'), \
+         patch('os.path.exists', return_value=True), \
+         patch('builtins.open', side_effect=ValueError("corrupt weights")):
+        with caplog.at_level(logging.WARNING, logger='genizah_core'):
+            eng = gc.LabEngine(MagicMock(), MagicMock())
+    # Defaults preserved (load failed silently before this fix).
+    assert eng.dynamic_rank_map is None
+    assert any('dynamic weights' in r.getMessage().lower() for r in caplog.records), \
+        "corrupt dynamic-weights load must emit a WARNING"
+
+
+# ---------------------------------------------------------------------------
+# #7 — source-level: deep swallow sites now log instead of bare `pass`.
+# These except-branches fire only mid-search against a live Tantivy index, so
+# they are asserted structurally (the codebase uses AST guards for the same
+# reason elsewhere). We require: the handler body contains a logging call and
+# is NOT a bare `pass`.
+# ---------------------------------------------------------------------------
+def _handlers_in_func(tree: ast.AST, func_name: str):
+    out = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == func_name:
+            for h in ast.walk(node):
+                if isinstance(h, ast.ExceptHandler):
+                    out.append(h)
+    return out
+
+
+def _handler_logs(handler: ast.ExceptHandler) -> bool:
+    for n in ast.walk(handler):
+        if isinstance(n, ast.Call):
+            f = n.func
+            # logging.getLogger(...).warning/debug(...) OR logger.debug(...) etc.
+            if isinstance(f, ast.Attribute) and f.attr in {
+                'debug', 'info', 'warning', 'error', 'exception', 'critical'
+            }:
+                return True
+    return False
+
+
+def _handler_is_bare_pass(handler: ast.ExceptHandler) -> bool:
+    return len(handler.body) == 1 and isinstance(handler.body[0], ast.Pass)
+
+
+def _handler_excepts_types(handler: ast.ExceptHandler, names: set[str]) -> bool:
+    t = handler.type
+    if t is None:
+        return False
+    elts = t.elts if isinstance(t, ast.Tuple) else [t]
+    got = {e.id for e in elts if isinstance(e, ast.Name)}
+    return got == names
+
+
+def test_lab_composition_search_dedup_swallows_now_log():
+    """#7: the two (KeyError, IndexError, TypeError) chunk-hit dedup handlers in
+    lab_composition_search must log (formerly bare `pass`). There are two — the
+    main composition path and the LOCAL-LAB branch sibling."""
+    src = (ROOT / "genizah_core.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    handlers = _handlers_in_func(tree, "lab_composition_search")
+    assert handlers, "lab_composition_search not found"
+    dedup = [h for h in handlers
+             if _handler_excepts_types(h, {"KeyError", "IndexError", "TypeError"})]
+    assert len(dedup) == 2, f"expected 2 dedup handlers, found {len(dedup)}"
+    for h in dedup:
+        assert not _handler_is_bare_pass(h), "dedup handler still a bare `pass`"
+        assert _handler_logs(h), "dedup handler must log before continuing"
+
+
+def test_lab_composition_search_local_lab_scan_logs_exc_info():
+    """#7: the broad LOCAL-LAB scan handler logs WITH exc_info (logging-only;
+    return shape unchanged — no degraded flag added by decision)."""
+    src = (ROOT / "genizah_core.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    handlers = _handlers_in_func(tree, "lab_composition_search")
+    # The LOCAL-LAB scan handler binds `_local_lab_exc`.
+    scan = [h for h in handlers if h.name == "_local_lab_exc"]
+    assert len(scan) == 1, "LOCAL-LAB scan handler not found"
+    h = scan[0]
+    assert _handler_logs(h), "LOCAL-LAB scan handler must log"
+    # exc_info=True present on the logging call.
+    has_exc_info = any(
+        isinstance(n, ast.Call) and any(
+            kw.arg == "exc_info" for kw in n.keywords
+        ) for n in ast.walk(h)
+    )
+    assert has_exc_info, "LOCAL-LAB scan log should pass exc_info=True"
+
+
+def test_result_dialog_regex_error_sites_log():
+    """#7: the three re.error highlight handlers in result_dialog now log."""
+    src = (ROOT / "desktop" / "result_dialog.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    re_error_handlers = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ExceptHandler) and node.type is not None:
+            # match `except re.error ...`
+            t = node.type
+            if isinstance(t, ast.Attribute) and t.attr == 'error' and \
+               isinstance(t.value, ast.Name) and t.value.id == 're':
+                re_error_handlers.append(node)
+    # Highlight sites the audit targeted (3 of the re.error handlers; the 4th is
+    # an early `return` guard, not a swallow). Require at least 3 that log.
+    logging_re_handlers = [h for h in re_error_handlers if _handler_logs(h)]
+    assert len(logging_re_handlers) >= 3, (
+        f"expected >=3 logging re.error handlers, found {len(logging_re_handlers)} "
+        f"of {len(re_error_handlers)} total"
+    )
+
+
+# ---------------------------------------------------------------------------
+# #39 — gui_threads sleep-prevention handlers log (debug) instead of pass.
+# ---------------------------------------------------------------------------
+def test_sleep_prevention_handlers_log():
+    src = (ROOT / "gui_threads.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    for fn in ("_prevent_sleep", "_allow_sleep"):
+        handlers = _handlers_in_func(tree, fn)
+        assert handlers, f"{fn} not found"
+        for h in handlers:
+            assert not _handler_is_bare_pass(h), f"{fn}: bare-pass handler remains"
+            assert _handler_logs(h), f"{fn}: handler must log"
+
+
+# ---------------------------------------------------------------------------
+# #32 — RRF_K constant replaces magic 60 (default arg + module constant).
+# ---------------------------------------------------------------------------
+def test_rrf_k_constant_value_and_default_arg():
+    import inspect
+    import genizah_core as gc
+    assert gc.RRF_K == 60
+    sig = inspect.signature(gc.SearchEngine._rrf_merge)
+    assert sig.parameters['k'].default == gc.RRF_K

--- a/tests/test_local_post_dedup_merge.py
+++ b/tests/test_local_post_dedup_merge.py
@@ -13,6 +13,8 @@ import ast
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from genizah_core import RRF_K
+
 
 # ---------------------------------------------------------------------------
 # Helper — bare SearchEngine instance (no real index required)
@@ -84,7 +86,7 @@ def test_local_hit_after_dedup_survives():
 
     # Simulate the post-dedup merge
     deduped = engine._deduplicate(genizah_hits)  # V0.8 survive
-    merged = engine._rrf_merge(deduped, local_hits, k=60)
+    merged = engine._rrf_merge(deduped, local_hits, k=RRF_K)
 
     uids = [r["uid"] for r in merged]
     assert "l1" in uids, "LOCAL hit merged AFTER _deduplicate must survive"

--- a/tests/test_side_index_merge.py
+++ b/tests/test_side_index_merge.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+from genizah_core import RRF_K
+
 
 # ---------------------------------------------------------------------------
 # Helper — bare SearchEngine instance
@@ -40,14 +42,14 @@ def _hit(uid: str, source: str = "V0.8") -> dict:
 # ---------------------------------------------------------------------------
 
 def test_rrf_merge_genizah_plus_local():
-    """REQ-3 + D-08: merge Genizah and LOCAL search results via RRF (k=60).
+    """REQ-3 + D-08: merge Genizah and LOCAL search results via RRF (k=RRF_K).
     With 2 Genizah + 2 LOCAL hits, all 4 appear in merged output.
     """
     engine = _make_engine()
     genizah_hits = [_hit("g1"), _hit("g2")]
     local_hits = [_hit("l1", "LOCAL"), _hit("l2", "LOCAL")]
 
-    merged = engine._rrf_merge(genizah_hits, local_hits, k=60)
+    merged = engine._rrf_merge(genizah_hits, local_hits, k=RRF_K)
 
     assert len(merged) == 4, f"Expected 4 merged hits, got {len(merged)}"
     uids = [r["uid"] for r in merged]
@@ -59,7 +61,7 @@ def test_rrf_merge_empty_local():
     engine = _make_engine()
     genizah_hits = [_hit("g1"), _hit("g2")]
 
-    merged = engine._rrf_merge(genizah_hits, [], k=60)
+    merged = engine._rrf_merge(genizah_hits, [], k=RRF_K)
 
     assert [r["uid"] for r in merged] == ["g1", "g2"]
 
@@ -69,7 +71,7 @@ def test_rrf_merge_empty_genizah():
     engine = _make_engine()
     local_hits = [_hit("l1", "LOCAL"), _hit("l2", "LOCAL")]
 
-    merged = engine._rrf_merge([], local_hits, k=60)
+    merged = engine._rrf_merge([], local_hits, k=RRF_K)
 
     assert [r["uid"] for r in merged] == ["l1", "l2"]
 
@@ -80,7 +82,7 @@ def test_rrf_score_uses_reciprocal_rank():
     genizah_hits = [_hit("g1")]
     local_hits = []
 
-    merged = engine._rrf_merge(genizah_hits, local_hits, k=60)
+    merged = engine._rrf_merge(genizah_hits, local_hits, k=RRF_K)
 
     assert len(merged) == 1
     assert merged[0]["uid"] == "g1"
@@ -100,13 +102,13 @@ def test_rrf_tiebreak_genizah_first():
     local_hits = [_hit("l_uid", "LOCAL")]
 
     # Both lists have 1 element at rank=1 → identical RRF score 1/(60+1).
-    result_a = engine._rrf_merge(genizah_hits, local_hits, k=60)
+    result_a = engine._rrf_merge(genizah_hits, local_hits, k=RRF_K)
     assert [r["uid"] for r in result_a] == ["g_uid", "l_uid"], (
         "Genizah-first tie-break violated when genizah passed as first arg"
     )
 
     # Reverse argument order — tie-break must still apply.
-    result_b = engine._rrf_merge(local_hits, genizah_hits, k=60)
+    result_b = engine._rrf_merge(local_hits, genizah_hits, k=RRF_K)
     assert [r["uid"] for r in result_b] == ["g_uid", "l_uid"], (
         "Genizah-first tie-break is supposed to be order-independent; "
         "argument order should not change outcome on tied scores"
@@ -124,7 +126,7 @@ def test_rrf_does_not_blanket_prioritize_genizah():
     genizah_hits = [_hit(f"g_{i}", "V0.8") for i in range(10)]
     local_hits = [_hit("l_uid", "LOCAL")]
 
-    result = engine._rrf_merge(genizah_hits, local_hits, k=60)
+    result = engine._rrf_merge(genizah_hits, local_hits, k=RRF_K)
 
     l_pos = next(i for i, r in enumerate(result) if r["uid"] == "l_uid")
     g9_pos = next(i for i, r in enumerate(result) if r["uid"] == "g_9")


### PR DESCRIPTION
Observability + safe fallbacks + mechanical cleanup across `genizah_core.py`, `genizah_app.py`, `desktop/result_dialog.py`, `gui_threads.py`. **No behavior change except added logging/guards.**

## SEED-013 — guards & exception hygiene
- **#12** `GenizahGUI._local_filter_state_index` helper — corrupt restored LOCAL filter state normalizes unknown→default (0) instead of raising `ValueError` from `list.index`. Wired at search/composition/parallels cycle sites.
- **#13** `GenizahGUI._text_position_from_index` helper — combo `currentIndex()==-1` / out-of-range → `None` instead of silently returning the last element (`'line_end'`). Wired at the search-launch and refinement-step sites.
- **#7** silent swallows → targeted logging + safe fallback:
  - corrupt dynamic-weights load → `WARNING` (exc_info), keeps defaults
  - chunk-hit dedup + its LOCAL-LAB sibling → debug log before continue (both)
  - LOCAL-LAB scan failure → `WARNING` with exc_info (**logging-only**; return shape unchanged, no degraded flag — deferred by decision)
  - `result_dialog` `re.error` highlight sites (×3) → debug log the bad pattern
- **#39** `gui_threads` sleep-prevention handlers → `logger.debug(exc_info=True)`

## SEED-018 core slice — cleanup
- **#32** extracted `RRF_K = 60` module constant; replaced `_rrf_merge` default arg + call site; tests reference `RRF_K`.
- **#34** named per-operation network-timeout constants (`MARC_FUTURE_TIMEOUT`, `NLI_IIIF_FUTURE_TIMEOUT`, `EXTERNAL_IIIF_HTTP_TIMEOUT`; `_VS_SERVER_HTTP_TIMEOUT` in genizah_app) — replaced magic `timeout=15`/`5` literals.
- **#40** deleted dead commented-out `@staticmethod` lines in `Config` (left the `tantivy >= 0.26` TODO untouched).

## Tests
- `tests/test_audit_2026_06_23_guards.py` — #12 default-not-raise, #13 −1/out-of-range→None, #7 weights caplog fallback + dedup/LOCAL-LAB/result_dialog/sleep log assertions, RRF_K constant.
- Updated `tests/test_local_post_dedup_merge.py` + `tests/test_side_index_merge.py` to reference `RRF_K`.
- `pytest` on the audit + both RRF suites: **34 passed**. Caller suites (lab composition, corpus scope, NLI breaker, local index fallback, local-lab invalidation, phase-97 invariants, browse, batched-progress): **151 passed**. `ruff check` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GnvGb31t729NCZbnUQXS6