### PR TITLE
fix(audit): address GitHub Codex reviews on PRs #297 & #300

### DIFF
--- a/shared/browse_service.py
+++ b/shared/browse_service.py
@@ -433,7 +433,22 @@ async def _wrap_with_timeout(
     """
     loop = asyncio.get_event_loop()
     sem = _get_browse_semaphore()
-    await sem.acquire()
+
+    # SEED-016 #29 FIX-2 (GitHub Codex P1): bound the slot wait itself. Because the
+    # slot is held for the worker thread's TRUE lifetime (see below), a plain
+    # unbounded `sem.acquire()` here would block this task OUTSIDE any timeout once
+    # every slot is occupied by timed-out-but-still-running sidecar calls -- turning
+    # a sidecar hang into a stuck /api/browse (the exact saturation this guard is
+    # meant to prevent). Cap the wait at the per-source timeout; on expiry skip the
+    # source with an enrichment_timeout warning and WITHOUT submitting work, so no
+    # slot is consumed. asyncio.Semaphore.acquire releases correctly if cancelled
+    # after acquisition (CPython 3.10+). Worst case per source is ~2x timeout
+    # (slot wait + work wait) under full saturation -- bounded, degraded, not hung.
+    try:
+        await asyncio.wait_for(sem.acquire(), timeout=timeout)
+    except asyncio.TimeoutError:
+        warnings_list.append({'code': 'enrichment_timeout', 'source': source_name})
+        return None
 
     # Release the slot from the executor future's completion path so it is held
     # for the work's TRUE lifetime, even if the caller-facing wait_for below

--- a/tests/test_seed016_layering_executor.py
+++ b/tests/test_seed016_layering_executor.py
@@ -402,20 +402,25 @@ def test_browse_slow_source_times_out_without_starving_others(monkeypatch):
     )
 
 
-def test_timed_out_source_holds_slot_until_blocking_call_returns(monkeypatch):
-    """SEED-016 #29 (Codex REQUEST-CHANGES): a source whose coroutine TIMES OUT
-    must keep its concurrency slot until the underlying blocking function ACTUALLY
-    returns -- not merely until asyncio.wait_for cancels the await.
+def test_timed_out_source_keeps_slot_and_does_not_hang_contenders(monkeypatch):
+    """SEED-016 #29 (in-session Codex REQUEST-CHANGES) + GitHub Codex PR #297 P1.
 
-    With BROWSE_SOURCE_CONCURRENCY = 1 we run two enrichment sources serialized by
-    the one slot. The first (slow) source blocks past its per-source timeout. We
-    prove the second source CANNOT begin executing its blocking body while the
-    first is still running (slot held despite the timeout), and that it DOES
-    proceed once the first blocking function returns.
+    Two properties that must coexist with BROWSE_SOURCE_CONCURRENCY = 1:
 
-    This is the gap the prior `..._without_starving_others` test missed: that one
-    only asserts the coroutine returned quickly, which the buggy
-    release-in-finally version also satisfied.
+      (A) Anti-early-re-admit: a source whose coroutine TIMES OUT keeps its slot
+          until the underlying blocking function ACTUALLY returns -- not merely
+          until asyncio.wait_for cancels the await. So a contender must NOT begin
+          executing its blocking body while the timed-out holder is still running.
+
+      (B) No-hang (PR #297 P1 FIX): a contender waiting for that held slot is
+          bounded -- once it cannot get a slot within the per-source timeout it is
+          SKIPPED with an enrichment_timeout warning, rather than blocking outside
+          any timeout until the hung thread returns. Browse stays responsive even
+          when every slot is occupied by a slow/hung sidecar call.
+
+    The slow holder blocks past its per-source timeout; the contender therefore
+    both (A) never runs its body while the slot is held AND (B) returns promptly
+    with an enrichment_timeout instead of waiting out the 5s hold.
     """
     # Cap concurrency to a single slot and rebuild the semaphore on this loop.
     monkeypatch.setattr(bs, 'BROWSE_SOURCE_CONCURRENCY', 1)
@@ -425,26 +430,17 @@ def test_timed_out_source_holds_slot_until_blocking_call_returns(monkeypatch):
 
     slow_started = threading.Event()
     slow_may_finish = threading.Event()
-    slow_returned = threading.Event()
     second_started = threading.Event()
-
-    # Records: did the second source begin its blocking body BEFORE the slow
-    # source's blocking body returned? If the slot was wrongly freed on timeout,
-    # the second source starts while slow_returned is still unset -> True (bug).
-    observed = {'second_started_before_slow_returned': None}
 
     def _slow_pgp(*a, **k):
         slow_started.set()
         # Block well past the 0.2s coroutine timeout; only finish on command.
         slow_may_finish.wait(timeout=5.0)
-        slow_returned.set()
         return {'page_section_text': 'late'}
 
     def _second_fjms(*a, **k):
+        # Should NEVER run: the contender times out waiting for the held slot.
         second_started.set()
-        # Observe whether the slow source had already returned (slot truly freed)
-        # at the instant we were admitted.
-        observed['second_started_before_slow_returned'] = not slow_returned.is_set()
         return {'source_names': ['CUL'], 'has_measurements': False,
                 'has_visual_suggestions': False}
 
@@ -468,36 +464,84 @@ def test_timed_out_source_holds_slot_until_blocking_call_returns(monkeypatch):
             await asyncio.sleep(0.01)
         assert slow_started.is_set(), 'slow source never started'
 
-        # Give the slow coroutine time to TIME OUT (0.2s) and then some. If the
-        # buggy finally-release were in place, the freed slot would let the
-        # second source begin its body here, while the slow body is still blocked.
-        await asyncio.sleep(0.6)
-        assert not second_started.is_set(), (
-            'second source acquired the slot while the timed-out source was '
-            'still running its blocking call -- the concurrency slot was freed '
-            'on coroutine timeout instead of on real completion (SEED-016 #29 '
-            'regression)'
-        )
+        # (B) The whole gather must resolve PROMPTLY (~per-source timeout), NOT
+        # wait out the slow holder's 5s block. If the contender's slot-acquire
+        # were unbounded (the PR #297 P1 bug) this await would hang until we set
+        # slow_may_finish below.
+        bundle, warnings = await asyncio.wait_for(task, timeout=2.0)
 
-        # Now let the slow blocking function return; the done-callback releases
-        # the slot and the second source must proceed.
-        slow_may_finish.set()
-        bundle, warnings = await asyncio.wait_for(task, timeout=5.0)
+        # (A) The contender never executed its blocking body -- the slot was held
+        # by the timed-out holder for the holder's true lifetime, never re-admitted
+        # early on coroutine timeout.
+        assert not second_started.is_set(), (
+            'contender ran its blocking body while the timed-out holder still held '
+            'the slot -- the slot was freed on coroutine timeout instead of on real '
+            'completion (SEED-016 #29 regression)'
+        )
         return bundle, warnings
+
+    try:
+        bundle, warnings = asyncio.run(_run())
+    finally:
+        # Release the still-blocked holder thread so it does not linger.
+        slow_may_finish.set()
+
+    # The slow holder timed out on its WORK; the contender timed out on its SLOT
+    # ACQUIRE -- both surface enrichment_timeout, neither hangs browse.
+    assert bundle.pgp is None and bundle.fjms is None
+    timed_out = {w.get('source') for w in warnings if w.get('code') == 'enrichment_timeout'}
+    assert {'pgp', 'fjms'} <= timed_out, (
+        f'expected enrichment_timeout for pgp (work) AND fjms (slot wait); got {warnings!r}'
+    )
+
+
+def test_slot_released_on_true_completion_lets_contender_proceed(monkeypatch):
+    """Companion to the no-hang test: when the holder finishes WITHIN the
+    contender's slot-acquire budget, the slot is released (on true completion) and
+    the contender proceeds -- and it only runs AFTER the holder's blocking call
+    actually returned (positive proof of release-on-completion, not on timeout)."""
+    monkeypatch.setattr(bs, 'BROWSE_SOURCE_CONCURRENCY', 1)
+    bs.reset_browse_executor_state()
+    # Generous per-source timeout so the slot wait (not the timeout) governs; the
+    # holder finishes quickly, well inside that budget.
+    monkeypatch.setenv('SEARCH_API_BROWSE_TIMEOUT', '2.0')
+
+    holder_returned = threading.Event()
+    observed = {'contender_started_before_holder_returned': None}
+
+    def _holder_pgp(*a, **k):
+        time.sleep(0.3)  # finishes well within the 2.0s contender budget
+        holder_returned.set()
+        return {'page_section_text': 'on-time'}
+
+    def _contender_fjms(*a, **k):
+        observed['contender_started_before_holder_returned'] = not holder_returned.is_set()
+        return {'source_names': ['CUL'], 'has_measurements': False,
+                'has_visual_suggestions': False}
+
+    def _noop_nli(*a, **k):
+        return {'physical_metadata': None, 'folio': None}
+
+    monkeypatch.setattr(bs, '_pgp_sync', _holder_pgp)
+    monkeypatch.setattr(bs, '_fjms_sync', _contender_fjms)
+    monkeypatch.setattr(bs, '_nli_sync', _noop_nli)
+
+    provider = _FakeProvider()
+
+    async def _run():
+        return await asyncio.wait_for(
+            bs.fetch_browse_bundle(service=provider, sys_id='99001', p_num=3),
+            timeout=5.0,
+        )
 
     bundle, warnings = asyncio.run(_run())
 
-    # The slow source timed out -> null + warning; the second source resolved.
-    assert bundle.pgp is None
-    assert any(
-        w.get('code') == 'enrichment_timeout' and w.get('source') == 'pgp'
-        for w in warnings
-    ), f'expected enrichment_timeout/pgp; got {warnings!r}'
+    # Both sources resolved (no timeout) and the contender ran only AFTER the
+    # holder's blocking call returned -- the slot was freed on true completion.
+    assert bundle.pgp is not None and bundle.pgp['page_section_text'] == 'on-time'
     assert bundle.fjms is not None and bundle.fjms['source_names'] == ['CUL']
-    # And when it finally ran, the slow body had already returned (slot freed only
-    # after real completion).
-    assert observed['second_started_before_slow_returned'] is False, (
-        'second source ran before the slow blocking call returned'
+    assert observed['contender_started_before_holder_returned'] is False, (
+        'contender ran before the holder blocking call returned'
     )
 
 

--- a/web/pages/search.py
+++ b/web/pages/search.py
@@ -1055,15 +1055,19 @@ def create_search_page(initial_query: str = None, initial_tag: str = None,
         )
         chip_bar_container.set_visibility(False)
 
-        # #11: per-op feedback for the (background) filter-count recompute. A tiny
-        # inline indicator inside the chip bar — spinner while pending, an error
-        # chip on failure — instead of leaving the count silently stale.
-        with chip_bar_container:
-            _filter_status_row = ui.row().classes('items-center gap-1')
-            _filter_status_row.set_visibility(False)
-            with _filter_status_row:
-                _filter_status_spinner = ui.spinner(size='sm').props('aria-hidden=true')
-                _filter_status_label = ui.label('').classes('text-xs').style('color: var(--text-muted);')
+        # #11: per-op feedback for the (background) filter-count recompute — spinner
+        # while pending, an error chip on failure — instead of leaving the count
+        # silently stale.
+        # GitHub Codex PR #300 P2: this row must live OUTSIDE chip_bar_container.
+        # _update_chip_bar() calls chip_bar_container.clear() (including on the initial
+        # render), which previously destroyed these stored elements, so every later
+        # pending/error update mutated detached nodes and never became visible. Keep it
+        # in its own persistent, chip-bar-aligned container below the chips.
+        _filter_status_row = ui.row().classes('w-full px-4 items-center gap-1')
+        _filter_status_row.set_visibility(False)
+        with _filter_status_row:
+            _filter_status_spinner = ui.spinner(size='sm').props('aria-hidden=true')
+            _filter_status_label = ui.label('').classes('text-xs').style('color: var(--text-muted);')
 
         def _set_filter_recompute_state(status):
             """Render pending/error feedback for the filter-count recompute (#11)."""

--- a/web/pages/search_results.py
+++ b/web/pages/search_results.py
@@ -445,9 +445,13 @@ def create_result_card(search_state, refs, index, result):
             search_state.expansion_toggle_refs[index] = _content_col
             _content_col.on('click', lambda idx=index, _ss=search_state, _r=refs: toggle_expansion(_ss, _r, idx))
             # Enter / Space activate, matching native button behavior. keydown.space.prevent
-            # stops the page from scrolling on Space.
-            _content_col.on('keydown.enter', lambda idx=index, _ss=search_state, _r=refs: toggle_expansion(_ss, _r, idx))
-            _content_col.on('keydown.space.prevent', lambda idx=index, _ss=search_state, _r=refs: toggle_expansion(_ss, _r, idx))
+            # stops the page from scrolling on Space. The `.self` modifier (GitHub Codex
+            # PR #300 P2) gates the handler on the wrapper being the event TARGET, so
+            # Enter/Space on a nested control (visual-similarity / title-swap button) does
+            # NOT bubble up and toggle the card -- click is already shielded via click.stop
+            # on those children, but keydown was not.
+            _content_col.on('keydown.enter.self', lambda idx=index, _ss=search_state, _r=refs: toggle_expansion(_ss, _r, idx))
+            _content_col.on('keydown.space.self.prevent', lambda idx=index, _ss=search_state, _r=refs: toggle_expansion(_ss, _r, idx))
             with _content_col:
                 with ui.row().classes('items-center gap-2 flex-wrap'):
                     ui.label(f"#{index + 1}").classes('text-xs px-2 py-0.5 rounded shrink-0').style(


### PR DESCRIPTION
Addresses the GitHub Codex bot reviews on the already-merged audit PRs #297 (SEED-016) and #300 (SEED-014). Three real findings.

## #297 (P1) — bound the browse slot-acquire wait
`shared/browse_service.py`. The SEED-016 #29 cap correctly holds a source's semaphore slot for the worker thread's **true lifetime** (so a coroutine timeout can't re-admit work past the cap). But the `sem.acquire()` itself was unbounded — once every slot is held by timed-out-but-still-running sidecar calls, later enrichment tasks block at the acquire **outside any timeout** and `/api/browse` stops returning promptly. Now the acquire is wrapped in `asyncio.wait_for(timeout)`; on expiry the source is skipped with `enrichment_timeout` **without** submitting work (no slot consumed). The regression test is split into two: (A) anti-early-re-admit **and** no-hang under saturation, (B) release-on-true-completion lets a contender proceed.

## #300 (P2) — keydown bubbling from nested controls
`web/pages/search_results.py`. Enter/Space on a nested control (visual-similarity / title-swap button) bubbled to the result card's keydown handler and toggled the card. `click` was already shielded via `click.stop`; added Vue `.self` to the keydown handlers so they fire only when the wrapper itself is the event target. (This is the nested-control nit from UAT.)

## #300 (P2) — filter status row destroyed by chip-bar clear
`web/pages/search.py`. `_filter_status_row` lived inside `chip_bar_container`, which `_update_chip_bar()` clears (including on initial render), detaching the spinner/label so the #11 pending/error feedback mutated dead nodes and never showed. Moved it to its own persistent, chip-bar-aligned container.

Tests: 14 SEED-016 + 58 a11y/rtl & browse_api green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
