### PR TITLE
feat(web): SEED-023 Part A — homepage corpus-stats band

### DIFF
--- a/genizah_translations.py
+++ b/genizah_translations.py
@@ -2091,6 +2091,10 @@ TRANSLATIONS = {
     "scholarly transcription/translation available": "תעתיק/תרגום מדעי זמין",
     # SEED-022: desktop results-table column header for the above (concise).
     "Edition": "מהדורה",
+    # SEED-023: homepage corpus-stats band labels ("Manuscripts"/"Images" already exist).
+    "Catalog entries": "רשומות קטלוג",
+    "Scholarly editions": "מהדורות מדעיות",
+    "Automatic transcriptions": "תעתוקים אוטומטיים",
     "PGP Transcription": "תעתוק PGP",
     "PGP Transcriptions": "תעתוקי PGP",
     # --- FGP (Friedberg Genizah Project) Transcription ---

--- a/tests/test_seed023_stats_service.py
+++ b/tests/test_seed023_stats_service.py
@@ -1,0 +1,99 @@
+"""SEED-023 Part A — cached homepage corpus stats (web/stats_service.py)."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+import web.stats_service as ss
+
+_EXPECTED = {
+    "manuscripts": 255723,
+    "catalog_entries": 731354,
+    "images": 1019886,
+    "scholarly_editions": 27424,
+    "automatic_transcriptions": 232450,
+}
+
+
+def _patch_all(monkeypatch, **vals):
+    monkeypatch.setattr(ss, "_count_manuscripts", lambda: vals["manuscripts"])
+    monkeypatch.setattr(ss, "_count_catalog_entries", lambda: vals["catalog_entries"])
+    monkeypatch.setattr(ss, "_count_image_records", lambda: vals["images"])
+    monkeypatch.setattr(ss, "_count_scholarly_editions", lambda: vals["scholarly_editions"])
+    monkeypatch.setattr(ss, "_count_automatic_transcriptions", lambda: vals["automatic_transcriptions"])
+
+
+def test_aggregates_and_memoizes_when_corpus_ready(monkeypatch):
+    ss.reset_cache()
+    _patch_all(monkeypatch, **_EXPECTED)
+    s = ss.get_corpus_stats()
+    for k, v in _EXPECTED.items():
+        assert s[k] == v
+    assert "computed_at" in s
+    assert ss._CACHE is not None  # memoized (manuscripts > 0)
+    ss.reset_cache()
+
+
+def test_second_call_hits_cache_no_recompute(monkeypatch):
+    ss.reset_cache()
+    calls = {"n": 0}
+
+    def _counter():
+        calls["n"] += 1
+        return 5
+
+    _patch_all(monkeypatch, **_EXPECTED)
+    monkeypatch.setattr(ss, "_count_manuscripts", _counter)
+    ss.get_corpus_stats()
+    ss.get_corpus_stats()
+    ss.get_corpus_stats()
+    assert calls["n"] == 1  # computed exactly once
+    ss.reset_cache()
+
+
+def test_not_memoized_until_corpus_ready(monkeypatch):
+    """manuscripts==0 (corpus not loaded yet) must NOT cache, so a later call recomputes."""
+    ss.reset_cache()
+    vals = dict(_EXPECTED, manuscripts=0, automatic_transcriptions=0)
+    _patch_all(monkeypatch, **vals)
+    s = ss.get_corpus_stats()
+    assert s["catalog_entries"] == 731354  # state-independent counts still returned
+    assert ss._CACHE is None               # but not memoized
+    ss.reset_cache()
+
+
+def test_force_refresh_recomputes(monkeypatch):
+    ss.reset_cache()
+    _patch_all(monkeypatch, **_EXPECTED)
+    first = ss.get_corpus_stats()
+    monkeypatch.setattr(ss, "_count_catalog_entries", lambda: 999)
+    again = ss.get_corpus_stats(force_refresh=True)
+    assert first["catalog_entries"] == 731354
+    assert again["catalog_entries"] == 999
+    ss.reset_cache()
+
+
+def test_compute_failure_returns_zero_dict_with_keys(monkeypatch):
+    ss.reset_cache()
+    def boom():
+        raise RuntimeError("boom")
+    monkeypatch.setattr(ss, "_compute", boom)
+    s = ss.get_corpus_stats()
+    for k in ss._KEYS:
+        assert s[k] == 0
+    assert "computed_at" in s
+    ss.reset_cache()
+
+
+# --- real-DB sanity for the state-independent metrics (skip if sidecars absent) ---
+
+@pytest.mark.skipif(
+    not (os.path.exists("fist_data/fjms_enrichment.db") and os.path.exists("nli_data/nli_crossref.db")),
+    reason="sidecar DBs absent",
+)
+def test_real_db_counts_are_positive():
+    assert ss._count_catalog_entries() > 100_000
+    assert ss._count_image_records() > 500_000
+    assert ss._count_scholarly_editions() > 1_000

--- a/tests/test_seed023_stats_service.py
+++ b/tests/test_seed023_stats_service.py
@@ -75,7 +75,7 @@ def test_force_refresh_recomputes(monkeypatch):
     ss.reset_cache()
 
 
-def test_compute_failure_returns_zero_dict_with_keys(monkeypatch):
+def test_compute_failure_returns_uncached_zero_dict(monkeypatch):
     ss.reset_cache()
     def boom():
         raise RuntimeError("boom")
@@ -84,6 +84,19 @@ def test_compute_failure_returns_zero_dict_with_keys(monkeypatch):
     for k in ss._KEYS:
         assert s[k] == 0
     assert "computed_at" in s
+    assert ss._CACHE is None  # total failure must NOT poison the cache (Codex #306)
+    ss.reset_cache()
+
+
+def test_partial_degraded_metric_not_cached(monkeypatch):
+    """manuscripts>0 but a sidecar metric transiently 0 -> incomplete -> not cached."""
+    ss.reset_cache()
+    vals = dict(_EXPECTED, catalog_entries=0)  # e.g. fjms transiently unavailable
+    _patch_all(monkeypatch, **vals)
+    s = ss.get_corpus_stats()
+    assert s["manuscripts"] == _EXPECTED["manuscripts"]
+    assert s["catalog_entries"] == 0
+    assert ss._CACHE is None  # incomplete -> recompute next call
     ss.reset_cache()
 
 

--- a/web/pages/home.py
+++ b/web/pages/home.py
@@ -153,6 +153,49 @@ def create_page():
                     ui.icon(icon_name).classes('text-sm').style('color: var(--primary-600);')
                     ui.label(label).classes('text-xs').style('color: var(--text-secondary);')
 
+        # === Corpus Stats Band (SEED-023) — advertises the scale of the corpus ===
+        # Five cached headline numbers. Values load asynchronously off the event loop
+        # AFTER the corpus is ready (web/stats_service memoizes once). Cards reserve a
+        # fixed min-height so filling the placeholder does not shift layout (CLS).
+        _stat_specs = [
+            ('collections_bookmark', 'manuscripts', tr('Manuscripts')),
+            ('inventory_2', 'catalog_entries', tr('Catalog entries')),
+            ('photo_library', 'images', tr('Images')),
+            ('menu_book', 'scholarly_editions', tr('Scholarly editions')),
+            ('subject', 'automatic_transcriptions', tr('Automatic transcriptions')),
+        ]
+        _stat_value_labels = {}
+        with ui.row().classes('w-full justify-center gap-3 flex-wrap mt-2 px-2'):
+            for _icon_name, _key, _label in _stat_specs:
+                with ui.column().classes('items-center justify-center px-4 py-3').style(
+                    'min-width: 150px; min-height: 96px; flex: 1 1 150px; max-width: 220px; '
+                    'border: 1px solid var(--border-light); border-radius: 10px; '
+                    'background: var(--bg-tertiary);'
+                ):
+                    ui.icon(_icon_name).classes('text-2xl').style('color: var(--primary-600);')
+                    _stat_value_labels[_key] = ui.label('…').classes('text-xl font-bold').style(
+                        'color: var(--text-primary);'
+                    )
+                    ui.label(_label).classes('text-xs text-center').style('color: var(--text-muted);')
+
+        async def _load_corpus_stats():
+            # Wait (bounded) for the corpus to finish loading so manuscripts /
+            # automatic_transcriptions reflect real counts (and the service memoizes
+            # a complete result), then fetch off the event loop.
+            for _ in range(120):
+                if state.is_ready():
+                    break
+                await asyncio.sleep(0.1)
+            try:
+                from nicegui import run
+                from web.stats_service import get_corpus_stats
+                stats = await run.io_bound(get_corpus_stats)
+                for _k, _lbl in _stat_value_labels.items():
+                    _lbl.text = f"{stats.get(_k, 0):,}"
+            except Exception:
+                pass  # leave the placeholders; the band stays usable
+        asyncio.ensure_future(_load_corpus_stats())
+
         # === Info Carousel (auto-rotates + manual arrows) ===
         _card_style = 'background: var(--bg-tertiary); border: 1px solid var(--border-light);'
         _card_classes = 'w-full p-0 overflow-hidden cursor-pointer hover:shadow-xl transition-all'

--- a/web/pages/home.py
+++ b/web/pages/home.py
@@ -179,11 +179,14 @@ def create_page():
                     ui.label(_label).classes('text-xs text-center').style('color: var(--text-muted);')
 
         async def _load_corpus_stats():
-            # Wait (bounded) for the corpus to finish loading so manuscripts /
-            # automatic_transcriptions reflect real counts (and the service memoizes
-            # a complete result), then fetch off the event loop.
-            for _ in range(120):
-                if state.is_ready():
+            # Wait (bounded) for the METADATA CACHE to finish loading before fetching.
+            # state.is_ready() only means searcher+meta_mgr exist; csv_bank (the
+            # manuscript count) loads later on a background thread (Codex #306), so
+            # poll csv_bank itself — and only call get_corpus_stats ONCE it is ready,
+            # so the service memoizes a complete result (not a premature manuscripts=0).
+            for _ in range(150):  # ~15s
+                _mm = getattr(state, 'meta_mgr', None)
+                if _mm is not None and getattr(_mm, 'csv_bank', None):
                     break
                 await asyncio.sleep(0.1)
             try:

--- a/web/stats_service.py
+++ b/web/stats_service.py
@@ -134,6 +134,12 @@ def _count_automatic_transcriptions() -> int:
         return 0
 
 
+def _is_complete(stats: Dict[str, int]) -> bool:
+    """A result is cacheable only when every metric is populated (> 0). See
+    get_corpus_stats — guards against caching pre-startup / partially-failed runs."""
+    return all(stats.get(k, 0) > 0 for k in _KEYS)
+
+
 def _compute() -> Dict[str, int]:
     stats = {
         "manuscripts": _count_manuscripts(),
@@ -169,15 +175,21 @@ def get_corpus_stats(*, force_refresh: bool = False) -> Dict[str, int]:
             computed = _compute()
         except Exception:
             logger.warning("corpus-stats computation failed", exc_info=True)
-            computed = {k: 0 for k in _KEYS}
-            computed["computed_at"] = int(time.time())
-            _CACHE = computed
-            return _CACHE
-        # Do NOT memoize a result computed before the corpus finished loading:
-        # `manuscripts` (and `automatic_transcriptions`) come from runtime state, so
-        # `manuscripts == 0` in production means metadata isn't loaded yet. Return it
-        # uncached so a later call (after startup) recomputes the real numbers.
-        if computed.get("manuscripts", 0) > 0:
+            # Return an uncached all-zero dict so a later call retries — do NOT
+            # poison the cache with a transient total failure (Codex #306).
+            fallback = {k: 0 for k in _KEYS}
+            fallback["computed_at"] = int(time.time())
+            return fallback
+        # Memoize ONLY a complete result (every metric > 0). This avoids caching:
+        #  (a) a result computed before the corpus finished loading — manuscripts /
+        #      automatic_transcriptions come from runtime state that loads on a bg
+        #      thread, so they are 0 until ready; and
+        #  (b) a result where a sidecar metric transiently failed (caught -> 0).
+        # Incomplete results are returned uncached so a later call recomputes the
+        # real numbers (Codex #306 SHOULD-FIX). In a production deployment with all
+        # sidecars present every metric is > 0, so this memoizes on the first
+        # post-startup call.
+        if _is_complete(computed):
             _CACHE = computed
         return computed
 

--- a/web/stats_service.py
+++ b/web/stats_service.py
@@ -1,0 +1,189 @@
+"""Cached corpus-scale statistics for the homepage (SEED-023 Part A).
+
+Five headline numbers advertising the scale of the corpus:
+
+    manuscripts                -- all loadable catalog records (libraries.csv rows)
+    catalog_entries            -- FJMS catalog rows
+    images                     -- NLI + Cambridge + Manchester + JTS image/manifest
+                                  records (raw provider-row SUM, not distinct images)
+    scholarly_editions         -- DISTINCT manuscripts with a scholarly edition
+                                  (PGP doc_relation %Edition% ∪ FGP 'Digital Edition')
+    automatic_transcriptions   -- DISTINCT manuscripts in the deduped GENIZAH
+                                  browse_map (MiDRASH automatic transcriptions)
+
+These are large tables, so each count is computed ONCE, lazily, on first access and
+cached process-wide -- NEVER queried per request. The cache is recomputed only on a
+process restart (so a data refresh + redeploy updates the numbers). Every metric
+degrades to 0 on any error so the homepage band never breaks. ``computed_at`` is a
+unix timestamp for diagnosability.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Dict, Optional
+
+from genizah_core import get_logger
+
+logger = get_logger(__name__)
+
+_LOCK = threading.Lock()
+_CACHE: Optional[Dict[str, int]] = None
+
+_KEYS = (
+    "manuscripts",
+    "catalog_entries",
+    "images",
+    "scholarly_editions",
+    "automatic_transcriptions",
+)
+
+
+def _count_manuscripts() -> int:
+    """All loadable catalog records, via the already-loaded metadata (libraries.csv
+    rows minus header / ``#`` markers -- the loader's own count, not raw line count)."""
+    try:
+        from web.state import state
+        mm = getattr(state, "meta_mgr", None)
+        bank = getattr(mm, "csv_bank", None) if mm is not None else None
+        return len(bank) if bank else 0
+    except Exception:
+        logger.debug("stats: manuscripts count failed", exc_info=True)
+        return 0
+
+
+def _count_catalog_entries() -> int:
+    try:
+        from shared.fjms_service import get_fjms_service
+        svc = get_fjms_service(thread_safe=True)
+        if not svc.is_available() or svc._conn is None:
+            return 0
+        return int(svc._conn.execute("SELECT COUNT(*) FROM catalog").fetchone()[0])
+    except Exception:
+        logger.debug("stats: catalog count failed", exc_info=True)
+        return 0
+
+
+def _count_image_records() -> int:
+    """Raw provider-row SUM across the four NLI-crossref image/manifest tables."""
+    try:
+        from shared.nli_crossref_service import get_nli_crossref_service
+        svc = get_nli_crossref_service(thread_safe=True)
+        if not svc.is_available() or svc._conn is None:
+            return 0
+        total = 0
+        for table in ("nli_images", "cambridge_manifests", "manchester_luna", "jts_dpul"):
+            try:
+                total += int(svc._conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+            except Exception:
+                logger.debug("stats: image table %s count failed", table, exc_info=True)
+        return total
+    except Exception:
+        logger.debug("stats: images count failed", exc_info=True)
+        return 0
+
+
+def _count_scholarly_editions() -> int:
+    """DISTINCT manuscripts with a scholarly edition: PGP %Edition% ∪ FGP Digital
+    Edition (editions only -- translations are NOT counted here)."""
+    sys_ids: set = set()
+    # PGP scholarly editions: document_fragments -> documents -> document_sources.
+    try:
+        from shared.document_service import get_pgp_service
+        pgp = get_pgp_service(thread_safe=True)
+        if pgp.is_available() and pgp._conn is not None:
+            cur = pgp._conn.execute(
+                "SELECT DISTINCT f.sys_id FROM document_fragments f "
+                "JOIN documents d ON d.pgpid = f.document_id "
+                "JOIN document_sources ds ON ds.pgpid = d.pgpid "
+                "WHERE ds.doc_relation LIKE '%Edition%'"
+            )
+            sys_ids.update(row[0] for row in cur if row[0])
+    except Exception:
+        logger.debug("stats: PGP edition count failed", exc_info=True)
+    # FGP Digital Editions (flag-gated, edition-only).
+    try:
+        from shared.fgp_service import _fgp_enabled, _quote_ident, get_fgp_service
+        if _fgp_enabled():
+            fgp = get_fgp_service(thread_safe=True)
+            cols = getattr(fgp, "_columns", None) or set()
+            if fgp.is_available() and fgp._conn is not None and "sys_id" in cols:
+                cur = fgp._conn.execute(
+                    f"SELECT DISTINCT sys_id FROM {_quote_ident(fgp._table)} "
+                    "WHERE doc_relation = 'Digital Edition' AND sys_id IS NOT NULL"
+                )
+                sys_ids.update(row[0] for row in cur if row[0])
+    except Exception:
+        logger.debug("stats: FGP edition count failed", exc_info=True)
+    return len(sys_ids)
+
+
+def _count_automatic_transcriptions() -> int:
+    """DISTINCT manuscripts in the deduped GENIZAH browse_map (held in memory at
+    runtime as SearchEngine._shared_browse_map -- no index-build artifact needed)."""
+    try:
+        from web.state import state
+        searcher = getattr(state, "searcher", None)
+        if searcher is None:
+            return 0
+        browse_map = searcher._load_browse_map()
+        return len(browse_map) if browse_map else 0
+    except Exception:
+        logger.debug("stats: browse_map count failed", exc_info=True)
+        return 0
+
+
+def _compute() -> Dict[str, int]:
+    stats = {
+        "manuscripts": _count_manuscripts(),
+        "catalog_entries": _count_catalog_entries(),
+        "images": _count_image_records(),
+        "scholarly_editions": _count_scholarly_editions(),
+        "automatic_transcriptions": _count_automatic_transcriptions(),
+        "computed_at": int(time.time()),
+    }
+    logger.info(
+        "corpus stats computed: manuscripts=%d catalog=%d images=%d editions=%d transcriptions=%d",
+        stats["manuscripts"], stats["catalog_entries"], stats["images"],
+        stats["scholarly_editions"], stats["automatic_transcriptions"],
+    )
+    return stats
+
+
+def get_corpus_stats(*, force_refresh: bool = False) -> Dict[str, int]:
+    """Return the cached corpus stats, computing them once (lazily) on first call.
+
+    Safe to call from a request path -- after the first call it is a dict return.
+    The first call performs a handful of indexed COUNT queries + an in-memory len();
+    callers on the event loop should still wrap it in ``run.io_bound`` for the
+    first-hit case (the homepage does).
+    """
+    global _CACHE
+    if _CACHE is not None and not force_refresh:
+        return _CACHE
+    with _LOCK:
+        if _CACHE is not None and not force_refresh:
+            return _CACHE
+        try:
+            computed = _compute()
+        except Exception:
+            logger.warning("corpus-stats computation failed", exc_info=True)
+            computed = {k: 0 for k in _KEYS}
+            computed["computed_at"] = int(time.time())
+            _CACHE = computed
+            return _CACHE
+        # Do NOT memoize a result computed before the corpus finished loading:
+        # `manuscripts` (and `automatic_transcriptions`) come from runtime state, so
+        # `manuscripts == 0` in production means metadata isn't loaded yet. Return it
+        # uncached so a later call (after startup) recomputes the real numbers.
+        if computed.get("manuscripts", 0) > 0:
+            _CACHE = computed
+        return computed
+
+
+def reset_cache() -> None:
+    """Test hook: drop the memoized stats so the next call recomputes."""
+    global _CACHE
+    with _LOCK:
+        _CACHE = None


### PR DESCRIPTION
SEED-023 **Part A** — a homepage band advertising the scale of the corpus. Part B (catalog PGP/Editions filters) is a separate follow-up PR.

## Five cached metrics
| Metric | Source | Count |
|---|---|---|
| Manuscripts | `len(meta_mgr.csv_bank)` (loadable libraries.csv rows) | 255,723 |
| Catalog entries | `COUNT(*)` FJMS catalog | 731,354 |
| Images | provider-row SUM (NLI + Cambridge + Manchester + JTS) | 1,019,886 |
| Scholarly editions | DISTINCT mss: PGP `%Edition%` ∪ FGP `Digital Edition` | 27,424 |
| Automatic transcriptions | `len(SearchEngine._shared_browse_map)` | 232,450 |

(All three DB-backed counts verified against the live sidecars.)

## `web/stats_service.py`
Lazy, lock-protected, memoized **once** (never per request), `computed_at` stamped. Each metric degrades to **0** on error. Reads each service's own resolved connection (`nli_data/`, `fist_data/`, `pgp_data/`, `fgp_data/`) — not the empty root `nli_crossref.db` (Codex SHOULD-FIX). **No index-build artifact needed** — the transcription count reads the in-memory `browse_map`, dropping the seed's B2 `corpus_stats.json` dependency. Guard: a `manuscripts==0` result (corpus still loading) is **not** memoized, so it recomputes once startup completes.

## Homepage band
5 cards, bilingual via `tr()` (+3 new HE keys), RTL-aware, fixed card `min-height` to avoid CLS. Values load off the event loop (`run.io_bound`) after `state.is_ready()`, filling placeholders — mirroring the existing hero mini-stat idiom.

## Tests
`tests/test_seed023_stats_service.py` (7): aggregate, memoize-when-ready, cache-hit-no-recompute, **not-cached-until-corpus-ready**, force_refresh, compute-failure-degrades-to-zero, real-DB sanity. ruff clean.

## Note
No home-route render-smoke harness added — the existing one is `/joins-lab`-specific, and the band uses the proven hero async-refresh pattern. Worth a quick **live UAT**: load `/`, confirm the 5 numbers fill in (HE + EN), and the band doesn't shift layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
