### PR TITLE
fix(web): permanent homepage stats — fix manuscripts count, rename, header

### DIFF
--- a/genizah_translations.py
+++ b/genizah_translations.py
@@ -1490,7 +1490,7 @@ TRANSLATIONS = {
     "Welcome to Dicta Genizah Search": "ברוכים הבאים לאתר הגניזה של דיקטה",
     "Dicta Genizah Search: Full-Text Manuscript Search": "אתר הגניזה של דיקטה: חיפוש בגניזה הקהירית",
     "Advanced research tools for Cairo Genizah manuscripts": "כלי מחקר מתקדמים לכתבי יד מגניזת קהיר",
-    "Search over 255,000 MiDRASH transcriptions: text, variants, parallels, joins, and images": "חיפוש בלמעלה מ-255,000 תעתוקי MiDRASH: טקסט, וריאנטים, מקבילות, צירופים ותמונות",
+    "Search MiDRASH transcriptions across 255,000+ manuscripts: text, variants, parallels, joins, and images": "חיפוש בתעתוקי MiDRASH של למעלה מ-255,000 כתבי יד: טקסט, וריאנטים, מקבילות, צירופים ותמונות",
     "What is the Cairo Genizah?": "מהי גניזת קהיר?",
     "Hundreds of thousands of medieval manuscripts from a Cairo synagogue attic, now searchable for the first time": "מאות אלפי כתבי יד מימי הביניים מעליית גג של בית כנסת בקהיר, זמינים לחיפוש לראשונה",
     "What can I do here?": "מה אפשר לעשות כאן?",
@@ -2093,7 +2093,7 @@ TRANSLATIONS = {
     "Edition": "מהדורה",
     # SEED-023: homepage corpus-stats band labels ("Manuscripts"/"Images" already exist).
     "Catalog entries": "רשומות קטלוג",
-    "Scholarly editions": "מהדורות מדעיות",
+    "Scholarly transcriptions": "תעתוקים מדעיים",
     "Automatic transcriptions": "תעתוקים אוטומטיים",
     "PGP Transcription": "תעתוק PGP",
     "PGP Transcriptions": "תעתוקי PGP",

--- a/tests/test_seed023_stats_service.py
+++ b/tests/test_seed023_stats_service.py
@@ -52,8 +52,11 @@ def test_returns_a_copy_not_the_shared_dict():
         os.path.exists("fist_data/fjms_enrichment.db")
         and os.path.exists("nli_data/nli_crossref.db")
         and os.path.exists("pgp_data/pgp.db")
+        # FGP is optional/gitignored, but scholarly_transcriptions (27,424) is defined
+        # as PGP ∪ FGP — without it the count is PGP-only and would fail (Codex #307).
+        and os.path.exists("fgp_data/fgp_transcriptions.db")
     ),
-    reason="sidecar DBs absent",
+    reason="sidecar DBs absent (incl. optional FGP, required for the editions union)",
 )
 def test_live_db_metrics_match_constants():
     # These three are fully determined by the sidecars (no runtime state needed), so
@@ -61,3 +64,13 @@ def test_live_db_metrics_match_constants():
     assert ss._count_catalog_entries() == _EXPECTED["catalog_entries"]
     assert ss._count_image_records() == _EXPECTED["images"]
     assert ss._count_scholarly_transcriptions() == _EXPECTED["scholarly_transcriptions"]
+
+
+@pytest.mark.skipif(
+    not os.path.exists("libraries.csv"), reason="libraries.csv absent"
+)
+def test_manuscripts_count_works_headless():
+    """compute_live_stats() must yield the real manuscripts count from a plain shell
+    (no loaded web.state) via the libraries.csv fallback — not 0 (Codex #307)."""
+    assert ss._count_manuscripts_from_csv() == _EXPECTED["manuscripts"]
+    assert ss._count_manuscripts() == _EXPECTED["manuscripts"]

--- a/tests/test_seed023_stats_service.py
+++ b/tests/test_seed023_stats_service.py
@@ -1,4 +1,9 @@
-"""SEED-023 Part A — cached homepage corpus stats (web/stats_service.py)."""
+"""SEED-023 Part A — homepage corpus stats (web/stats_service.py).
+
+The five headline numbers are hardcoded constants (decision 2026-06-24); computing
+them live caused a partial-load race. These tests pin the constants and verify the
+live-regeneration path still matches for the DB-deterministic metrics.
+"""
 
 from __future__ import annotations
 
@@ -9,104 +14,50 @@ import pytest
 import web.stats_service as ss
 
 _EXPECTED = {
-    "manuscripts": 255723,
-    "catalog_entries": 731354,
-    "images": 1019886,
-    "scholarly_editions": 27424,
-    "automatic_transcriptions": 232450,
+    "manuscripts": 255_723,
+    "catalog_entries": 731_354,
+    "images": 1_019_886,
+    "scholarly_transcriptions": 27_424,
+    "automatic_transcriptions": 232_450,
 }
 
 
-def _patch_all(monkeypatch, **vals):
-    monkeypatch.setattr(ss, "_count_manuscripts", lambda: vals["manuscripts"])
-    monkeypatch.setattr(ss, "_count_catalog_entries", lambda: vals["catalog_entries"])
-    monkeypatch.setattr(ss, "_count_image_records", lambda: vals["images"])
-    monkeypatch.setattr(ss, "_count_scholarly_editions", lambda: vals["scholarly_editions"])
-    monkeypatch.setattr(ss, "_count_automatic_transcriptions", lambda: vals["automatic_transcriptions"])
-
-
-def test_aggregates_and_memoizes_when_corpus_ready(monkeypatch):
-    ss.reset_cache()
-    _patch_all(monkeypatch, **_EXPECTED)
+def test_corpus_stats_are_the_expected_constants():
     s = ss.get_corpus_stats()
-    for k, v in _EXPECTED.items():
-        assert s[k] == v
-    assert "computed_at" in s
-    assert ss._CACHE is not None  # memoized (manuscripts > 0)
-    ss.reset_cache()
+    assert s == _EXPECTED
 
 
-def test_second_call_hits_cache_no_recompute(monkeypatch):
-    ss.reset_cache()
-    calls = {"n": 0}
-
-    def _counter():
-        calls["n"] += 1
-        return 5
-
-    _patch_all(monkeypatch, **_EXPECTED)
-    monkeypatch.setattr(ss, "_count_manuscripts", _counter)
-    ss.get_corpus_stats()
-    ss.get_corpus_stats()
-    ss.get_corpus_stats()
-    assert calls["n"] == 1  # computed exactly once
-    ss.reset_cache()
-
-
-def test_not_memoized_until_corpus_ready(monkeypatch):
-    """manuscripts==0 (corpus not loaded yet) must NOT cache, so a later call recomputes."""
-    ss.reset_cache()
-    vals = dict(_EXPECTED, manuscripts=0, automatic_transcriptions=0)
-    _patch_all(monkeypatch, **vals)
+def test_all_keys_present_and_positive():
     s = ss.get_corpus_stats()
-    assert s["catalog_entries"] == 731354  # state-independent counts still returned
-    assert ss._CACHE is None               # but not memoized
-    ss.reset_cache()
+    assert set(s.keys()) == set(_EXPECTED)
+    assert all(v > 0 for v in s.values())
 
 
-def test_force_refresh_recomputes(monkeypatch):
-    ss.reset_cache()
-    _patch_all(monkeypatch, **_EXPECTED)
-    first = ss.get_corpus_stats()
-    monkeypatch.setattr(ss, "_count_catalog_entries", lambda: 999)
-    again = ss.get_corpus_stats(force_refresh=True)
-    assert first["catalog_entries"] == 731354
-    assert again["catalog_entries"] == 999
-    ss.reset_cache()
-
-
-def test_compute_failure_returns_uncached_zero_dict(monkeypatch):
-    ss.reset_cache()
-    def boom():
-        raise RuntimeError("boom")
-    monkeypatch.setattr(ss, "_compute", boom)
+def test_renamed_key_scholarly_transcriptions():
     s = ss.get_corpus_stats()
-    for k in ss._KEYS:
-        assert s[k] == 0
-    assert "computed_at" in s
-    assert ss._CACHE is None  # total failure must NOT poison the cache (Codex #306)
-    ss.reset_cache()
+    assert "scholarly_transcriptions" in s
+    assert "scholarly_editions" not in s  # renamed per UAT
 
 
-def test_partial_degraded_metric_not_cached(monkeypatch):
-    """manuscripts>0 but a sidecar metric transiently 0 -> incomplete -> not cached."""
-    ss.reset_cache()
-    vals = dict(_EXPECTED, catalog_entries=0)  # e.g. fjms transiently unavailable
-    _patch_all(monkeypatch, **vals)
+def test_returns_a_copy_not_the_shared_dict():
     s = ss.get_corpus_stats()
-    assert s["manuscripts"] == _EXPECTED["manuscripts"]
-    assert s["catalog_entries"] == 0
-    assert ss._CACHE is None  # incomplete -> recompute next call
-    ss.reset_cache()
+    s["manuscripts"] = 0
+    assert ss.get_corpus_stats()["manuscripts"] == _EXPECTED["manuscripts"]
 
 
-# --- real-DB sanity for the state-independent metrics (skip if sidecars absent) ---
+# --- live regeneration sanity: DB-deterministic metrics must match the constants ---
 
 @pytest.mark.skipif(
-    not (os.path.exists("fist_data/fjms_enrichment.db") and os.path.exists("nli_data/nli_crossref.db")),
+    not (
+        os.path.exists("fist_data/fjms_enrichment.db")
+        and os.path.exists("nli_data/nli_crossref.db")
+        and os.path.exists("pgp_data/pgp.db")
+    ),
     reason="sidecar DBs absent",
 )
-def test_real_db_counts_are_positive():
-    assert ss._count_catalog_entries() > 100_000
-    assert ss._count_image_records() > 500_000
-    assert ss._count_scholarly_editions() > 1_000
+def test_live_db_metrics_match_constants():
+    # These three are fully determined by the sidecars (no runtime state needed), so
+    # a drift here means the hardcoded constants are stale and should be regenerated.
+    assert ss._count_catalog_entries() == _EXPECTED["catalog_entries"]
+    assert ss._count_image_records() == _EXPECTED["images"]
+    assert ss._count_scholarly_transcriptions() == _EXPECTED["scholarly_transcriptions"]

--- a/web/pages/home.py
+++ b/web/pages/home.py
@@ -75,7 +75,7 @@ def create_page():
                     h1(tr('Dicta Genizah Search: Full-Text Manuscript Search'),
                        classes='text-lg font-bold',
                        style='color: var(--text-primary); margin: 0;')
-                    ui.label(tr('Search over 255,000 MiDRASH transcriptions: text, variants, parallels, joins, and images')).classes(
+                    ui.label(tr('Search MiDRASH transcriptions across 255,000+ manuscripts: text, variants, parallels, joins, and images')).classes(
                         'text-sm'
                     ).style('color: var(--text-secondary);')
 
@@ -154,17 +154,17 @@ def create_page():
                     ui.label(label).classes('text-xs').style('color: var(--text-secondary);')
 
         # === Corpus Stats Band (SEED-023) — advertises the scale of the corpus ===
-        # Five cached headline numbers. Values load asynchronously off the event loop
-        # AFTER the corpus is ready (web/stats_service memoizes once). Cards reserve a
-        # fixed min-height so filling the placeholder does not shift layout (CLS).
+        # Five HARDCODED headline numbers (web/stats_service.CORPUS_STATS). Rendered
+        # synchronously — no async/placeholder/readiness poll, so no layout shift.
+        from web.stats_service import get_corpus_stats as _get_corpus_stats
+        _stats = _get_corpus_stats()
         _stat_specs = [
             ('collections_bookmark', 'manuscripts', tr('Manuscripts')),
             ('inventory_2', 'catalog_entries', tr('Catalog entries')),
             ('photo_library', 'images', tr('Images')),
-            ('menu_book', 'scholarly_editions', tr('Scholarly editions')),
+            ('menu_book', 'scholarly_transcriptions', tr('Scholarly transcriptions')),
             ('subject', 'automatic_transcriptions', tr('Automatic transcriptions')),
         ]
-        _stat_value_labels = {}
         with ui.row().classes('w-full justify-center gap-3 flex-wrap mt-2 px-2'):
             for _icon_name, _key, _label in _stat_specs:
                 with ui.column().classes('items-center justify-center px-4 py-3').style(
@@ -173,31 +173,10 @@ def create_page():
                     'background: var(--bg-tertiary);'
                 ):
                     ui.icon(_icon_name).classes('text-2xl').style('color: var(--primary-600);')
-                    _stat_value_labels[_key] = ui.label('…').classes('text-xl font-bold').style(
+                    ui.label(f"{_stats.get(_key, 0):,}").classes('text-xl font-bold').style(
                         'color: var(--text-primary);'
                     )
                     ui.label(_label).classes('text-xs text-center').style('color: var(--text-muted);')
-
-        async def _load_corpus_stats():
-            # Wait (bounded) for the METADATA CACHE to finish loading before fetching.
-            # state.is_ready() only means searcher+meta_mgr exist; csv_bank (the
-            # manuscript count) loads later on a background thread (Codex #306), so
-            # poll csv_bank itself — and only call get_corpus_stats ONCE it is ready,
-            # so the service memoizes a complete result (not a premature manuscripts=0).
-            for _ in range(150):  # ~15s
-                _mm = getattr(state, 'meta_mgr', None)
-                if _mm is not None and getattr(_mm, 'csv_bank', None):
-                    break
-                await asyncio.sleep(0.1)
-            try:
-                from nicegui import run
-                from web.stats_service import get_corpus_stats
-                stats = await run.io_bound(get_corpus_stats)
-                for _k, _lbl in _stat_value_labels.items():
-                    _lbl.text = f"{stats.get(_k, 0):,}"
-            except Exception:
-                pass  # leave the placeholders; the band stays usable
-        asyncio.ensure_future(_load_corpus_stats())
 
         # === Info Carousel (auto-rotates + manual arrows) ===
         _card_style = 'background: var(--bg-tertiary); border: 1px solid var(--border-light);'

--- a/web/stats_service.py
+++ b/web/stats_service.py
@@ -17,6 +17,7 @@ authoritative computation; it is NOT called at runtime.
 
 from __future__ import annotations
 
+import os
 from typing import Dict
 
 from genizah_core import get_logger
@@ -52,16 +53,46 @@ def get_corpus_stats() -> Dict[str, int]:
 # ---------------------------------------------------------------------------
 
 def _count_manuscripts() -> int:
-    """All loadable catalog records, via the loaded metadata (libraries.csv rows
-    minus header / ``#`` markers). NOTE: only reliable once csv_bank has finished
-    loading -- hence the runtime value is hardcoded, not read from here."""
+    """All loadable catalog records (libraries.csv rows minus header / ``#`` markers).
+
+    Prefers the loaded runtime metadata, but falls back to counting libraries.csv
+    DIRECTLY so compute_live_stats() yields the real number from a plain shell
+    (where web.state is never initialized) -- otherwise the regeneration recipe
+    would emit 0 (Codex #307)."""
     try:
         from web.state import state
         mm = getattr(state, "meta_mgr", None)
         bank = getattr(mm, "csv_bank", None) if mm is not None else None
-        return len(bank) if bank else 0
+        if bank:
+            return len(bank)
     except Exception:
-        logger.debug("stats: manuscripts count failed", exc_info=True)
+        logger.debug("stats: manuscripts count (state) failed", exc_info=True)
+    return _count_manuscripts_from_csv()
+
+
+def _count_manuscripts_from_csv() -> int:
+    """Count distinct sys_ids in libraries.csv, replicating _load_csv_bank's filter
+    (skip header + ``#`` marker rows + rows with < 3 columns; key by digit-only sys_id)."""
+    try:
+        import csv as _csv
+        from genizah_core import Config
+        path = getattr(Config, "LIBRARIES_CSV", None)
+        if not path or not os.path.exists(path):
+            return 0
+        seen = set()
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            reader = _csv.reader(f, delimiter=",")
+            next(reader, None)  # header
+            for row in reader:
+                if not row or len(row) < 3:
+                    continue
+                raw = row[0]
+                if raw.startswith("#"):
+                    continue
+                seen.add("".join(ch for ch in str(raw) if ch.isdigit()))
+        return len(seen)
+    except Exception:
+        logger.debug("stats: manuscripts count (csv) failed", exc_info=True)
         return 0
 
 
@@ -131,16 +162,34 @@ def _count_scholarly_transcriptions() -> int:
 
 def _count_automatic_transcriptions() -> int:
     """DISTINCT manuscripts in the deduped GENIZAH browse_map (MiDRASH automatic
-    transcriptions), held in memory at runtime as SearchEngine._shared_browse_map."""
+    transcriptions). Prefers the in-memory SearchEngine._shared_browse_map; falls
+    back to reading the persisted browse_map.pkl so compute_live_stats() works from
+    a plain shell (Codex #307). NOTE: the pkl is deduped after the app's first load,
+    so the fallback is exact post-deploy."""
     try:
         from web.state import state
         searcher = getattr(state, "searcher", None)
-        if searcher is None:
+        if searcher is not None:
+            browse_map = searcher._load_browse_map()
+            if browse_map:
+                return len(browse_map)
+    except Exception:
+        logger.debug("stats: browse_map count (state) failed", exc_info=True)
+    return _count_browse_map_from_pkl()
+
+
+def _count_browse_map_from_pkl() -> int:
+    try:
+        import pickle
+        from genizah_core import Config
+        path = getattr(Config, "BROWSE_MAP", None)
+        if not path or not os.path.exists(path):
             return 0
-        browse_map = searcher._load_browse_map()
+        with open(path, "rb") as f:
+            browse_map = pickle.load(f)
         return len(browse_map) if browse_map else 0
     except Exception:
-        logger.debug("stats: browse_map count failed", exc_info=True)
+        logger.debug("stats: browse_map count (pkl) failed", exc_info=True)
         return 0
 
 

--- a/web/stats_service.py
+++ b/web/stats_service.py
@@ -1,48 +1,60 @@
-"""Cached corpus-scale statistics for the homepage (SEED-023 Part A).
+"""Homepage corpus statistics (SEED-023 Part A).
 
-Five headline numbers advertising the scale of the corpus:
+The five headline numbers are **hardcoded constants** by design (decision 2026-06-24):
+they change only on a data refresh + redeploy, and computing them live caused a
+partial-load race (``manuscripts`` was read mid ``csv_bank`` background load, yielding
+e.g. 17,852 instead of 255,723). Constants render instantly and CLS-free, with no
+readiness/caching machinery.
 
-    manuscripts                -- all loadable catalog records (libraries.csv rows)
-    catalog_entries            -- FJMS catalog rows
-    images                     -- NLI + Cambridge + Manchester + JTS image/manifest
-                                  records (raw provider-row SUM, not distinct images)
-    scholarly_editions         -- DISTINCT manuscripts with a scholarly edition
-                                  (PGP doc_relation %Edition% ∪ FGP 'Digital Edition')
-    automatic_transcriptions   -- DISTINCT manuscripts in the deduped GENIZAH
-                                  browse_map (MiDRASH automatic transcriptions)
+To refresh after a data update, regenerate from the live sidecars and paste the new
+values into ``CORPUS_STATS``::
 
-These are large tables, so each count is computed ONCE, lazily, on first access and
-cached process-wide -- NEVER queried per request. The cache is recomputed only on a
-process restart (so a data refresh + redeploy updates the numbers). Every metric
-degrades to 0 on any error so the homepage band never breaks. ``computed_at`` is a
-unix timestamp for diagnosability.
+    python -c "import web.stats_service as s; print(s.compute_live_stats())"
+
+(run from the repo root with the sidecars present). ``compute_live_stats()`` is the
+authoritative computation; it is NOT called at runtime.
 """
 
 from __future__ import annotations
 
-import threading
-import time
-from typing import Dict, Optional
+from typing import Dict
 
 from genizah_core import get_logger
 
 logger = get_logger(__name__)
 
-_LOCK = threading.Lock()
-_CACHE: Optional[Dict[str, int]] = None
+# --- Hardcoded headline numbers -------------------------------------------
+# Verified 2026-06-24 against the live sidecars via compute_live_stats():
+#   manuscripts              libraries.csv loadable rows (header + '#' markers excluded)
+#   catalog_entries          fjms_enrichment.db `catalog`
+#   images                   NLI + Cambridge + Manchester + JTS image/manifest records
+#   scholarly_transcriptions DISTINCT manuscripts: PGP %Edition% ∪ FGP 'Digital Edition'
+#   automatic_transcriptions DISTINCT manuscripts in the deduped GENIZAH browse_map
+CORPUS_STATS: Dict[str, int] = {
+    "manuscripts": 255_723,
+    "catalog_entries": 731_354,
+    "images": 1_019_886,
+    "scholarly_transcriptions": 27_424,
+    "automatic_transcriptions": 232_450,
+}
 
-_KEYS = (
-    "manuscripts",
-    "catalog_entries",
-    "images",
-    "scholarly_editions",
-    "automatic_transcriptions",
-)
+_KEYS = tuple(CORPUS_STATS.keys())
 
+
+def get_corpus_stats() -> Dict[str, int]:
+    """Return the (hardcoded) homepage corpus stats. Instant; safe on any thread."""
+    return dict(CORPUS_STATS)
+
+
+# ---------------------------------------------------------------------------
+# Live regeneration (NOT called at runtime) — run to refresh CORPUS_STATS after a
+# data refresh. Each metric degrades to 0 on error so a missing sidecar doesn't crash.
+# ---------------------------------------------------------------------------
 
 def _count_manuscripts() -> int:
-    """All loadable catalog records, via the already-loaded metadata (libraries.csv
-    rows minus header / ``#`` markers -- the loader's own count, not raw line count)."""
+    """All loadable catalog records, via the loaded metadata (libraries.csv rows
+    minus header / ``#`` markers). NOTE: only reliable once csv_bank has finished
+    loading -- hence the runtime value is hardcoded, not read from here."""
     try:
         from web.state import state
         mm = getattr(state, "meta_mgr", None)
@@ -84,11 +96,10 @@ def _count_image_records() -> int:
         return 0
 
 
-def _count_scholarly_editions() -> int:
-    """DISTINCT manuscripts with a scholarly edition: PGP %Edition% ∪ FGP Digital
-    Edition (editions only -- translations are NOT counted here)."""
+def _count_scholarly_transcriptions() -> int:
+    """DISTINCT manuscripts with a scholarly edition/transcription: PGP %Edition% ∪
+    FGP 'Digital Edition' (editions only -- translations are NOT counted here)."""
     sys_ids: set = set()
-    # PGP scholarly editions: document_fragments -> documents -> document_sources.
     try:
         from shared.document_service import get_pgp_service
         pgp = get_pgp_service(thread_safe=True)
@@ -102,7 +113,6 @@ def _count_scholarly_editions() -> int:
             sys_ids.update(row[0] for row in cur if row[0])
     except Exception:
         logger.debug("stats: PGP edition count failed", exc_info=True)
-    # FGP Digital Editions (flag-gated, edition-only).
     try:
         from shared.fgp_service import _fgp_enabled, _quote_ident, get_fgp_service
         if _fgp_enabled():
@@ -120,8 +130,8 @@ def _count_scholarly_editions() -> int:
 
 
 def _count_automatic_transcriptions() -> int:
-    """DISTINCT manuscripts in the deduped GENIZAH browse_map (held in memory at
-    runtime as SearchEngine._shared_browse_map -- no index-build artifact needed)."""
+    """DISTINCT manuscripts in the deduped GENIZAH browse_map (MiDRASH automatic
+    transcriptions), held in memory at runtime as SearchEngine._shared_browse_map."""
     try:
         from web.state import state
         searcher = getattr(state, "searcher", None)
@@ -134,68 +144,15 @@ def _count_automatic_transcriptions() -> int:
         return 0
 
 
-def _is_complete(stats: Dict[str, int]) -> bool:
-    """A result is cacheable only when every metric is populated (> 0). See
-    get_corpus_stats — guards against caching pre-startup / partially-failed runs."""
-    return all(stats.get(k, 0) > 0 for k in _KEYS)
-
-
-def _compute() -> Dict[str, int]:
+def compute_live_stats() -> Dict[str, int]:
+    """Compute the stats live from the sidecars + loaded state. Use this to refresh
+    CORPUS_STATS after a data update; NOT used on the request path."""
     stats = {
         "manuscripts": _count_manuscripts(),
         "catalog_entries": _count_catalog_entries(),
         "images": _count_image_records(),
-        "scholarly_editions": _count_scholarly_editions(),
+        "scholarly_transcriptions": _count_scholarly_transcriptions(),
         "automatic_transcriptions": _count_automatic_transcriptions(),
-        "computed_at": int(time.time()),
     }
-    logger.info(
-        "corpus stats computed: manuscripts=%d catalog=%d images=%d editions=%d transcriptions=%d",
-        stats["manuscripts"], stats["catalog_entries"], stats["images"],
-        stats["scholarly_editions"], stats["automatic_transcriptions"],
-    )
+    logger.info("live corpus stats: %s", stats)
     return stats
-
-
-def get_corpus_stats(*, force_refresh: bool = False) -> Dict[str, int]:
-    """Return the cached corpus stats, computing them once (lazily) on first call.
-
-    Safe to call from a request path -- after the first call it is a dict return.
-    The first call performs a handful of indexed COUNT queries + an in-memory len();
-    callers on the event loop should still wrap it in ``run.io_bound`` for the
-    first-hit case (the homepage does).
-    """
-    global _CACHE
-    if _CACHE is not None and not force_refresh:
-        return _CACHE
-    with _LOCK:
-        if _CACHE is not None and not force_refresh:
-            return _CACHE
-        try:
-            computed = _compute()
-        except Exception:
-            logger.warning("corpus-stats computation failed", exc_info=True)
-            # Return an uncached all-zero dict so a later call retries — do NOT
-            # poison the cache with a transient total failure (Codex #306).
-            fallback = {k: 0 for k in _KEYS}
-            fallback["computed_at"] = int(time.time())
-            return fallback
-        # Memoize ONLY a complete result (every metric > 0). This avoids caching:
-        #  (a) a result computed before the corpus finished loading — manuscripts /
-        #      automatic_transcriptions come from runtime state that loads on a bg
-        #      thread, so they are 0 until ready; and
-        #  (b) a result where a sidecar metric transiently failed (caught -> 0).
-        # Incomplete results are returned uncached so a later call recomputes the
-        # real numbers (Codex #306 SHOULD-FIX). In a production deployment with all
-        # sidecars present every metric is > 0, so this memoizes on the first
-        # post-startup call.
-        if _is_complete(computed):
-            _CACHE = computed
-        return computed
-
-
-def reset_cache() -> None:
-    """Test hook: drop the memoized stats so the next call recomputes."""
-    global _CACHE
-    with _LOCK:
-        _CACHE = None


### PR DESCRIPTION
UAT fixes on the SEED-023 Part A homepage stats band (#306).

## The bug
**Manuscripts showed 17,852** (should be 255,723). `csv_bank` loads row-by-row on a background thread with no atomic swap or done-flag, so the band read it **mid-load** — and the "complete result" cache then froze the partial number.

## Fix: make the numbers permanent (per direction)
`web/stats_service.py` now returns **hardcoded `CORPUS_STATS` constants** (verified 2026-06-24 against the live sidecars), rendered **synchronously** — no readiness poll, no async placeholder, no cache, no CLS, no race. The live computation is retained as `compute_live_stats()` to regenerate the constants after a data refresh (documented; not on the request path).

## Also
- **Rename** "Scholarly editions" → **"Scholarly transcriptions" / "תעתוקים מדעיים"** (label + internal key). Count unchanged — **27,424** distinct manuscripts (PGP `%Edition%` ∪ FGP `Digital Edition`), re-verified.
- **Header consistency:** "Search over 255,000 MiDRASH transcriptions" wrongly labeled the 255K figure "transcriptions" (it's the *manuscript* count; transcriptions = 232,450). Reworded to **"Search MiDRASH transcriptions across 255,000+ manuscripts"** (matches the Manuscripts stat and the other on-page copy), EN + HE.

## Final numbers
Manuscripts **255,723** · Catalog entries **731,354** · Images **1,019,886** · Scholarly transcriptions **27,424** · Automatic transcriptions **232,450**.

## Tests
Rewritten: pin the constants, the key rename, copy-not-shared, and a **live-DB sanity** that the DB-deterministic constants (catalog/images/scholarly) still match — a drift means regenerate. 5 green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
