### PR TITLE
feat(desktop): SEED-022 — scholarly-transcription column in results table

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -6993,7 +6993,7 @@ class GenizahGUI(QMainWindow):
         self.COL_TRANSCRIPTION = 12  # SEED-022: APPENDED (no index shift) — manual transcription/translation
 
         self.results_table = QTableWidget(); self.results_table.setColumnCount(13)
-        self.results_table.setHorizontalHeaderLabels(["", "", tr("System ID"), tr("Library"), tr("Shelfmark"), tr("Img"), tr("Title"), tr("Snippet"), tr("Src"), tr("PGP"), tr("Domain"), tr("Printed"), tr("Scholarly")])
+        self.results_table.setHorizontalHeaderLabels(["", "", tr("System ID"), tr("Library"), tr("Shelfmark"), tr("Img"), tr("Title"), tr("Snippet"), tr("Src"), tr("PGP"), tr("Domain"), tr("Printed"), tr("Edition")])
         # Tooltip for PGP column header
         self.results_table.horizontalHeaderItem(self.COL_PGP).setToolTip(tr("Scholarly transcriptions/data available from the Princeton Geniza Project"))
         self.results_table.horizontalHeaderItem(self.COL_PRINTED).setToolTip(tr("Printed material (not handwritten manuscript)"))
@@ -7029,6 +7029,14 @@ class GenizahGUI(QMainWindow):
         self.results_table.horizontalHeader().setSectionResizeMode(self.COL_PGP, QHeaderView.ResizeMode.Fixed)
         self.results_table.horizontalHeader().setSectionResizeMode(self.COL_PRINTED, QHeaderView.ResizeMode.Fixed)
         self.results_table.horizontalHeader().setSectionResizeMode(self.COL_TRANSCRIPTION, QHeaderView.ResizeMode.Fixed)
+        # SEED-022 (UAT): place PGP visually adjacent to the Edition column — move it
+        # to sit right after Printed. This is a VISUAL move only; logical indices
+        # (COL_*) are unchanged, and CheckBoxHeader is fully logical-index based
+        # (paintSection/logicalIndexAt/sectionViewportPosition), so filters, sorting,
+        # clicks and persistence are unaffected — only the display order changes.
+        # Final visual order: … Domain, Printed, PGP, Edition.
+        _res_hdr = self.results_table.horizontalHeader()
+        _res_hdr.moveSection(_res_hdr.visualIndex(self.COL_PGP), _res_hdr.visualIndex(self.COL_PRINTED))
         # Ensure column 0 is not sortable to avoid confusion with check action
         self.results_table.horizontalHeader().setSectionResizeMode(self.COL_CHECKBOX, QHeaderView.ResizeMode.Fixed)
         self.results_table.horizontalHeader().setSectionResizeMode(self.COL_ACTIONS, QHeaderView.ResizeMode.Fixed)

--- a/genizah_app.py
+++ b/genizah_app.py
@@ -3380,6 +3380,7 @@ class GenizahGUI(QMainWindow):
         self.results_filters = {}
         self.list_filter_state = {'active': False, 'mode': 'in', 'lists': 'all'}
         self._pgp_transcription_sys_ids = set()
+        self._manual_transcription_sys_ids = set()  # SEED-022: PGP text ∪ FGP (scholarly transcription/translation)
         self._pgp_badge_worker = None
         self._printed_badge_worker = None
         self._printed_sys_ids = set()
@@ -6989,12 +6990,15 @@ class GenizahGUI(QMainWindow):
         self.COL_PGP = 9
         self.COL_DOMAIN = 10
         self.COL_PRINTED = 11
+        self.COL_TRANSCRIPTION = 12  # SEED-022: APPENDED (no index shift) — manual transcription/translation
 
-        self.results_table = QTableWidget(); self.results_table.setColumnCount(12)
-        self.results_table.setHorizontalHeaderLabels(["", "", tr("System ID"), tr("Library"), tr("Shelfmark"), tr("Img"), tr("Title"), tr("Snippet"), tr("Src"), tr("PGP"), tr("Domain"), tr("Printed")])
+        self.results_table = QTableWidget(); self.results_table.setColumnCount(13)
+        self.results_table.setHorizontalHeaderLabels(["", "", tr("System ID"), tr("Library"), tr("Shelfmark"), tr("Img"), tr("Title"), tr("Snippet"), tr("Src"), tr("PGP"), tr("Domain"), tr("Printed"), tr("Scholarly")])
         # Tooltip for PGP column header
         self.results_table.horizontalHeaderItem(self.COL_PGP).setToolTip(tr("Scholarly transcriptions/data available from the Princeton Geniza Project"))
         self.results_table.horizontalHeaderItem(self.COL_PRINTED).setToolTip(tr("Printed material (not handwritten manuscript)"))
+        # SEED-022: source-agnostic "has readable manual transcription/translation" column
+        self.results_table.horizontalHeaderItem(self.COL_TRANSCRIPTION).setToolTip(tr("scholarly transcription/translation available"))
 
         # Custom Header
         # Disable sort for Checkbox (0), Actions (1), and Image (5)
@@ -7005,7 +7009,7 @@ class GenizahGUI(QMainWindow):
             filter_callback=self._open_results_filter_dialog,
             star_columns=[self.COL_ACTIONS],
             star_callback=self.toggle_list_filter,
-            desc_first_cols=[self.COL_PGP, self.COL_PRINTED]
+            desc_first_cols=[self.COL_PGP, self.COL_PRINTED, self.COL_TRANSCRIPTION]
         )
         self.chk_search_header.toggled.connect(self.on_search_select_all_toggled)
         self.results_table.setHorizontalHeader(self.chk_search_header)
@@ -7019,10 +7023,12 @@ class GenizahGUI(QMainWindow):
         self.results_table.setColumnWidth(self.COL_PGP, 40)  # PGP badge column
         self.results_table.setColumnWidth(self.COL_DOMAIN, 130)  # Domain column
         self.results_table.setColumnWidth(self.COL_PRINTED, 50)  # Printed badge column
+        self.results_table.setColumnWidth(self.COL_TRANSCRIPTION, 70)  # SEED-022 scholarly-transcription badge
         self.results_table.horizontalHeader().setSectionResizeMode(self.COL_SNIPPET, QHeaderView.ResizeMode.Interactive)
         self.results_table.setColumnWidth(self.COL_SNIPPET, 600)
         self.results_table.horizontalHeader().setSectionResizeMode(self.COL_PGP, QHeaderView.ResizeMode.Fixed)
         self.results_table.horizontalHeader().setSectionResizeMode(self.COL_PRINTED, QHeaderView.ResizeMode.Fixed)
+        self.results_table.horizontalHeader().setSectionResizeMode(self.COL_TRANSCRIPTION, QHeaderView.ResizeMode.Fixed)
         # Ensure column 0 is not sortable to avoid confusion with check action
         self.results_table.horizontalHeader().setSectionResizeMode(self.COL_CHECKBOX, QHeaderView.ResizeMode.Fixed)
         self.results_table.horizontalHeader().setSectionResizeMode(self.COL_ACTIONS, QHeaderView.ResizeMode.Fixed)
@@ -18008,6 +18014,7 @@ class GenizahGUI(QMainWindow):
 
         # 7. Clear printed filter state
         self._printed_sys_ids = set()
+        self._manual_transcription_sys_ids = set()  # SEED-022
         self._printed_filter_state = 'all'
         if hasattr(self, 'chk_search_header'):
             self.chk_search_header.set_filter_active(self.COL_PRINTED, False)
@@ -18267,6 +18274,15 @@ class GenizahGUI(QMainWindow):
             else:
                 self.results_table.setItem(row_idx, self.COL_PRINTED, QTableWidgetItem(""))
 
+            # SEED-022: scholarly transcription/translation badge (amber check)
+            if sid and sid in self._manual_transcription_sys_ids:
+                tr_item = QTableWidgetItem("\u2713")
+                tr_item.setForeground(QColor("#b45309"))
+                tr_item.setToolTip(tr("scholarly transcription/translation available"))
+                self.results_table.setItem(row_idx, self.COL_TRANSCRIPTION, tr_item)
+            else:
+                self.results_table.setItem(row_idx, self.COL_TRANSCRIPTION, QTableWidgetItem(""))
+
             self._update_search_row_list_indicator(row_idx, res)
 
         self.results_loaded = end_idx
@@ -18357,6 +18373,7 @@ class GenizahGUI(QMainWindow):
             self._result_domain_counts = {}
             self._result_domain_map = {}
             self._printed_sys_ids = set()
+            self._manual_transcription_sys_ids = set()  # SEED-022
             # Phase 55: Zero-result refinement -- don't commit step (D-14a)
             if self._refine_mode:
                 self._zero_result_refine = True
@@ -19293,9 +19310,12 @@ class GenizahGUI(QMainWindow):
                 tr("Showing {} of {} results").format(visible_count, total)
             )
 
-    def _on_pgp_badges_loaded(self, pgp_sys_ids):
-        """Handle PGP badge worker results - update badge column for all rows."""
+    def _on_pgp_badges_loaded(self, pgp_sys_ids, manual_sys_ids):
+        """Handle PGP badge worker results - update the PGP + scholarly-transcription
+        columns for all rows (SEED-022). pgp_sys_ids = PGP link presence (green "PGP");
+        manual_sys_ids = readable transcription/translation, PGP text ∪ FGP (amber ✓)."""
         self._pgp_transcription_sys_ids = pgp_sys_ids
+        self._manual_transcription_sys_ids = manual_sys_ids
         for row in range(self.results_table.rowCount()):
             item = self.results_table.item(row, self.COL_SYS_ID)
             if item:
@@ -19306,6 +19326,13 @@ class GenizahGUI(QMainWindow):
                     self.results_table.setItem(row, self.COL_PGP, pgp_item)
                 else:
                     self.results_table.setItem(row, self.COL_PGP, QTableWidgetItem(""))
+                if sys_id in manual_sys_ids:
+                    tr_item = QTableWidgetItem("✓")
+                    tr_item.setForeground(QColor("#b45309"))
+                    tr_item.setToolTip(tr("scholarly transcription/translation available"))
+                    self.results_table.setItem(row, self.COL_TRANSCRIPTION, tr_item)
+                else:
+                    self.results_table.setItem(row, self.COL_TRANSCRIPTION, QTableWidgetItem(""))
         self._apply_results_table_filters()
 
     def _on_printed_badges_loaded(self, printed_sys_ids):

--- a/genizah_app.py
+++ b/genizah_app.py
@@ -19526,6 +19526,17 @@ class GenizahGUI(QMainWindow):
 
         # Mark all as PGP
         self._pgp_transcription_sys_ids = {r['display']['id'] for r in formatted}
+        # SEED-022: this PGP-tag path bypasses the badge worker, so compute the
+        # scholarly-transcription set (PGP text ∪ FGP) for the new column here too —
+        # otherwise it would render stale/blank. Tag-result counts are bounded and
+        # this is two batched SQLite queries (lighter than the per-row meta loop above).
+        try:
+            from shared.transcription_service import get_sys_ids_with_manual_transcriptions
+            self._manual_transcription_sys_ids = get_sys_ids_with_manual_transcriptions(
+                [r['display']['id'] for r in formatted]
+            )
+        except Exception:
+            self._manual_transcription_sys_ids = set()
 
         self.chk_search_header.blockSignals(True)
         self.chk_search_header.setChecked(False)

--- a/genizah_translations.py
+++ b/genizah_translations.py
@@ -2090,7 +2090,7 @@ TRANSLATIONS = {
     # SEED-022: source-agnostic "has manual transcription" indicator tooltip.
     "scholarly transcription/translation available": "תעתיק/תרגום מדעי זמין",
     # SEED-022: desktop results-table column header for the above (concise).
-    "Scholarly": "מדעי",
+    "Edition": "מהדורה",
     "PGP Transcription": "תעתוק PGP",
     "PGP Transcriptions": "תעתוקי PGP",
     # --- FGP (Friedberg Genizah Project) Transcription ---

--- a/genizah_translations.py
+++ b/genizah_translations.py
@@ -2089,6 +2089,8 @@ TRANSLATIONS = {
     "Has PGP info": "יש מידע PGP",
     # SEED-022: source-agnostic "has manual transcription" indicator tooltip.
     "scholarly transcription/translation available": "תעתיק/תרגום מדעי זמין",
+    # SEED-022: desktop results-table column header for the above (concise).
+    "Scholarly": "מדעי",
     "PGP Transcription": "תעתוק PGP",
     "PGP Transcriptions": "תעתוקי PGP",
     # --- FGP (Friedberg Genizah Project) Transcription ---

--- a/gui_threads.py
+++ b/gui_threads.py
@@ -791,8 +791,18 @@ class PGPSourceWorker(QThread):
 
 
 class PGPBadgeWorker(QThread):
-    """Batch check which sys_ids have PGP transcriptions for badge display."""
-    finished = pyqtSignal(set)
+    """Batch check badge sets for the results table (SEED-022).
+
+    Emits TWO sets:
+      * pgp_link_ids  -- sys_ids present in PGP (document_fragments link presence;
+        feeds the unchanged green "PGP" badge = "has PGP info", ~34K corpus-wide).
+      * manual_ids    -- sys_ids with readable manual transcription/translation
+        (PGP text presence ∪ FGP, translations included; feeds the new amber
+        "scholarly transcription" column, ~7.3K). FGP honors the shared
+        FGP_TRANSCRIPTIONS_ENABLED flag (no web-only override on desktop).
+    These are DIFFERENT predicates (link vs readable text), not a duplicate query.
+    """
+    finished = pyqtSignal(set, set)
 
     def __init__(self, sys_ids: list, parent=None):
         super().__init__(parent)
@@ -801,11 +811,13 @@ class PGPBadgeWorker(QThread):
     def run(self):
         try:
             from shared.document_service import get_sys_ids_with_transcriptions
-            result = get_sys_ids_with_transcriptions(self.sys_ids)
-            self.finished.emit(result)
+            from shared.transcription_service import get_sys_ids_with_manual_transcriptions
+            pgp_link_ids = get_sys_ids_with_transcriptions(self.sys_ids)
+            manual_ids = get_sys_ids_with_manual_transcriptions(self.sys_ids)
+            self.finished.emit(pgp_link_ids, manual_ids)
         except Exception as e:
             logger.error("PGPBadgeWorker error: %s", e)
-            self.finished.emit(set())
+            self.finished.emit(set(), set())
 
 
 class PrintedBadgeWorker(QThread):

--- a/gui_threads.py
+++ b/gui_threads.py
@@ -809,15 +809,21 @@ class PGPBadgeWorker(QThread):
         self.sys_ids = sys_ids
 
     def run(self):
+        # Isolate the two queries (Codex #304 review): a failure in the new manual
+        # enrichment must NOT clear the unchanged green PGP badges (and vice versa).
+        pgp_link_ids: set = set()
+        manual_ids: set = set()
         try:
             from shared.document_service import get_sys_ids_with_transcriptions
-            from shared.transcription_service import get_sys_ids_with_manual_transcriptions
             pgp_link_ids = get_sys_ids_with_transcriptions(self.sys_ids)
-            manual_ids = get_sys_ids_with_manual_transcriptions(self.sys_ids)
-            self.finished.emit(pgp_link_ids, manual_ids)
         except Exception as e:
-            logger.error("PGPBadgeWorker error: %s", e)
-            self.finished.emit(set(), set())
+            logger.error("PGPBadgeWorker PGP-link error: %s", e)
+        try:
+            from shared.transcription_service import get_sys_ids_with_manual_transcriptions
+            manual_ids = get_sys_ids_with_manual_transcriptions(self.sys_ids)
+        except Exception as e:
+            logger.error("PGPBadgeWorker manual-transcription error: %s", e)
+        self.finished.emit(pgp_link_ids, manual_ids)
 
 
 class PrintedBadgeWorker(QThread):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,7 @@ if os.environ.get("GITHUB_ACTIONS", "").lower() == "true":
 # ---------------------------------------------------------------------------
 _GUI_TEST_FILES = {
     "test_telemetry_consent_ux.py",
+    "test_seed022_desktop_badge.py",
 }
 
 

--- a/tests/test_seed022_desktop_badge.py
+++ b/tests/test_seed022_desktop_badge.py
@@ -30,20 +30,41 @@ def test_pgp_badge_worker_emits_link_and_manual(monkeypatch):
     assert captured.get('manual') == {'b'}          # -> amber scholarly column
 
 
-def test_pgp_badge_worker_error_emits_two_empty_sets(monkeypatch):
+def _boom(ids):
+    raise RuntimeError('db down')
+
+
+def _run_worker(monkeypatch, *, pgp, manual):
+    """Run PGPBadgeWorker with monkeypatched source helpers (each may be a set or
+    the _boom raiser) and return the captured (pgp, manual) emission."""
     import shared.document_service as ds
-
-    def boom(ids):
-        raise RuntimeError('db down')
-
-    monkeypatch.setattr(ds, 'get_sys_ids_with_transcriptions', boom)
-
+    import shared.transcription_service as ts
+    monkeypatch.setattr(ds, 'get_sys_ids_with_transcriptions', pgp if callable(pgp) else (lambda ids: pgp))
+    monkeypatch.setattr(ts, 'get_sys_ids_with_manual_transcriptions', manual if callable(manual) else (lambda ids: manual))
     from gui_threads import PGPBadgeWorker
     captured = {}
-    w = PGPBadgeWorker(['a'])
-    w.finished.connect(lambda pgp, manual: captured.update(pgp=pgp, manual=manual))
+    w = PGPBadgeWorker(['a', 'b'])
+    w.finished.connect(lambda p, m: captured.update(pgp=p, manual=m))
     w.run()
+    return captured
 
-    # Must still emit the (set, set) shape so the slot signature never mismatches.
+
+def test_manual_failure_does_not_clear_pgp(monkeypatch):
+    """If the new manual-union query fails, the green PGP badges must survive."""
+    captured = _run_worker(monkeypatch, pgp={'a', 'b'}, manual=_boom)
+    assert captured.get('pgp') == {'a', 'b'}
+    assert captured.get('manual') == set()
+
+
+def test_pgp_failure_does_not_clear_manual(monkeypatch):
+    """Symmetric: a PGP-link failure must not wipe the manual column."""
+    captured = _run_worker(monkeypatch, pgp=_boom, manual={'b'})
+    assert captured.get('pgp') == set()
+    assert captured.get('manual') == {'b'}
+
+
+def test_both_failures_emit_two_empty_sets(monkeypatch):
+    """Both fail -> still emit the (set, set) shape so the slot never mismatches."""
+    captured = _run_worker(monkeypatch, pgp=_boom, manual=_boom)
     assert captured.get('pgp') == set()
     assert captured.get('manual') == set()

--- a/tests/test_seed022_desktop_badge.py
+++ b/tests/test_seed022_desktop_badge.py
@@ -1,0 +1,49 @@
+"""SEED-022 desktop — PGPBadgeWorker emits BOTH badge sets.
+
+The worker now feeds two results-table columns:
+  * the unchanged green "PGP" badge  (link presence -> get_sys_ids_with_transcriptions)
+  * the new amber scholarly-transcription column (PGP text ∪ FGP ->
+    get_sys_ids_with_manual_transcriptions).
+
+These are distinct predicates. GUI-marked (PyQt signals); runs in the gui-tests job.
+"""
+
+from PyQt6.QtWidgets import QApplication
+
+_app = QApplication.instance() or QApplication([])
+
+
+def test_pgp_badge_worker_emits_link_and_manual(monkeypatch):
+    import shared.document_service as ds
+    import shared.transcription_service as ts
+    # Link presence (PGP badge) is a SUPERSET of readable text here.
+    monkeypatch.setattr(ds, 'get_sys_ids_with_transcriptions', lambda ids: {'a', 'b', 'c'})
+    monkeypatch.setattr(ts, 'get_sys_ids_with_manual_transcriptions', lambda ids: {'b'})
+
+    from gui_threads import PGPBadgeWorker
+    captured = {}
+    w = PGPBadgeWorker(['a', 'b', 'c'])
+    w.finished.connect(lambda pgp, manual: captured.update(pgp=pgp, manual=manual))
+    w.run()  # synchronous (not .start()) -> direct-connected slot fires inline
+
+    assert captured.get('pgp') == {'a', 'b', 'c'}   # -> green "PGP" column
+    assert captured.get('manual') == {'b'}          # -> amber scholarly column
+
+
+def test_pgp_badge_worker_error_emits_two_empty_sets(monkeypatch):
+    import shared.document_service as ds
+
+    def boom(ids):
+        raise RuntimeError('db down')
+
+    monkeypatch.setattr(ds, 'get_sys_ids_with_transcriptions', boom)
+
+    from gui_threads import PGPBadgeWorker
+    captured = {}
+    w = PGPBadgeWorker(['a'])
+    w.finished.connect(lambda pgp, manual: captured.update(pgp=pgp, manual=manual))
+    w.run()
+
+    # Must still emit the (set, set) shape so the slot signature never mismatches.
+    assert captured.get('pgp') == set()
+    assert captured.get('manual') == set()


### PR DESCRIPTION
SEED-022 desktop side — the counterpart to the merged web badge (#303). A NEW results-table column flags whether a manuscript has any **readable manual transcription/translation** (PGP text ∪ FGP), source-agnostic. The existing green **PGP** column is unchanged.

Built per the Codex **GO-WITH-CHANGES** review of the seed.

## What's here
- **Column APPENDED, not inserted (Codex B3):** `COL_TRANSCRIPTION = 12`, `setColumnCount(13)`. No existing `COL_*` index shifts → headers/widths/resize-modes/filter-columns/persisted indices untouched. Header **"Scholarly" / "מדעי"** + tooltip *scholarly transcription/translation available* / *תעתיק/תרגום מדעי זמין*; fixed width, desc-first sort like PGP/Printed. Cell = amber **✓**.
- **`PGPBadgeWorker` now emits two sets** `(pgp_link_ids, manual_ids)`: the unchanged PGP link-presence set (green "PGP" = "has PGP info") + `get_sys_ids_with_manual_transcriptions` (PGP text ∪ FGP, translations included; FGP honors the shared `FGP_TRANSCRIPTIONS_ENABLED` flag — desktop has no web-only override). Distinct predicates, not a duplicate query.
- **`_on_pgp_badges_loaded(pgp, manual)`** + the row-render loop populate the new column. State `_manual_transcription_sys_ids` initialized in `__init__`, cleared at the reset + no-results sites alongside `_printed_sys_ids`. Populates on session restore via the existing (deferred) worker, exactly like PGP.

## Tests
`tests/test_seed022_desktop_badge.py` — worker emits link+manual; error path emits two empty sets (so the slot arity never mismatches). GUI-marked (PyQt signals), registered in conftest `_GUI_TEST_FILES`. 16 SEED-022 + i18n tests green; ruff + py_compile clean.

## Note
Headless tests can't construct the full main window, so the column wiring (count/index/render) is verified by compile + ruff + the append-only invariant (header-label count == `setColumnCount` == 13). Worth a quick desktop UAT: run a search, confirm the amber ✓ appears in the new "מדעי/Scholarly" column for manuscripts with readable text, and that PGP/Domain/Printed columns are unshifted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
