### PR TITLE
feat(web): SEED-022 — source-agnostic 'has manual transcription' indicator (web)

### DIFF
--- a/.planning/seeds/SEED-022-unified-has-transcription-tag.md
+++ b/.planning/seeds/SEED-022-unified-has-transcription-tag.md
@@ -1,0 +1,146 @@
+---
+id: SEED-022
+status: dormant
+planted: 2026-06-23
+planted_during: User feature request (relayed by Hillel) — "can users see which mss have a manual transcription?" Mapped via two Explore passes. NOT part of the 2026-06-23 audit; a new feature.
+trigger_when: After audit PRs #298 (genizah_app.py/gui_threads.py) and #300 (web/pages/search.py, search_results.py) MERGE — SEED-022 edits the same files and would conflict. Build on the merged base. Codex-review this seed before coding (per the project's seed-review gate).
+scope: small-medium (one union helper + a NEW additive indicator on both apps, alongside the unchanged PGP tag)
+---
+
+# SEED-022: "Has transcription" tag/column — NEW, additive, source-agnostic
+
+> User intent (Hillel, 2026-06-23): a reader wants to know **"is there a manual transcription to read here"**
+> regardless of source. Add a NEW indicator = **PGP ∪ FGP** transcriptions (translations included).
+
+## Decisions (locked by Hillel)
+- **KEEP the PGP tag exactly as-is** — do NOT repurpose/relabel/rewire it. The new "has transcription"
+  indicator is a **SEPARATE, ADDITIONAL** badge (web) / column (desktop) that sits alongside the PGP one.
+  A PGP manuscript will show both its PGP tag AND the transcription tag (intended — different signals:
+  "has PGP specifically" vs "has any manual transcription").
+- **Include translations** — the new tag = "has any manual text (transcription OR translation)". Use the
+  EXISTING any-source presence functions; no edition-only filtering.
+- **No connection to `is_printed`** — independent axis; don't filter by it.
+- **User-contributed transcriptions: SKIP for now** (none exist — no `transcriptions` table; `corrections`
+  are edits, `discoveries` are discussion). Build the union helper EXTENSIBLE so a future user-source is a
+  one-line add.
+
+## Design — ADD a new indicator (the PGP wiring is untouched)
+The version chooser already shows source-specific PGP/FGP groups (unchanged). The PGP tag stays. We add one
+new "has transcription" signal computed from a union, and render it as a new badge/column.
+
+### New primitive (the only net-new logic)
+`shared/document_service.py` (or a thin new `shared/transcription_service.py`):
+```python
+def get_sys_ids_with_manual_transcriptions(sys_ids, *, include_user=True):
+    """Union of manual-transcription presence across sources (translations included).
+    PGP ∪ FGP today; user-source slot reserved for the future. Does NOT replace the PGP-only set."""
+    out = set()
+    out |= get_sys_ids_with_transcriptions(sys_ids)        # PGP, any-source (document_service.py:438)
+    out |= get_sys_ids_with_fgp_sources(sys_ids)           # FGP, any-source (fgp_service.py:923)
+    # if include_user: out |= get_sys_ids_with_user_transcriptions(sys_ids)  # FUTURE — no store yet
+    return out
+```
+Graceful: FGP returns `set()` when the sidecar/flag is absent → the new tag then equals the PGP set (still
+fine; it's a superset by construction).
+
+### WEB — additive (PGP badge/filter/state all unchanged)
+- **State** `web/pages/search_state.py`: ADD a new field `manual_transcription_sys_ids: Set[str]` NEXT TO the
+  existing `transcription_sys_ids` (PGP) — do not rename or reuse the PGP field.
+- **Enrichment** `web/pages/search.py:~4655-4679`: keep the existing `get_sys_ids_with_transcriptions` call
+  (feeds PGP); ADD `get_sys_ids_with_manual_transcriptions` to the `asyncio.gather` (or compute the union
+  as `pgp_set | fgp_set` to avoid double-querying PGP) → store in `manual_transcription_sys_ids`.
+- **Badge** `web/pages/search_results.py:~463`: keep the PGP badge block; ADD a SECOND small badge next to it,
+  shown when `sys_id in search_state.manual_transcription_sys_ids`, with the new label + a distinct color
+  (PGP is green `#22c55e`; pick a different hue for the transcription tag).
+- **Filter (OPTIONAL):** the existing 3-state `pgp_filter` stays PGP-only. If a transcription filter is
+  wanted, ADD a separate 3-state filter cloning that pattern against `manual_transcription_sys_ids` — but
+  default scope is tag/column only (confirm if filter is desired).
+- **API (optional):** keep `has_pgp`; optionally ADD `has_transcription` to the serializer envelope
+  (additive, export-opt-in). Check the public skill/API docs before exposing.
+
+### DESKTOP — additive (COL_PGP unchanged)
+- **Worker** `gui_threads.py`: keep `PGPBadgeWorker`/`get_sys_ids_with_transcriptions` for the PGP column;
+  ADD the FGP/union fetch (extend the worker to also emit the union set, or a small sibling worker) → a new
+  `self._manual_transcription_sys_ids` set. Do NOT change `_pgp_transcription_sys_ids`.
+- **Column** `genizah_app.py:6986-6994`: ADD a new column constant (e.g. `COL_TRANSCRIPTION`) + header +
+  tooltip AFTER `COL_PGP` (shift subsequent column indices or append at the end); fixed-width like COL_PGP.
+- **Cell render** `genizah_app.py:18243-18248`: keep the PGP cell; ADD a parallel cell for the new column
+  populated from `_manual_transcription_sys_ids`. Update the render loop + the badge handler (:19267-19280).
+- (Excel export already has a "Has PGP" column at :2939 — optionally add a "Has transcription" column too.)
+
+## Label — DECIDED (Hillel, 2026-06-23)
+PGP tag keeps "PGP" untouched. The NEW tag is an **icon + tooltip** (not a long text label — "Transcription"
+misleads because the GENIZAH corpus is itself MiDRASH *automatic* transcriptions).
+- **Tooltip text (exact):** EN `"scholarly transcription/translation available"` · HE
+  `"תעתיק/תרגום מדעי זמין"`. (Note: includes translation — matches the "include translations" decision.)
+- **Visible element:** a compact icon, distinct color from PGP-green. Propose a scholarly/edition icon
+  (e.g. a document-with-check / scroll / ✓-in-badge) at implementation; confirm the exact glyph in review.
+  Optionally pair with a 1-word label ("מדעי"/"Scholarly") if the icon alone reads as unclear.
+- Add the tooltip string as an EN+HE key in `genizah_translations.py` (batch with SEED-014's new keys).
+
+## Tests required
+- Union helper: PGP∪FGP; FGP-absent degrades to PGP set; extensible signature.
+- Web: NEW badge renders for an FGP-only sys_id AND for a PGP sys_id; PGP badge unchanged; (filter if added).
+- Desktop: new column populated from the union; COL_PGP behavior unchanged; column indices correct after insert.
+- i18n: new label key EN+HE (no English leak under Hebrew).
+
+## Done when
+PGP tag UNCHANGED; a NEW additive "has transcription" badge (web) + column (desktop) reflects PGP∪FGP
+(translations included), labeled with a source-agnostic term (EN+HE), distinct color; user-source slot
+reserved; tests green; ruff clean. Codex-reviewed before code.
+
+## NOT in scope
+Touching/relabeling the PGP tag; edition/translation splitting; printed coupling; a NEW user-transcription
+store (separate feature — when it ships, flip `include_user` to a real query).
+
+---
+
+## Codex review corrections (2026-06-24) — BUILD PER THESE (override the above where they differ)
+Codex verdict: **GO-WITH-CHANGES**. The feature is feasible; build with these corrections.
+
+### BLOCKERS (must fix before coding)
+- **B1 — PGP predicate is the WRONG one for "has readable text."** `get_sys_ids_with_transcriptions`
+  (document_service.py:438) only checks `document_fragments.sys_id` = *link* presence, NOT actual
+  transcription/translation TEXT (it does not look at `document_sources.content` / `has_transcription` /
+  `has_translation`); tests lock this as linked-fragment presence (test_document_service.py:498). For the
+  feature ("is there manual text to READ here?") build the new tag from a **real text predicate**:
+  `document_fragments JOIN document_sources` where relation ∈ {Edition, Translation} and `content` is
+  non-empty → that PGP-text set, **unioned with** `get_sys_ids_with_fgp_sources` (FGP). Add this as a NEW
+  helper (e.g. `get_sys_ids_with_pgp_text(sys_ids)` in document_service) — **do NOT modify the existing PGP
+  badge helper** (the PGP badge keeps its current link-presence semantics, per Hillel). CONSEQUENCE (intended,
+  confirmed): a PGP-linked-but-textless mss shows the PGP badge but NOT the new transcription tag — correct,
+  there's nothing to read.
+- **B2 — helper signature must match the real ones.** Both existing helpers are `List[str]` + use `len()`/
+  slicing; a generic iterable/generator breaks them. `get_sys_ids_with_manual_transcriptions(sys_ids)` must
+  `list(sys_ids or [])` once up front (or type as `Sequence[str]`).
+- **B3 — desktop column APPEND, do not insert.** Current logical cols: `COL_PGP=9`, `COL_DOMAIN=10`,
+  `COL_PRINTED=11`, `setColumnCount(12)` (genizah_app.py:6980,6993). Inserting after COL_PGP shifts indices
+  and breaks headers/tooltips (7004/7019), cell population (18244), badge handlers (19296), persisted filter
+  indices (26702/26916). **Append `COL_TRANSCRIPTION=12` + `setColumnCount(13)`.** If visual adjacency is
+  ever wanted, do a header VISUAL move while preserving logical indices — not now.
+
+### SHOULD-FIX
+- **Stale web anchors.** Real enrichment sites are `web/pages/search.py:4702` AND `:4757` (TWO passes —
+  stage 1 + stage 2), not `~4655-4679`. Fetch PGP-text once + FGP once, compute `manual = pgp_text | fgp` in
+  BOTH passes; never call a union helper that re-queries PGP inside the gather.
+- **Web restore + PGP-tag branch missed.** Session restore (`search.py:4965`) only reloads PGP IDs — also
+  restore `manual_transcription_sys_ids`. PGP-tag search has a SEPARATE hardcoded badge path
+  (`search.py:4890`) — render the new badge there too.
+- **Desktop worker — no second PGP query.** Existing `PGPBadgeWorker` (gui_threads.py:793,803) emits only the
+  PGP set; extend it to emit BOTH `pgp_ids` and `manual_ids = pgp_text_ids | fgp_ids` (one pass).
+- **Init/clear new desktop state at ALL lifecycle sites.** Existing init at genizah_app.py:3382; reset/
+  no-result paths (18010, 18359) clear printed but not the new set — explicitly init+clear
+  `_manual_transcription_sys_ids` on new-search, reset, no-results, session-restore, PGP-tag search.
+- **FGP translation-only test.** `get_sys_ids_with_fgp_sources` already includes Digital Translation (no
+  edition-only filter) — add a test that an FGP translation-only row surfaces.
+
+### NICE-TO-HAVE / DEFER
+- Perf is fine batched (PGP+FGP both chunk at 500, both indexed on sys_id) — keep one extra FGP batch lookup
+  per chunk, no per-row queries.
+- **API/export columns: DEFER** unless asked. `has_pgp` is export/session-opt-in only and NOT in public API
+  docs; if `has_transcription` is ever added keep it export-opt-in and update SEARCH_API.md/OpenAPI/tests.
+- **XLSX column: DEFER** — export dossier is 12-col pinned (export_dossier.py:230,253); adding a column means
+  shared headers + web/desktop exporters + image-URL index + parity tests.
+- i18n: add the exact EN `"scholarly transcription/translation available"` / HE `"תעתיק/תרגום מדעי זמין"`
+  key before rendering (not yet present).
+- Version chooser: leave unchanged (already separates PGP/FGP editions/translations).

--- a/genizah_translations.py
+++ b/genizah_translations.py
@@ -2086,7 +2086,7 @@ TRANSLATIONS = {
     "Tag: {} - {} results": "תגית: {} - {} תוצאות",
 
     # --- PGP Transcription ---
-    "Has PGP Transcription": "יש תעתיק PGP",
+    "Has PGP info": "יש מידע PGP",
     # SEED-022: source-agnostic "has manual transcription" indicator tooltip.
     "scholarly transcription/translation available": "תעתיק/תרגום מדעי זמין",
     "PGP Transcription": "תעתוק PGP",

--- a/genizah_translations.py
+++ b/genizah_translations.py
@@ -2087,6 +2087,8 @@ TRANSLATIONS = {
 
     # --- PGP Transcription ---
     "Has PGP Transcription": "יש תעתיק PGP",
+    # SEED-022: source-agnostic "has manual transcription" indicator tooltip.
+    "scholarly transcription/translation available": "תעתיק/תרגום מדעי זמין",
     "PGP Transcription": "תעתוק PGP",
     "PGP Transcriptions": "תעתוקי PGP",
     # --- FGP (Friedberg Genizah Project) Transcription ---

--- a/shared/document_service.py
+++ b/shared/document_service.py
@@ -467,6 +467,47 @@ class PgpService:
             logger.error(f"Error batch checking transcriptions: {e}")
             return set()
 
+    def get_sys_ids_with_pgp_text(self, sys_ids: List[str]) -> Set[str]:
+        """Batch check which sys_ids have actual readable PGP transcription OR
+        translation TEXT (SEED-022).
+
+        DISTINCT from :meth:`get_sys_ids_with_transcriptions`, which only checks
+        whether a sys_id is *linked* to any PGP document (document_fragments
+        presence -- ~34K sys_ids, nearly the whole corpus). This method joins
+        through to ``documents`` and requires the precomputed availability flags
+        ``has_transcription`` / ``has_translation`` (~7.3K sys_ids), i.e. there is
+        genuine manual text to READ. Used by the new "has manual transcription"
+        indicator; the existing PGP badge keeps its link-presence helper untouched.
+
+        Args:
+            sys_ids: List of system IDs to check.
+
+        Returns:
+            Set of sys_ids linked to a PGP document with transcription/translation text.
+        """
+        sys_ids = list(sys_ids or [])
+        if not sys_ids or not self._conn:
+            return set()
+
+        try:
+            result_set: Set[str] = set()
+            batch_size = 500  # stay under the SQLite variable limit (999)
+            for i in range(0, len(sys_ids), batch_size):
+                batch = sys_ids[i:i + batch_size]
+                placeholders = ','.join('?' * len(batch))
+                cursor = self._conn.execute(
+                    f"SELECT DISTINCT f.sys_id FROM document_fragments f "
+                    f"JOIN documents d ON d.pgpid = f.document_id "
+                    f"WHERE f.sys_id IN ({placeholders}) "
+                    f"AND (d.has_transcription = 1 OR d.has_translation = 1)",
+                    batch
+                )
+                result_set.update(row['sys_id'] for row in cursor)
+            return result_set
+        except Exception as e:
+            logger.error(f"Error batch checking PGP text presence: {e}")
+            return set()
+
     def get_fragments_by_tag(self, tag: str) -> List[Dict[str, Any]]:
         """
         Get all fragments linked to PGP documents with a specific tag.
@@ -1100,6 +1141,15 @@ def get_sys_ids_with_transcriptions(sys_ids: List[str]) -> Set[str]:
     """
     svc = get_pgp_service()
     return svc.get_sys_ids_with_transcriptions(sys_ids)
+
+
+def get_sys_ids_with_pgp_text(sys_ids: List[str]) -> Set[str]:
+    """Batch check which sys_ids have readable PGP transcription/translation TEXT
+    (SEED-022). See :meth:`PGPDocumentService.get_sys_ids_with_pgp_text` -- this is
+    the text-presence predicate (has_transcription/has_translation), NOT the
+    link-presence helper used by the existing PGP badge."""
+    svc = get_pgp_service()
+    return svc.get_sys_ids_with_pgp_text(sys_ids)
 
 
 def get_fragments_by_tag(tag: str) -> List[Dict[str, Any]]:

--- a/shared/transcription_service.py
+++ b/shared/transcription_service.py
@@ -1,0 +1,71 @@
+"""Source-agnostic "has manual transcription" presence (SEED-022).
+
+A reader wants to know, on a result row, whether there is a *manual / scholarly*
+transcription OR translation to READ for a manuscript -- regardless of which
+project produced it. This module computes that union across sources:
+
+    PGP readable text  ∪  FGP sources   (today)
+    ∪  user-contributed transcriptions  (FUTURE -- no store exists yet)
+
+It is deliberately ADDITIVE and independent of the existing PGP badge:
+
+* The PGP badge keeps its own *link-presence* helper
+  (``document_service.get_sys_ids_with_transcriptions`` -- ~34K sys_ids, "is this
+  in PGP at all"). It is NOT touched here.
+* This union uses the PGP *text-presence* predicate
+  (``document_service.get_sys_ids_with_pgp_text`` -- has_transcription/has_translation,
+  ~7.3K sys_ids) so the new tag means "there is genuine manual text to read".
+
+Graceful degradation: FGP returns an empty set when its sidecar/flag is absent, so
+the union then simply equals the PGP-text set (still a correct superset by
+construction).
+"""
+
+from __future__ import annotations
+
+from typing import List, Set
+
+
+def get_sys_ids_with_manual_transcriptions(
+    sys_ids: List[str], *, include_user: bool = True
+) -> Set[str]:
+    """Union of manual-transcription presence across sources (translations included).
+
+    PGP readable text ∪ FGP sources today; a user-source slot is reserved for the
+    future (no ``transcriptions`` store exists yet -- ``corrections`` are edits and
+    ``discoveries`` are discussion, so ``include_user`` is a no-op for now and kept
+    only so a future store is a one-line add).
+
+    Args:
+        sys_ids: System IDs to check (cast to list once; matches the underlying
+            helpers which require ``List[str]`` for ``len()``/slicing).
+        include_user: Reserved. When a user-transcription store ships, this gates a
+            third union term.
+
+    Returns:
+        Set of sys_ids that have at least one manual transcription OR translation.
+    """
+    sys_ids = list(sys_ids or [])
+    if not sys_ids:
+        return set()
+
+    # Imported lazily so importing this module never forces the FGP/PGP service
+    # singletons (and their SQLite connections) to construct.
+    from shared.document_service import get_sys_ids_with_pgp_text
+    from shared.fgp_service import get_sys_ids_with_fgp_sources
+
+    out: Set[str] = set()
+    out |= get_sys_ids_with_pgp_text(sys_ids)        # PGP readable text
+    out |= get_sys_ids_with_fgp_sources(sys_ids)     # FGP (editions + translations); set() when absent
+    # if include_user:
+    #     out |= get_sys_ids_with_user_transcriptions(sys_ids)  # FUTURE -- no store yet
+    return out
+
+
+def union_manual_transcriptions(pgp_text_ids: Set[str], fgp_ids: Set[str]) -> Set[str]:
+    """Combine already-fetched per-source sets into the manual-transcription union.
+
+    Use this at call sites that ALREADY fetch the PGP-text and FGP sets (e.g. the
+    web enrichment passes) to avoid re-querying PGP. Pure set algebra, no I/O.
+    """
+    return set(pgp_text_ids) | set(fgp_ids)

--- a/tests/test_seed022_manual_transcription_tag.py
+++ b/tests/test_seed022_manual_transcription_tag.py
@@ -1,0 +1,109 @@
+"""SEED-022 — source-agnostic "has manual transcription" indicator.
+
+Covers the new union primitive (PGP readable-text ∪ FGP) and proves it is DISTINCT
+from the existing PGP link-presence helper that feeds the unchanged PGP badge.
+DB-independent: the source helpers are monkeypatched so these run in CI without the
+PGP/FGP sidecars. Two optional tests exercise the real pgp.db when present.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+import shared.document_service as ds
+import shared.fgp_service as fgp
+import shared.transcription_service as ts
+
+
+# --- union logic (DB-independent) -----------------------------------------
+
+def test_union_is_pgp_text_or_fgp(monkeypatch):
+    monkeypatch.setattr(ds, 'get_sys_ids_with_pgp_text', lambda ids: {'a', 'b'})
+    monkeypatch.setattr(fgp, 'get_sys_ids_with_fgp_sources', lambda ids: {'b', 'c'})
+    assert ts.get_sys_ids_with_manual_transcriptions(['a', 'b', 'c', 'd']) == {'a', 'b', 'c'}
+
+
+def test_union_degrades_to_pgp_when_fgp_absent(monkeypatch):
+    """FGP returns set() when its sidecar/flag is absent -> union == PGP-text set."""
+    monkeypatch.setattr(ds, 'get_sys_ids_with_pgp_text', lambda ids: {'x', 'y'})
+    monkeypatch.setattr(fgp, 'get_sys_ids_with_fgp_sources', lambda ids: set())
+    assert ts.get_sys_ids_with_manual_transcriptions(['x', 'y', 'z']) == {'x', 'y'}
+
+
+def test_fgp_only_sys_id_surfaces(monkeypatch):
+    """An FGP-only manuscript (translation-only, no PGP text) still gets the tag."""
+    monkeypatch.setattr(ds, 'get_sys_ids_with_pgp_text', lambda ids: set())
+    monkeypatch.setattr(fgp, 'get_sys_ids_with_fgp_sources', lambda ids: {'fgp1'})
+    assert ts.get_sys_ids_with_manual_transcriptions(['fgp1', 'other']) == {'fgp1'}
+
+
+def test_pure_union_helper_no_io():
+    assert ts.union_manual_transcriptions({'a'}, {'b'}) == {'a', 'b'}
+    assert ts.union_manual_transcriptions(set(), set()) == set()
+
+
+def test_signature_accepts_list_and_is_none_empty_safe(monkeypatch):
+    """Mirrors the underlying List[str] helpers; None/empty short-circuit to set()."""
+    called = {'n': 0}
+
+    def _pgp(ids):
+        called['n'] += 1
+        assert isinstance(ids, list)  # cast happened before dispatch
+        return set()
+
+    monkeypatch.setattr(ds, 'get_sys_ids_with_pgp_text', _pgp)
+    monkeypatch.setattr(fgp, 'get_sys_ids_with_fgp_sources', lambda ids: set())
+    assert ts.get_sys_ids_with_manual_transcriptions(None) == set()
+    assert ts.get_sys_ids_with_manual_transcriptions([]) == set()
+    assert called['n'] == 0  # empty inputs never hit the source helpers
+    ts.get_sys_ids_with_manual_transcriptions(('s1', 's2'))  # tuple cast to list
+    assert called['n'] == 1
+
+
+def test_include_user_flag_is_accepted_noop(monkeypatch):
+    monkeypatch.setattr(ds, 'get_sys_ids_with_pgp_text', lambda ids: {'a'})
+    monkeypatch.setattr(fgp, 'get_sys_ids_with_fgp_sources', lambda ids: set())
+    # No user store yet -> include_user must not change the result.
+    assert ts.get_sys_ids_with_manual_transcriptions(['a'], include_user=True) == {'a'}
+    assert ts.get_sys_ids_with_manual_transcriptions(['a'], include_user=False) == {'a'}
+
+
+# --- i18n ------------------------------------------------------------------
+
+def test_tooltip_key_present_en_he():
+    import genizah_translations as gt
+    key = 'scholarly transcription/translation available'
+    assert key in gt.TRANSLATIONS
+    assert gt.TRANSLATIONS[key] == 'תעתיק/תרגום מדעי זמין'
+
+
+# --- real-DB distinction (PGP text-presence != link-presence) --------------
+
+_PGP_DB = 'pgp_data/pgp.db'
+
+
+@pytest.mark.skipif(not os.path.exists(_PGP_DB), reason='pgp.db sidecar absent')
+def test_pgp_text_predicate_is_stricter_than_link_presence():
+    """The new text-predicate must be a STRICT subset of the link helper: there
+    exists at least one sys_id that is PGP-linked but has no readable text, and it
+    must be in the link set but NOT the text set."""
+    import sqlite3
+    c = sqlite3.connect(_PGP_DB)
+    link_only = c.execute(
+        "SELECT f.sys_id FROM document_fragments f JOIN documents d ON d.pgpid=f.document_id "
+        "WHERE COALESCE(d.has_transcription,0)=0 AND COALESCE(d.has_translation,0)=0 LIMIT 1"
+    ).fetchone()
+    has_text = c.execute(
+        "SELECT f.sys_id FROM document_fragments f JOIN documents d ON d.pgpid=f.document_id "
+        "WHERE d.has_transcription=1 OR d.has_translation=1 LIMIT 1"
+    ).fetchone()
+    c.close()
+    assert link_only and has_text, 'fixture corpus lacks both cases'
+    link_only, has_text = link_only[0], has_text[0]
+
+    assert link_only in ds.get_sys_ids_with_transcriptions([link_only])      # PGP badge would show
+    assert link_only not in ds.get_sys_ids_with_pgp_text([link_only])        # manual tag correctly hidden
+    assert has_text in ds.get_sys_ids_with_pgp_text([has_text])              # manual tag shows
+    assert has_text in ts.get_sys_ids_with_manual_transcriptions([has_text])  # union includes it

--- a/tests/test_seed022_manual_transcription_tag.py
+++ b/tests/test_seed022_manual_transcription_tag.py
@@ -70,6 +70,29 @@ def test_include_user_flag_is_accepted_noop(monkeypatch):
     assert ts.get_sys_ids_with_manual_transcriptions(['a'], include_user=False) == {'a'}
 
 
+# --- web FGP kill-switch gating (GitHub Codex #303 P2) ---------------------
+
+def test_web_manual_ids_respect_web_fgp_killswitch(monkeypatch):
+    """On web, the manual-transcription union must drop FGP when WEB_FGP_ENABLED=0,
+    even if the shared FGP flag/sidecar is present — otherwise FGP-only manuscripts
+    get badged but cannot be opened in the chooser."""
+    import web.feature_flags as ff
+    import web.pages.search as wsearch
+
+    monkeypatch.setattr(wsearch, 'get_sys_ids_with_pgp_text', lambda ids: {'pgp1'})
+    monkeypatch.setattr(wsearch, 'get_sys_ids_with_fgp_sources', lambda ids: {'fgp1'})
+
+    # FGP disabled on web -> FGP set dropped; union is PGP-text only.
+    monkeypatch.setattr(ff, 'web_fgp_enabled', lambda: False)
+    assert wsearch._web_fgp_sys_ids(['x']) == set()
+    assert wsearch._web_manual_transcription_ids(['x']) == {'pgp1'}
+
+    # FGP enabled on web -> FGP set included.
+    monkeypatch.setattr(ff, 'web_fgp_enabled', lambda: True)
+    assert wsearch._web_fgp_sys_ids(['x']) == {'fgp1'}
+    assert wsearch._web_manual_transcription_ids(['x']) == {'pgp1', 'fgp1'}
+
+
 # --- i18n ------------------------------------------------------------------
 
 def test_tooltip_key_present_en_he():

--- a/web/document_service.py
+++ b/web/document_service.py
@@ -18,6 +18,7 @@ from shared.document_service import (
     get_editions_for_document as get_editions_for_document,
     get_translations_for_document as get_translations_for_document,
     get_sys_ids_with_transcriptions as get_sys_ids_with_transcriptions,
+    get_sys_ids_with_pgp_text as get_sys_ids_with_pgp_text,
     get_fragments_by_tag as get_fragments_by_tag,
     get_all_distinct_tags as get_all_distinct_tags,
     parse_html_sections as parse_html_sections,

--- a/web/pages/search.py
+++ b/web/pages/search.py
@@ -61,6 +61,29 @@ import time
 logger = logging.getLogger(__name__)
 
 
+def _web_fgp_sys_ids(sys_ids):
+    """FGP presence set, gated by the WEB-ONLY FGP kill switch (GitHub Codex #303).
+
+    The shared ``get_sys_ids_with_fgp_sources`` only honors the shared
+    ``FGP_TRANSCRIPTIONS_ENABLED`` flag; on web, FGP can be turned off independently
+    via ``WEB_FGP_ENABLED=0`` (mirrors the result-dialog/chooser gating). Without
+    this, a web deploy with FGP disabled but the sidecar present would still badge
+    FGP-only manuscripts the user cannot open. Returns set() when web FGP is off.
+    """
+    from web.feature_flags import web_fgp_enabled
+    if not web_fgp_enabled():
+        return set()
+    return get_sys_ids_with_fgp_sources(sys_ids)
+
+
+def _web_manual_transcription_ids(sys_ids):
+    """Web-aware manual-transcription union (PGP readable text ∪ web-gated FGP).
+
+    Used by the PGP-tag-browse and session-restore paths, which would otherwise call
+    the shared union helper that always includes FGP regardless of the web flag."""
+    return union_manual_transcriptions(get_sys_ids_with_pgp_text(sys_ids), _web_fgp_sys_ids(sys_ids))
+
+
 def create_search_page(initial_query: str = None, initial_tag: str = None,
                        initial_mode: str = None, initial_variants: int = None,
                        initial_ja: int = None, initial_flex_spaces: int = None,
@@ -4726,7 +4749,7 @@ def create_search_page(initial_query: str = None, initial_tag: str = None,
                 run.io_bound(collect_translations, visible_ids, _show_trans_for_enrich),
                 run.io_bound(collect_vs_availability, visible_ids),
                 run.io_bound(get_sys_ids_with_pgp_text, visible_ids),
-                run.io_bound(get_sys_ids_with_fgp_sources, visible_ids),
+                run.io_bound(_web_fgp_sys_ids, visible_ids),
             )
             # Check generation before applying (user may have started a new search)
             if search_state.search_generation == this_generation:
@@ -4790,7 +4813,7 @@ def create_search_page(initial_query: str = None, initial_tag: str = None,
                     run.io_bound(collect_translations, chunk_ids, _show_trans_for_enrich),
                     run.io_bound(collect_vs_availability, chunk_ids),
                     run.io_bound(get_sys_ids_with_pgp_text, chunk_ids),
-                    run.io_bound(get_sys_ids_with_fgp_sources, chunk_ids),
+                    run.io_bound(_web_fgp_sys_ids, chunk_ids),
                 )
                 if search_state.search_generation != this_generation:
                     break
@@ -4897,9 +4920,8 @@ def create_search_page(initial_query: str = None, initial_tag: str = None,
             try:
                 _tag_all_sids = [r.get('sys_id') for r in tag_results if r.get('sys_id')]
                 if _tag_all_sids:
-                    from shared.transcription_service import get_sys_ids_with_manual_transcriptions
                     _tag_manual_ids = await run.io_bound(
-                        get_sys_ids_with_manual_transcriptions, _tag_all_sids
+                        _web_manual_transcription_ids, _tag_all_sids
                     )
             except Exception:
                 pass  # Manual-transcription lookup failed; omit the badge
@@ -5020,10 +5042,9 @@ def create_search_page(initial_query: str = None, initial_tag: str = None,
                 # transcription union (new badge) in parallel, so both reappear on a
                 # reloaded session.
                 try:
-                    from shared.transcription_service import get_sys_ids_with_manual_transcriptions
                     link_ids, manual_ids = await asyncio.gather(
                         run.io_bound(get_sys_ids_with_transcriptions, sys_ids),
-                        run.io_bound(get_sys_ids_with_manual_transcriptions, sys_ids),
+                        run.io_bound(_web_manual_transcription_ids, sys_ids),
                     )
                     search_state.transcription_sys_ids = link_ids
                     search_state.manual_transcription_sys_ids = manual_ids

--- a/web/pages/search.py
+++ b/web/pages/search.py
@@ -4962,7 +4962,7 @@ def create_search_page(initial_query: str = None, initial_tag: str = None,
                                         ).tooltip(tr('Has PGP Transcription'))
                                         # SEED-022: manual-transcription indicator (icon + tooltip)
                                         if result.get('sys_id') in _tag_manual_ids:
-                                            ui.icon('menu_book').classes('text-sm shrink-0').props(
+                                            ui.icon('description').classes('text-sm shrink-0').props(
                                                 f'role=img aria-label="{tr("scholarly transcription/translation available")}"'
                                             ).style(
                                                 'color: var(--accent-amber, #b45309);'

--- a/web/pages/search.py
+++ b/web/pages/search.py
@@ -4959,7 +4959,7 @@ def create_search_page(initial_query: str = None, initial_tag: str = None,
                                         # PGP indicator
                                         ui.label('PGP').classes('text-xs px-2 py-0.5 rounded shrink-0').style(
                                             'background: var(--success-100); color: var(--success-700); font-weight: 600;'
-                                        ).tooltip(tr('Has PGP Transcription'))
+                                        ).tooltip(tr('Has PGP info'))
                                         # SEED-022: manual-transcription indicator (icon + tooltip)
                                         if result.get('sys_id') in _tag_manual_ids:
                                             ui.icon('description').classes('text-sm shrink-0').props(

--- a/web/pages/search.py
+++ b/web/pages/search.py
@@ -46,7 +46,12 @@ from shared.exclusion_service import (
     resolve_shelfmarks, build_shelf_map, compute_excluded_ids,
     serialize_sources, deserialize_sources,
 )
-from web.document_service import get_sys_ids_with_transcriptions, get_fragments_by_tag, get_all_distinct_tags
+from web.document_service import (
+    get_sys_ids_with_transcriptions, get_sys_ids_with_pgp_text,
+    get_fragments_by_tag, get_all_distinct_tags,
+)
+from shared.fgp_service import get_sys_ids_with_fgp_sources
+from shared.transcription_service import union_manual_transcriptions
 from urllib.parse import quote
 import logging
 import html
@@ -2120,6 +2125,7 @@ def create_search_page(initial_query: str = None, initial_tag: str = None,
         search_state.displayed_results = []
         search_state.selected_indices.clear()
         search_state.transcription_sys_ids = set()
+        search_state.manual_transcription_sys_ids = set()  # SEED-022
         search_state.total_count = 0
         search_state.current_page = 0
         search_state.result_domains = {}
@@ -4452,6 +4458,7 @@ def create_search_page(initial_query: str = None, initial_tag: str = None,
 
         # Initialize enrichment fields to empty (will be populated progressively)
         search_state.transcription_sys_ids = set()
+        search_state.manual_transcription_sys_ids = set()  # SEED-022
         search_state.all_result_domains = {}
         search_state.result_domains = {}
         search_state.domain_name_map = {}
@@ -4703,11 +4710,16 @@ def create_search_page(initial_query: str = None, initial_tag: str = None,
         _t_stage1 = time.perf_counter()
         visible_ids = all_sys_ids[:PAGE_SIZE]
         if visible_ids and search_state.search_generation == this_generation:
-            fjms_tuple, transcription_ids, trans_data, vs_avail = await asyncio.gather(
+            # SEED-022: fetch the PGP-text set and FGP set alongside the existing
+            # PGP link-presence set (transcription_ids, which still feeds the PGP
+            # badge). pgp_text ∪ fgp = the new "has manual transcription" union.
+            fjms_tuple, transcription_ids, trans_data, vs_avail, pgp_text_ids, fgp_ids = await asyncio.gather(
                 run.io_bound(collect_fjms_enrichment, visible_ids),
                 run.io_bound(get_sys_ids_with_transcriptions, visible_ids),
                 run.io_bound(collect_translations, visible_ids, _show_trans_for_enrich),
                 run.io_bound(collect_vs_availability, visible_ids),
+                run.io_bound(get_sys_ids_with_pgp_text, visible_ids),
+                run.io_bound(get_sys_ids_with_fgp_sources, visible_ids),
             )
             # Check generation before applying (user may have started a new search)
             if search_state.search_generation == this_generation:
@@ -4715,6 +4727,7 @@ def create_search_page(initial_query: str = None, initial_tag: str = None,
                 search_state._measurement_cache.update(meas_batch)  # Phase 54
                 _process_domain_data(raw_domains)
                 search_state.transcription_sys_ids = transcription_ids
+                search_state.manual_transcription_sys_ids = union_manual_transcriptions(pgp_text_ids, fgp_ids)
                 search_state.catalog_source_counts = catalog_counts
                 search_state.printed_ids = printed_ids
                 search_state.translation_data = trans_data
@@ -4758,11 +4771,13 @@ def create_search_page(initial_query: str = None, initial_tag: str = None,
                 if search_state.search_generation != this_generation:
                     break  # New search started, abandon background enrichment
                 chunk_ids = remaining_ids[chunk_start:chunk_start + CHUNK_SIZE]
-                bg_fjms_tuple, bg_trans_ids, bg_trans_data, bg_vs = await asyncio.gather(
+                bg_fjms_tuple, bg_trans_ids, bg_trans_data, bg_vs, bg_pgp_text_ids, bg_fgp_ids = await asyncio.gather(
                     run.io_bound(collect_fjms_enrichment, chunk_ids),
                     run.io_bound(get_sys_ids_with_transcriptions, chunk_ids),
                     run.io_bound(collect_translations, chunk_ids, _show_trans_for_enrich),
                     run.io_bound(collect_vs_availability, chunk_ids),
+                    run.io_bound(get_sys_ids_with_pgp_text, chunk_ids),
+                    run.io_bound(get_sys_ids_with_fgp_sources, chunk_ids),
                 )
                 if search_state.search_generation != this_generation:
                     break
@@ -4770,6 +4785,7 @@ def create_search_page(initial_query: str = None, initial_tag: str = None,
                 search_state._measurement_cache.update(bg_meas)  # Phase 54
                 _process_domain_data(bg_domains)
                 search_state.transcription_sys_ids |= bg_trans_ids
+                search_state.manual_transcription_sys_ids |= union_manual_transcriptions(bg_pgp_text_ids, bg_fgp_ids)
                 search_state.catalog_source_counts.update(bg_counts)
                 search_state.printed_ids |= bg_printed
                 search_state.translation_data.update(bg_trans_data)
@@ -4861,6 +4877,20 @@ def create_search_page(initial_query: str = None, initial_tag: str = None,
                 except Exception:
                     pass  # Translation lookup failed; continue without translation
 
+            # SEED-022: which tag-result sys_ids have readable manual text (PGP
+            # text ∪ FGP). The PGP badge below is unconditional (tag search is
+            # PGP-scoped); the new manual badge is conditional on actual text.
+            _tag_manual_ids: set = set()
+            try:
+                _tag_all_sids = [r.get('sys_id') for r in tag_results if r.get('sys_id')]
+                if _tag_all_sids:
+                    from shared.transcription_service import get_sys_ids_with_manual_transcriptions
+                    _tag_manual_ids = await run.io_bound(
+                        get_sys_ids_with_manual_transcriptions, _tag_all_sids
+                    )
+            except Exception:
+                pass  # Manual-transcription lookup failed; omit the badge
+
             results_container.clear()
             with results_container:
                 if not tag_results:
@@ -4895,6 +4925,11 @@ def create_search_page(initial_query: str = None, initial_tag: str = None,
                                         ui.label('PGP').classes('text-xs px-2 py-0.5 rounded shrink-0').style(
                                             'background: var(--success-100); color: var(--success-700); font-weight: 600;'
                                         ).tooltip(tr('Has PGP Transcription'))
+                                        # SEED-022: manual-transcription indicator (icon + tooltip)
+                                        if result.get('sys_id') in _tag_manual_ids:
+                                            ui.icon('menu_book').classes('text-sm shrink-0').style(
+                                                'color: var(--accent-amber, #b45309);'
+                                            ).tooltip(tr('scholarly transcription/translation available'))
                                         ui.label(result.get('shelfmark', 'Unknown')).classes(
                                             'font-bold break-all'
                                         ).style('color: var(--primary-700);')
@@ -4969,6 +5004,15 @@ def create_search_page(initial_query: str = None, initial_tag: str = None,
                 search_state.transcription_sys_ids = await run.io_bound(
                     get_sys_ids_with_transcriptions, sys_ids
                 )
+                # SEED-022: restore the manual-transcription union too, so the new
+                # badge reappears on a reloaded session (not just the PGP badge).
+                try:
+                    from shared.transcription_service import get_sys_ids_with_manual_transcriptions
+                    search_state.manual_transcription_sys_ids = await run.io_bound(
+                        get_sys_ids_with_manual_transcriptions, sys_ids
+                    )
+                except Exception:
+                    search_state.manual_transcription_sys_ids = set()
                 # Phase 999.2: PGP button + chip visibility now that transcription data is loaded.
                 _set_btn_visible(pgp_filter_btn, bool(search_state.transcription_sys_ids))
                 _update_pgp_filter_btn()

--- a/web/pages/search.py
+++ b/web/pages/search.py
@@ -4097,6 +4097,13 @@ def create_search_page(initial_query: str = None, initial_tag: str = None,
         search_state.status = tr("Starting...")
         search_state.search_start_time = time.time()
         search_state.results = []
+        # SEED-022 (Codex #303 review): clear enrichment presence sets at new-search
+        # START, not only at the later common reset (~line 4460) which a cancelled/
+        # partial render path can skip — otherwise the prior search's PGP / manual-
+        # transcription / printed icons leak onto partial results of the new one.
+        search_state.transcription_sys_ids = set()
+        search_state.manual_transcription_sys_ids = set()
+        search_state.printed_ids = set()
         search_state.search_generation += 1  # Invalidate stale background enrichment
 
         # Immediate visual feedback — swap buttons before the 500ms timer tick
@@ -4738,6 +4745,12 @@ def create_search_page(initial_query: str = None, initial_tag: str = None,
                 # Smoke verification round 2 (2026-05-21) added the
                 # ``domain_name_map`` kwarg for the xlsx Hebrew domain
                 # substitution path; built by ``_process_domain_data`` above.
+                # SEED-022 (Codex #303 review): the new manual-transcription
+                # indicator is intentionally UI-ONLY for now — it is NOT plumbed
+                # into the export payload / JSON / xlsx (the seed deferred the
+                # API/export column; adding `has_transcription` would touch the
+                # public API contract + 12-col xlsx + parity tests). Revisit if a
+                # caller asks for it.
                 from web.export_state import update_search_export_enrichment
                 update_search_export_enrichment(
                     transcription_sys_ids=search_state.transcription_sys_ids,
@@ -4927,7 +4940,9 @@ def create_search_page(initial_query: str = None, initial_tag: str = None,
                                         ).tooltip(tr('Has PGP Transcription'))
                                         # SEED-022: manual-transcription indicator (icon + tooltip)
                                         if result.get('sys_id') in _tag_manual_ids:
-                                            ui.icon('menu_book').classes('text-sm shrink-0').style(
+                                            ui.icon('menu_book').classes('text-sm shrink-0').props(
+                                                f'role=img aria-label="{tr("scholarly transcription/translation available")}"'
+                                            ).style(
                                                 'color: var(--accent-amber, #b45309);'
                                             ).tooltip(tr('scholarly transcription/translation available'))
                                         ui.label(result.get('shelfmark', 'Unknown')).classes(
@@ -5001,17 +5016,21 @@ def create_search_page(initial_query: str = None, initial_tag: str = None,
                 if r.get('display', {}).get('id')
             ]
             if sys_ids:
-                search_state.transcription_sys_ids = await run.io_bound(
-                    get_sys_ids_with_transcriptions, sys_ids
-                )
-                # SEED-022: restore the manual-transcription union too, so the new
-                # badge reappears on a reloaded session (not just the PGP badge).
+                # SEED-022: restore the PGP link set (PGP badge) AND the manual-
+                # transcription union (new badge) in parallel, so both reappear on a
+                # reloaded session.
                 try:
                     from shared.transcription_service import get_sys_ids_with_manual_transcriptions
-                    search_state.manual_transcription_sys_ids = await run.io_bound(
-                        get_sys_ids_with_manual_transcriptions, sys_ids
+                    link_ids, manual_ids = await asyncio.gather(
+                        run.io_bound(get_sys_ids_with_transcriptions, sys_ids),
+                        run.io_bound(get_sys_ids_with_manual_transcriptions, sys_ids),
                     )
+                    search_state.transcription_sys_ids = link_ids
+                    search_state.manual_transcription_sys_ids = manual_ids
                 except Exception:
+                    search_state.transcription_sys_ids = await run.io_bound(
+                        get_sys_ids_with_transcriptions, sys_ids
+                    )
                     search_state.manual_transcription_sys_ids = set()
                 # Phase 999.2: PGP button + chip visibility now that transcription data is loaded.
                 _set_btn_visible(pgp_filter_btn, bool(search_state.transcription_sys_ids))

--- a/web/pages/search_results.py
+++ b/web/pages/search_results.py
@@ -469,6 +469,14 @@ def create_result_card(search_state, refs, index, result):
                         ui.label('PGP').classes('text-xs px-2 py-0.5 rounded shrink-0').style(
                             'background: var(--success-100); color: var(--success-700); font-weight: 600;'
                         ).tooltip(tr('Has PGP Transcription'))
+                    # SEED-022: source-agnostic manual-transcription indicator (icon +
+                    # tooltip). Additive; sits beside the PGP badge with a distinct
+                    # (amber) hue. Shown when the mss has any readable manual
+                    # transcription/translation (PGP text ∪ FGP).
+                    if sys_id and sys_id in getattr(search_state, 'manual_transcription_sys_ids', set()):
+                        ui.icon('menu_book').classes('text-sm shrink-0').style(
+                            'color: var(--accent-amber, #b45309);'
+                        ).tooltip(tr('scholarly transcription/translation available'))
                     # Domain indicator
                     if sys_id and search_state.result_domains:
                         domains_for_result = search_state.result_domains.get(sys_id, [])

--- a/web/pages/search_results.py
+++ b/web/pages/search_results.py
@@ -474,7 +474,9 @@ def create_result_card(search_state, refs, index, result):
                     # (amber) hue. Shown when the mss has any readable manual
                     # transcription/translation (PGP text ∪ FGP).
                     if sys_id and sys_id in getattr(search_state, 'manual_transcription_sys_ids', set()):
-                        ui.icon('menu_book').classes('text-sm shrink-0').style(
+                        ui.icon('menu_book').classes('text-sm shrink-0').props(
+                            f'role=img aria-label="{tr("scholarly transcription/translation available")}"'
+                        ).style(
                             'color: var(--accent-amber, #b45309);'
                         ).tooltip(tr('scholarly transcription/translation available'))
                     # Domain indicator

--- a/web/pages/search_results.py
+++ b/web/pages/search_results.py
@@ -474,7 +474,7 @@ def create_result_card(search_state, refs, index, result):
                     # (amber) hue. Shown when the mss has any readable manual
                     # transcription/translation (PGP text ∪ FGP).
                     if sys_id and sys_id in getattr(search_state, 'manual_transcription_sys_ids', set()):
-                        ui.icon('menu_book').classes('text-sm shrink-0').props(
+                        ui.icon('description').classes('text-sm shrink-0').props(
                             f'role=img aria-label="{tr("scholarly transcription/translation available")}"'
                         ).style(
                             'color: var(--accent-amber, #b45309);'

--- a/web/pages/search_results.py
+++ b/web/pages/search_results.py
@@ -468,7 +468,7 @@ def create_result_card(search_state, refs, index, result):
                     if sys_id and sys_id in search_state.transcription_sys_ids:
                         ui.label('PGP').classes('text-xs px-2 py-0.5 rounded shrink-0').style(
                             'background: var(--success-100); color: var(--success-700); font-weight: 600;'
-                        ).tooltip(tr('Has PGP Transcription'))
+                        ).tooltip(tr('Has PGP info'))
                     # SEED-022: source-agnostic manual-transcription indicator (icon +
                     # tooltip). Additive; sits beside the PGP badge with a distinct
                     # (amber) hue. Shown when the mss has any readable manual

--- a/web/pages/search_state.py
+++ b/web/pages/search_state.py
@@ -40,7 +40,11 @@ class SearchUIState:
         self.is_panel_collapsed = False  # For collapsible search panel
         self.last_scroll_top = 0  # For scroll-based auto-collapse
         self.update_timer = None  # Track progress update asyncio Task to prevent duplicates
-        self.transcription_sys_ids: Set[str] = set()  # sys_ids with PGP transcriptions
+        self.transcription_sys_ids: Set[str] = set()  # sys_ids with PGP transcriptions (link-presence; PGP badge)
+        # SEED-022: sys_ids with ANY readable manual transcription/translation
+        # (PGP text ∪ FGP). Source-agnostic; rendered as a SEPARATE additive badge
+        # alongside the PGP one. Do NOT conflate with transcription_sys_ids above.
+        self.manual_transcription_sys_ids: Set[str] = set()
         self.displayed_results = []  # Currently rendered subset (may be filtered)
         self.builder_negated_words: list = []  # Words negated via Query Builder
         self.result_domains: dict = {}  # Domain classification map for result indicators


### PR DESCRIPTION
SEED-022 web side — a NEW, additive, source-agnostic **"has manual transcription"** indicator. Answers *"is there a manual/scholarly transcription or translation to READ here?"* regardless of source. The existing **PGP badge is unchanged.**

Built per the Codex **GO-WITH-CHANGES** review of the seed (corrections folded into `.planning/seeds/SEED-022-*.md`).

## Key design decision (Codex B1)
The existing PGP badge helper (`get_sys_ids_with_transcriptions`) is pure **link-presence** — `SELECT DISTINCT sys_id FROM document_fragments` → **~34,171** sys_ids (nearly the whole corpus). That's "is this in PGP at all," not "has text." The new tag uses a **text-presence** predicate `get_sys_ids_with_pgp_text` (`JOIN documents … WHERE has_transcription=1 OR has_translation=1`) → **~7,331** sys_ids with genuine readable text.

**Intended consequence:** a PGP-linked-but-textless manuscript shows the PGP badge but **not** the new tag — correct, there's nothing to read.

## What's here
- `shared/transcription_service.py` — `get_sys_ids_with_manual_transcriptions` = PGP-text ∪ FGP (translations included; FGP-absent degrades to PGP-text). `include_user` slot reserved (no store yet). List-cast signature (B2).
- `shared/document_service.py` — new `get_sys_ids_with_pgp_text` + wrapper; **PGP link helper untouched.**
- Web: new `search_state.manual_transcription_sys_ids`; both enrichment passes fetch PGP-text + FGP concurrently and union inline (no PGP re-query); session restore reloads it; PGP-tag-browse branch renders it; init/cleared at all reset sites.
- Badge: `menu_book` icon + tooltip *scholarly transcription/translation available* / *תעתיק/תרגום מדעי זמין*, amber, beside the green PGP badge.

## Deferred (per review)
Desktop side (`COL_TRANSCRIPTION` **appended** as col 12 — no index shift — + `PGPBadgeWorker` emits the union) is a **separate follow-up PR**. API/export columns deferred.

## Tests
`tests/test_seed022_manual_transcription_tag.py`: union logic, list-cast, None/empty-safe, FGP-absent degrade, FGP-only surfaces, i18n key, real-DB text-vs-link distinction. 41 + a11y/pgp-filter/i18n suites green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
