### PR TITLE
SEED-021: image-fetch observability + desktop viewer polish

### DIFF
--- a/desktop/join_workbench.py
+++ b/desktop/join_workbench.py
@@ -495,7 +495,7 @@ try:
         QWidget, QLineEdit, QInputDialog, QMessageBox,
         QCheckBox, QMenu, QComboBox, QListWidget, QListWidgetItem,
     )
-    from PyQt6.QtCore import Qt, QThread, pyqtSignal
+    from PyQt6.QtCore import Qt, QThread, pyqtSignal, QTimer
     from PyQt6.QtGui import QPalette, QPixmap, QImage
     from desktop.image_loader import ImageLoaderThread
     from desktop.widgets.line_number_text_edit import apply_line_numbered_text
@@ -1775,6 +1775,18 @@ if _QT_AVAILABLE:
             self.img.setAlignment(Qt.AlignmentFlag.AlignCenter)
             self.img.setStyleSheet("background:#e2e8f0;color:#64748b;")
             lay.addWidget(self.img)
+            # Audit #43: web uses an animated skeleton while the candidate
+            # thumbnail loads. Minimal desktop parity — a lightweight animated
+            # "loading…" with cycling dots driven by a QTimer (no pixmap churn,
+            # no extra threads). The pump replaces the text with a pixmap or
+            # "(no image)" once done; the animator stops itself then.
+            self._loading_frame = 0
+            self._loading_timer = QTimer(self)
+            self._loading_timer.setInterval(350)
+            self._loading_timer.timeout.connect(self._tick_loading_anim)
+            # Initial thumbnail load is driven by ThumbResolver (see pane render);
+            # start animating immediately so the placeholder isn't static.
+            self._start_loading_anim()
 
             # 2. Shelfmark + provenance badge
             shelf_text = c.shelfmark
@@ -2076,7 +2088,7 @@ if _QT_AVAILABLE:
             """
             try:
                 self._folio_lbl.setText(f"p.{self._card_page}")
-                self.img.setText(tr("loading…"))
+                self._start_loading_anim()
             except RuntimeError:
                 return
             try:
@@ -2085,6 +2097,55 @@ if _QT_AVAILABLE:
                 )
             except Exception:
                 pass
+
+        def _start_loading_anim(self):
+            """Audit #43: begin the lightweight loading animation on self.img.
+
+            Sets the initial placeholder text and starts a QTimer that cycles
+            the trailing dots. The image pump (`_pump_images`) replaces the text
+            with a pixmap or "(no image)" when the fetch resolves; the tick then
+            detects the pixmap and stops itself.
+            """
+            self._loading_frame = 0
+            try:
+                self.img.setText(tr("loading…"))
+                if not self._loading_timer.isActive():
+                    self._loading_timer.start()
+            except RuntimeError:
+                pass
+
+        def _tick_loading_anim(self):
+            """Audit #43: cycle the loading dots; self-stop once the pump has
+            replaced the placeholder with a pixmap or a terminal text.
+
+            The animator only owns the text while it equals one of the frames it
+            itself produced (``loading…`` or ``loading``+dots). If the pump has
+            swapped in a pixmap, ``""`` (about to set a pixmap), or ``(no
+            image)``, the text no longer matches and the timer stops — it never
+            clobbers a real result.
+            """
+            try:
+                pm = self.img.pixmap()
+                if pm is not None and not pm.isNull():
+                    self._loading_timer.stop()
+                    return
+                cur = self.img.text()
+                # Reuse the existing tr("loading…") key (no new untranslated
+                # key) and animate by varying the count of trailing dots after
+                # the base label (the base already ends in an ellipsis glyph).
+                base = tr("loading…")
+                own_frames = {base + "." * n for n in range(4)}
+                if cur not in own_frames:
+                    # Pump set terminal text (e.g. "(no image)") or cleared it.
+                    self._loading_timer.stop()
+                    return
+                self._loading_frame = (self._loading_frame + 1) % 4
+                self.img.setText(base + "." * self._loading_frame)
+            except RuntimeError:
+                try:
+                    self._loading_timer.stop()
+                except RuntimeError:
+                    pass
 
         def _refresh_card_text(self):
             """Fetch the page text for the current _card_page on a background worker.
@@ -3867,7 +3928,16 @@ if _QT_AVAILABLE:
             btn_zoom_in.setFixedSize(26, 22)
             btn_zoom_in.setToolTip(tr("Zoom in"))
             btn_zoom_in.setAccessibleName(tr("Zoom in"))
+            # Audit #42: zoom-% label (parity with the web Compare panes, which
+            # show a live zoom percentage). Updated on every zoom change.
+            zoom_lbl = QLabel("100%")
+            zoom_lbl.setStyleSheet(f"font-size:10px;color:{_META_COLOR};")
+            zoom_lbl.setMinimumWidth(36)
+            zoom_lbl.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            zoom_lbl.setToolTip(tr("Zoom level"))
+            zoom_lbl.setAccessibleName(tr("Zoom level"))
             ctrl_row.addWidget(btn_zoom_out)
+            ctrl_row.addWidget(zoom_lbl)
             ctrl_row.addWidget(btn_zoom_in)
 
             img = QLabel(tr("…"))
@@ -3902,6 +3972,7 @@ if _QT_AVAILABLE:
                 "folio_prev": folio_prev,
                 "folio_lbl": folio_lbl,
                 "folio_next": folio_next,
+                "zoom_lbl": zoom_lbl,
                 "img": img,
                 "img_scroll": img_scroll,
                 "txt": txt,
@@ -3934,9 +4005,16 @@ if _QT_AVAILABLE:
             pannable scroll area can pan a zoomed image (mirrors window._apply_zoom)."""
             pix = pane.get("full_pix")
             lbl = pane.get("img")
+            z = pane.get("zoom", 1.0) or 1.0
+            # Audit #42: keep the zoom-% label in sync on every render/zoom.
+            zoom_lbl = pane.get("zoom_lbl")
+            if zoom_lbl is not None:
+                try:
+                    zoom_lbl.setText(f"{int(round(z * 100))}%")
+                except RuntimeError:
+                    pass
             if pix is None or lbl is None:
                 return
-            z = pane.get("zoom", 1.0) or 1.0
             try:
                 scaled = pix.scaled(
                     max(1, int(pix.width() * z)),

--- a/genizah_translations.py
+++ b/genizah_translations.py
@@ -1769,6 +1769,7 @@ TRANSLATIONS = {
     "Zoom": "זום",
     "Zoom in": "הגדל",
     "Zoom out": "הקטן",
+    "Zoom level": "רמת זום",
     "Reset zoom": "אפס זום",
     "Fit to width": "התאם לרוחב",
     "Fit to height": "התאם לגובה",

--- a/tests/test_audit_2026_06_23_image_obs.py
+++ b/tests/test_audit_2026_06_23_image_obs.py
@@ -1,0 +1,285 @@
+# -*- coding: utf-8 -*-
+"""SEED-021 — image-fetch observability + viewer-polish audit tests.
+
+Covers:
+  #23 — fetch_fl_ids_from_nli persists a LOCK-CONSISTENT cache snapshot
+        (the snapshot is copied inside the same critical section as the update,
+        passed into _persist_positive_cache_snapshot).
+  #36 — nli_image logs non-200/non-429/non-5xx statuses (404 / unexpected 4xx)
+        at debug for both the IIIF and Rosetta fetch handlers.
+  #37 — resolve_external_images warning includes exc_info (stack trace).
+  #38 — resolve_external_images warns when invoked on the asyncio event loop.
+
+State isolation for the web.api closures is provided by the module fixtures
+below (mirrors tests/test_api_nli_breaker_integration.py).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+
+
+# ─── web.api closure seam fixtures (mirrors test_api_nli_breaker_integration) ────
+
+class _MockResponse:
+    def __init__(self, status_code=200, content=b'', headers=None, text='', json_data=None):
+        self.status_code = status_code
+        self.content = content
+        self.headers = headers or {}
+        self.text = text
+        self._json_data = json_data or {}
+
+    def json(self):
+        return self._json_data
+
+
+@pytest.fixture(scope='module', autouse=True)
+def _initialize_api_routes():
+    from web.api import init_api_routes
+    bare = FastAPI()
+    init_api_routes(app_override=bare)
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _clear_nli_in_memory_cache():
+    from web.api import _api_test_seam
+    fn = _api_test_seam.get('fetch_fl_ids_from_nli')
+    if fn is not None and fn.__closure__:
+        closure_vars = dict(zip(fn.__code__.co_freevars, fn.__closure__))
+        nli_cache = closure_vars.get('_nli_cache')
+        nli_cache_time = closure_vars.get('_nli_cache_time')
+        nli_cache_lock = closure_vars.get('_nli_cache_lock')
+        if nli_cache is not None and nli_cache_time is not None and nli_cache_lock is not None:
+            with nli_cache_lock.cell_contents:
+                nli_cache.cell_contents.clear()
+                nli_cache_time.cell_contents.clear()
+    yield
+
+
+def _seam(name):
+    from web.api import _api_test_seam
+    return _api_test_seam[name]
+
+
+# ─── #36 — nli_image non-200/non-429/non-5xx status logging ─────────────────────
+
+class TestNliImageStatusLogging:
+    """nli_image previously fell through 404/unexpected statuses silently."""
+
+    def test_iiif_404_logs_debug_and_falls_through(self, caplog):
+        nli_image = _seam('nli_image')
+        # IIIF 404 → debug log + fall through to Rosetta (also 404 here → final 404).
+        responses = [
+            _MockResponse(status_code=404),  # IIIF
+            _MockResponse(status_code=404),  # Rosetta
+        ]
+
+        def _fake_get(url, *a, **kw):
+            return responses.pop(0)
+
+        with caplog.at_level(logging.DEBUG, logger='web.api'):
+            with patch('web.api.requests.get', side_effect=_fake_get):
+                resp = nli_image('12345')
+
+        assert resp.status_code == 404
+        msgs = " ".join(r.getMessage() for r in caplog.records)
+        assert 'IIIF non-success status 404' in msgs
+        assert 'Rosetta non-success status 404' in msgs
+
+    def test_iiif_unexpected_3xx_logged(self, caplog):
+        nli_image = _seam('nli_image')
+        responses = [
+            _MockResponse(status_code=302),  # IIIF unexpected redirect status
+            _MockResponse(status_code=404),  # Rosetta
+        ]
+
+        def _fake_get(url, *a, **kw):
+            return responses.pop(0)
+
+        with caplog.at_level(logging.DEBUG, logger='web.api'):
+            with patch('web.api.requests.get', side_effect=_fake_get):
+                nli_image('99999')
+
+        msgs = " ".join(r.getMessage() for r in caplog.records)
+        assert 'IIIF non-success status 302' in msgs
+
+    def test_429_and_5xx_do_not_emit_fallthrough_debug(self, caplog):
+        """429/5xx are recorded as breaker failures, NOT the new fall-through log."""
+        nli_image = _seam('nli_image')
+        responses = [
+            _MockResponse(status_code=429),  # IIIF — breaker failure path
+            _MockResponse(status_code=503),  # Rosetta — breaker failure path
+        ]
+
+        def _fake_get(url, *a, **kw):
+            return responses.pop(0)
+
+        with caplog.at_level(logging.DEBUG, logger='web.api'):
+            with patch('web.api.requests.get', side_effect=_fake_get):
+                nli_image('55555')
+
+        msgs = " ".join(r.getMessage() for r in caplog.records)
+        assert 'non-success status' not in msgs
+
+
+# ─── #23 — lock-consistent persisted snapshot ───────────────────────────────────
+
+class TestPersistSnapshotConsistency:
+    """The persisted snapshot must reflect the cache AT update time, copied
+    inside the same critical section — not a re-locked read that could
+    interleave with a concurrent mutation."""
+
+    def test_snapshot_reflects_update_under_lock(self):
+        captured = {}
+
+        def _capture_save(cache_snapshot, cache_time_snapshot):
+            captured['cache'] = dict(cache_snapshot)
+            captured['time'] = dict(cache_time_snapshot)
+
+        manifest = _MockResponse(
+            status_code=200,
+            json_data={'sequences': [{'canvases': [
+                {'images': [{'resource': {'service': {
+                    '@id': 'https://iiif.nli.org.il/IIIFv21/FL7734473/info.json'}}}]},
+            ]}]},
+        )
+        with patch('web.api._save_nli_persistent_cache', side_effect=_capture_save):
+            # fetch_fl_ids_from_nli fetches the IIIF manifest via _nli_session.get.
+            with patch('web.api._nli_session.get', return_value=manifest):
+                fl_ids = _seam('fetch_fl_ids_from_nli')('sysid_snap_test')
+
+        assert fl_ids == ['7734473']
+        # The persisted snapshot must already contain the just-resolved entry —
+        # proving the snapshot was copied AFTER the in-lock update (consistent).
+        assert captured['cache'].get('sysid_snap_test') == ['7734473']
+        assert 'sysid_snap_test' in captured['time']
+
+    def test_persist_helper_accepts_passed_snapshot(self):
+        """The writer accepts an explicit pre-copied snapshot (the consistent path)."""
+        captured = {}
+
+        def _capture_save(cache_snapshot, cache_time_snapshot):
+            captured['cache'] = cache_snapshot
+            captured['time'] = cache_time_snapshot
+
+        snap = ({'k': ['1', '2']}, {'k': 123.0})
+        with patch('web.api._save_nli_persistent_cache', side_effect=_capture_save):
+            _seam('_persist_positive_cache_snapshot')(snap)
+
+        assert captured['cache'] == {'k': ['1', '2']}
+        assert captured['time'] == {'k': 123.0}
+
+    def test_persist_helper_self_locks_when_no_snapshot(self):
+        """Backward-compat: called with no arg, it still takes its own copy."""
+        captured = {}
+
+        def _capture_save(cache_snapshot, cache_time_snapshot):
+            captured['called'] = True
+
+        with patch('web.api._save_nli_persistent_cache', side_effect=_capture_save):
+            _seam('_persist_positive_cache_snapshot')()
+
+        assert captured.get('called') is True
+
+
+# ─── #37 / #38 — resolve_external_images observability ──────────────────────────
+
+class _FakeMetaMgrRaises:
+    def __init__(self):
+        self.nli_cache: dict = {}
+
+    def enrich_metadata(self, sys_id):
+        raise RuntimeError("NLI unreachable")
+
+
+class TestResolveExternalImagesObservability:
+    def test_enrich_failure_warning_has_exc_info(self, caplog):
+        """#37: the degraded-path warning must carry stack info (exc_info)."""
+        from web.components.image_resolution import resolve_external_images
+
+        mgr = _FakeMetaMgrRaises()
+        with caplog.at_level(logging.WARNING, logger='web.components.image_resolution'):
+            result = resolve_external_images('990025143260205171', meta_mgr=mgr)
+
+        # Degrades gracefully.
+        assert result['cambridge_images'] == []
+        # The warning record must include exception info (traceback attached).
+        warn_records = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING and 'enrich_metadata error' in r.getMessage()
+        ]
+        assert warn_records, "expected an enrich_metadata error warning"
+        assert any(r.exc_info is not None for r in warn_records), (
+            "the enrich_metadata warning must attach exc_info (#37)"
+        )
+
+    def test_warns_when_called_on_event_loop(self, caplog):
+        """#38: invoking on the asyncio event loop thread emits a warning."""
+        from web.components.image_resolution import resolve_external_images
+
+        mgr = _FakeMetaMgrRaises()
+
+        async def _run_on_loop():
+            with caplog.at_level(logging.WARNING, logger='web.components.image_resolution'):
+                # Runs synchronously on the running event loop → guard must fire.
+                resolve_external_images('990025143260205171', meta_mgr=mgr)
+            return [r.getMessage() for r in caplog.records]
+
+        messages = asyncio.run(_run_on_loop())
+        joined = " ".join(messages)
+        assert 'event-loop thread' in joined, (
+            "resolve_external_images must warn when run on the event loop (#38)"
+        )
+
+    def test_no_event_loop_warning_off_loop(self, caplog):
+        """#38: when NOT on the event loop (normal sync/io_bound), no guard warning."""
+        from web.components.image_resolution import resolve_external_images
+
+        mgr = _FakeMetaMgrRaises()
+        with caplog.at_level(logging.WARNING, logger='web.components.image_resolution'):
+            resolve_external_images('990025143260205171', meta_mgr=mgr)
+
+        joined = " ".join(r.getMessage() for r in caplog.records)
+        assert 'event-loop thread' not in joined
+
+
+# ─── #42 / #43 — desktop join_workbench viewer polish (source-level) ─────────────
+# GUI construction segfaults headless on Windows (see memory
+# feedback_full_suite_testing_windows); assert against the source instead.
+
+import pathlib  # noqa: E402
+
+_JW_SRC = (
+    pathlib.Path(__file__).resolve().parent.parent / 'desktop' / 'join_workbench.py'
+).read_text(encoding='utf-8')
+
+
+class TestDesktopViewerPolishSource:
+    def test_compare_pane_has_zoom_percent_label(self):
+        """#42: the Compare pane builds a zoom-% label wired into the pane dict."""
+        assert '"zoom_lbl": zoom_lbl' in _JW_SRC
+        # The label is updated to a percentage on render.
+        assert 'zoom_lbl.setText(f"{int(round(z * 100))}%")' in _JW_SRC
+
+    def test_zoom_label_updated_in_render_pane_image(self):
+        """#42: render path keeps the zoom-% label in sync on each zoom change."""
+        idx = _JW_SRC.index('def _render_pane_image')
+        body = _JW_SRC[idx:idx + 1200]
+        assert 'zoom_lbl' in body and 'setText' in body
+
+    def test_candidate_card_has_animated_loading_placeholder(self):
+        """#43: candidate card runs a QTimer-driven animated loading placeholder."""
+        assert '_loading_timer' in _JW_SRC
+        assert 'def _tick_loading_anim' in _JW_SRC
+        assert 'def _start_loading_anim' in _JW_SRC
+        # Animation reuses the existing tr("loading…") key (no new untranslated key).
+        assert 'base = tr("loading…")' in _JW_SRC
+
+    def test_qtimer_imported(self):
+        """#43: QTimer must be imported for the animator to construct."""
+        assert 'QTimer' in _JW_SRC

--- a/web/api.py
+++ b/web/api.py
@@ -630,10 +630,22 @@ def init_api_routes(app_override=None):
 
     _register_runtime_cache_stats('nli_fl_ids', _nli_memory_cache_stats)
 
-    def _persist_positive_cache_snapshot() -> None:
-        with _nli_cache_lock:
-            cache_snapshot = dict(_nli_cache)
-            cache_time_snapshot = dict(_nli_cache_time)
+    def _persist_positive_cache_snapshot(snapshot: tuple | None = None) -> None:
+        """Persist the positive NLI cache to disk.
+
+        Audit #23: callers that have just mutated the cache under
+        ``_nli_cache_lock`` should pass a snapshot copied *inside* that same
+        critical section (``(dict(_nli_cache), dict(_nli_cache_time))``) so the
+        persisted view is consistent with the update and cannot interleave with
+        a concurrent mutation between the unlock and the re-lock. When no
+        snapshot is supplied this falls back to taking its own locked copy.
+        """
+        if snapshot is None:
+            with _nli_cache_lock:
+                cache_snapshot = dict(_nli_cache)
+                cache_time_snapshot = dict(_nli_cache_time)
+        else:
+            cache_snapshot, cache_time_snapshot = snapshot
         _save_nli_persistent_cache(cache_snapshot, cache_time_snapshot)
 
     def fetch_fl_ids_from_nli(system_id: str, suffix: int = 1) -> list:
@@ -738,11 +750,15 @@ def init_api_routes(app_override=None):
                                 fl_ids.append(fl_match.group(1))
 
                 if fl_ids:
+                    # Audit #23: copy the snapshot INSIDE the same critical
+                    # section as the update so the persisted view is consistent
+                    # (no interleaving mutation between unlock and re-lock).
                     with _nli_cache_lock:
                         _nli_cache[cache_key] = fl_ids
                         _nli_cache_time[cache_key] = _time.time()
                         _prune_nli_memory_cache_locked(_time.time())
-                    _persist_positive_cache_snapshot()
+                        _cache_snapshot = (dict(_nli_cache), dict(_nli_cache_time))
+                    _persist_positive_cache_snapshot(_cache_snapshot)
                     logger.info(f"Resolved {len(fl_ids)} FL IDs for {cache_key} from network IIIF manifest")
                     # Phase 98 D-06/D-08: real success — close the breaker.
                     _nli_record_success(path='fetch_fl_ids_from_nli')
@@ -787,11 +803,13 @@ def init_api_routes(app_override=None):
                             seen.add(fl_id)
                             unique_fl_ids.append(fl_id)
                     if unique_fl_ids:
+                        # Audit #23: snapshot copied inside the lock (see above).
                         with _nli_cache_lock:
                             _nli_cache[cache_key] = unique_fl_ids
                             _nli_cache_time[cache_key] = _time.time()
                             _prune_nli_memory_cache_locked(_time.time())
-                        _persist_positive_cache_snapshot()
+                            _cache_snapshot = (dict(_nli_cache), dict(_nli_cache_time))
+                        _persist_positive_cache_snapshot(_cache_snapshot)
                         logger.info(f"Cached {len(unique_fl_ids)} FL IDs from MARC for {system_id}")
                         # Phase 98 D-06/D-08: MARC fallback succeeded.
                         _nli_record_success(path='fetch_fl_ids_from_nli')
@@ -868,6 +886,14 @@ def init_api_routes(app_override=None):
                 _nli_record_failure(failure_type='429', path='nli_image')
             elif 500 <= resp.status_code < 600:
                 _nli_record_failure(failure_type='5xx', path='nli_image')
+            else:
+                # Audit #36: previously fell through silently. Low-noise debug
+                # log of the unexpected status (404 + any 3xx/other 4xx) so
+                # NLI-side behaviour changes are observable.
+                logger.debug(
+                    "NLI IIIF non-success status %s for FL%s (falling through to Rosetta)",
+                    resp.status_code, digits,
+                )
             # 404 / other → fall through to Rosetta
         except requests.exceptions.Timeout as e:
             logger.error(f"IIIF timeout for FL{digits}: {e}")
@@ -904,6 +930,12 @@ def init_api_routes(app_override=None):
                 _nli_record_failure(failure_type='429', path='nli_image')
             elif 500 <= resp.status_code < 600:
                 _nli_record_failure(failure_type='5xx', path='nli_image')
+            else:
+                # Audit #36: previously fell through silently to the final 404.
+                logger.debug(
+                    "NLI Rosetta non-success status %s for FL%s (returning 404)",
+                    resp.status_code, digits,
+                )
         except requests.exceptions.Timeout as e:
             logger.error(f"Rosetta timeout for FL{digits}: {e}")
             _nli_record_failure(failure_type='timeout', path='nli_image')
@@ -1008,6 +1040,11 @@ def init_api_routes(app_override=None):
     # FastAPI route). Production code never reads this dict.
     _api_test_seam['fetch_fl_ids_from_nli'] = fetch_fl_ids_from_nli
     _api_test_seam['_fetch_nli_image_bytes'] = _fetch_nli_image_bytes
+    # Audit SEED-021 #36/#23: expose the image route + the persist-snapshot
+    # helper so tests can assert the new non-200/non-429/non-5xx status logging
+    # and the lock-consistent cache snapshot without going through TestClient.
+    _api_test_seam['nli_image'] = nli_image
+    _api_test_seam['_persist_positive_cache_snapshot'] = _persist_positive_cache_snapshot
 
     @target_app.get('/api/nli_image_by_sysid/{sys_id}')
     def nli_image_by_sysid(sys_id: str, page: int = 0, width: int = 2000, suffix: int = 1):

--- a/web/components/image_resolution.py
+++ b/web/components/image_resolution.py
@@ -44,6 +44,31 @@ from shared.synthetic_sys_id import is_synthetic_sys_id
 logger = logging.getLogger(__name__)
 
 
+def _warn_if_on_event_loop(func_name: str) -> None:
+    """Warn (never raise) if ``func_name`` is running on the asyncio event loop.
+
+    Audit #38: ``resolve_external_images`` does synchronous network I/O via
+    ``enrich_metadata`` and must run inside ``run.io_bound`` (an executor
+    thread), never directly on the NiceGUI/asyncio event loop where it would
+    block every other request. Detecting a *running* loop on the current thread
+    means we are NOT on an io_bound worker. This is a soft guard: it logs a
+    warning so the misuse is observable but does not change behaviour.
+    """
+    import asyncio
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        # No running loop on this thread → we are on a worker thread (or sync
+        # context). This is the correct place to call. Nothing to warn about.
+        return
+    logger.warning(
+        "%s called on the event-loop thread — it performs blocking network I/O "
+        "and must be invoked inside run.io_bound to avoid stalling the UI.",
+        func_name,
+        stack_info=True,
+    )
+
+
 def resolve_image_url(
     *,
     sys_id: str,
@@ -272,6 +297,14 @@ def resolve_external_images(
         On enrich_metadata failure (any Exception), returns the same shape with
         all-empty values — degrades gracefully, mirrors browse_enrichment.py:249-250.
     """
+    # Audit #38: the io_bound requirement (docstring above) was comment-only.
+    # Add a runtime guard that warns when this is mistakenly invoked on the
+    # asyncio event loop thread (i.e. NOT inside run.io_bound), where the
+    # synchronous enrich_metadata network call would block the whole UI. This
+    # only warns — it never raises — so existing callers that already wrap the
+    # call in run.io_bound (anchor_viewer.py, joins_lab.py) are unaffected.
+    _warn_if_on_event_loop("resolve_external_images")
+
     if meta_mgr is None:
         from web.state import state as _state
         meta_mgr = _state.meta_mgr
@@ -293,7 +326,12 @@ def resolve_external_images(
             meta_mgr.enrich_metadata(sys_id)
             cached = meta_mgr.nli_cache.get(sys_id, {})
         except Exception as e:
-            logger.warning("resolve_external_images enrich_metadata error for %s: %s", sys_id, e)
+            # Audit #37: include stack info so the failing call path is
+            # diagnosable (the bare warning lost the traceback).
+            logger.warning(
+                "resolve_external_images enrich_metadata error for %s: %s",
+                sys_id, e, exc_info=True,
+            )
             cached = {}
 
     return {


### PR DESCRIPTION
## SEED-021 — image-fetch observability + desktop viewer polish

Observability/polish only. No behavior change beyond logging + UI parity. (Image-loading *unification* is SEED-015, out of scope here.)

### web/api.py — NLI image observability
- **#23** — `fetch_fl_ids_from_nli` now copies the cache snapshot **inside** the same `_nli_cache_lock` critical section as the update and passes it to `_persist_positive_cache_snapshot(snapshot)`, so the persisted view is lock-consistent (no mutation can interleave between unlock and re-lock). Helper gains an optional pre-copied snapshot arg; falls back to its own locked copy when omitted.
- **#36** — `nli_image`'s IIIF + Rosetta handlers now log non-200/non-429/non-5xx statuses (404 + unexpected 3xx/4xx) at `DEBUG` instead of falling through silently to the final 404. `nli_image` + the persist helper exposed via `_api_test_seam`.

### web/components/image_resolution.py
- **#37** — `resolve_external_images` enrich-failure warning now carries `exc_info=True` (stack trace).
- **#38** — runtime guard warns (never raises) when `resolve_external_images` runs on the asyncio event-loop thread; it does blocking network I/O and must run inside `run.io_bound`. Existing io_bound-wrapped callers (`anchor_viewer.py`, `joins_lab.py`) are unaffected.

### desktop/join_workbench.py — viewer polish (parity)
- **#42** — Compare panes show a live zoom-% label, updated on every zoom/render (web parity).
- **#43** — candidate cards animate the loading placeholder via a `QTimer` (cycling dots, reusing the existing `tr("loading…")` key), self-stopping when the image pump delivers a pixmap or terminal text (minimal parity with web's animated skeleton).

### Tests
`tests/test_audit_2026_06_23_image_obs.py` (13 tests): #36 caplog assertions, #23 lock-consistent snapshot + helper arg/self-lock paths, #37 exc_info, #38 guard on/off loop, #42/#43 source-level (GUI construct segfaults headless on Windows).

Verification:
- `tests/test_audit_2026_06_23_image_obs.py` + `tests/test_image_resolution.py` → green
- NLI cache regression (`test_api_nli_breaker_integration`, `test_nli_cache_persist_retry`, `test_nli_cache_bounded_lru`) → green
- join_workbench guard/construct tests → green
- `ruff check` on all changed files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GnvGb31t729NCZbnUQXS6