### PR TITLE
fix(desktop): valid QScrollArea stylesheets (silence startup parse warnings)

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -7969,7 +7969,7 @@ class GenizahGUI(QMainWindow):
         edit_bar_layout.addWidget(self.btn_b_cancel_edit)
 
         edit_scroll = _make_scrollable_row(edit_bar_layout)
-        edit_scroll.setStyleSheet("background: transparent; QScrollBar:horizontal { height: 6px; }")
+        edit_scroll.setStyleSheet("QScrollArea { background: transparent; } QScrollBar:horizontal { height: 6px; }")
         edit_outer.addWidget(edit_scroll)
 
         self.browse_edit_bar.hide()
@@ -8070,7 +8070,7 @@ class GenizahGUI(QMainWindow):
         rd_toolbar_layout.addWidget(btn_rd_exit)
 
         rd_scroll = _make_scrollable_row(rd_toolbar_layout)
-        rd_scroll.setStyleSheet("background: transparent; QScrollBar:horizontal { height: 6px; }")
+        rd_scroll.setStyleSheet("QScrollArea { background: transparent; } QScrollBar:horizontal { height: 6px; }")
         rd_outer.addWidget(rd_scroll)
 
         self.browse_rd_toolbar.hide()


### PR DESCRIPTION
Silences the repeated startup console warning:
`Could not parse stylesheet of object QScrollArea(0x...)`

## Cause
The Browse edit-bar and reading-desk toolbar scroll rows set a stylesheet that **mixes a top-level bare declaration with a selector block**:
```python
"background: transparent; QScrollBar:horizontal { height: 6px; }"
```
Qt's stylesheet parser can't parse a bare `property: value;` at the top level followed by a selector rule — it rejects the **entire** sheet. So neither the transparent background nor the 6px scrollbar was ever applied, and Qt logged the warning on every (re)polish of the two `QScrollArea` objects.

## Fix
Wrap the declaration in a `QScrollArea {}` selector so the sheet is valid Qt CSS and both rules take effect:
```python
"QScrollArea { background: transparent; } QScrollBar:horizontal { height: 6px; }"
```
Two call sites (`edit_scroll`, `rd_scroll` from `_make_scrollable_row`). A repo-wide scan for the same mixed pattern (`decl ; … {`) found no others. ruff + py_compile clean. Net effect: no more console spam, and the scroll rows now actually render transparent with the thin scrollbar as originally intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
