### PR TITLE
feat(fgp): bilingual per-transcription credits + UI wiring

### DIFF
--- a/genizah_app.py
+++ b/genizah_app.py
@@ -5006,12 +5006,16 @@ class GenizahGUI(QMainWindow):
 
         # === FGP Group (distinct from PGP; FGP-07) ===
         if fgp_sources:
+            from shared.fgp_service import pick_fgp_credit
+            # Live read (CURRENT_LANG flips at runtime on language switch — the
+            # module-level import binds a stale snapshot; see the lines-button site).
+            from genizah_core import CURRENT_LANG as _fgp_lang
             combo.addItem("─────────────", {"source": "header"})
             combo.model().item(combo.count() - 1).setEnabled(False)
             # Show the transcription credit in the FGP group header when the
             # manuscript has a single shared credit (the common case); the
             # per-item tooltip still carries each row's credit when they differ.
-            _fgp_credits = {s.get('source_credit') for s in fgp_sources if s.get('source_credit')}
+            _fgp_credits = {c for c in (pick_fgp_credit(s, _fgp_lang) for s in fgp_sources) if c}
             _fgp_hdr = (f"-- FGP · {next(iter(_fgp_credits))} --"
                         if len(_fgp_credits) == 1 else "-- FGP --")
             combo.addItem(_fgp_hdr, {"source": "header"})
@@ -5025,6 +5029,7 @@ class GenizahGUI(QMainWindow):
                     label = f"  FGP {lang_part}{tr('Translation')}"
                 else:
                     label = f"  {tr('FGP Transcription')}"
+                _credit = pick_fgp_credit(fsrc, _fgp_lang)
                 # No folio suffix: the combo is filtered to the displayed image's
                 # folio, so the folio only routes placement (it's not shown).
                 combo.addItem(label, {
@@ -5033,14 +5038,14 @@ class GenizahGUI(QMainWindow):
                     "scholar": fsrc.get('source_scholar', 'FGP'),
                     "language": language,
                     "attribution": fsrc.get('attribution'),
-                    "source_credit": fsrc.get('source_credit'),
+                    "source_credit": _credit,
                     "source_id": fsrc.get('id'),
                     "uid": fsrc.get('uid'),
                 })
                 # Surface the FGP team credit on hover (the label stays compact).
-                _credit = fsrc.get('source_credit') or fsrc.get('attribution')
-                if _credit:
-                    combo.setItemData(combo.count() - 1, _credit,
+                _tooltip = _credit or fsrc.get('attribution')
+                if _tooltip:
+                    combo.setItemData(combo.count() - 1, _tooltip,
                                       Qt.ItemDataRole.ToolTipRole)
 
         # === Visual divider before HTR ===

--- a/scripts/fgp_fill_credits_bilingual.py
+++ b/scripts/fgp_fill_credits_bilingual.py
@@ -157,13 +157,29 @@ TEAM_TOKENS = {t: _team_token(he) for t, (he, _en) in TEAM_CREDITS.items()}
 
 
 # ── FIST catalog (500) and book (600) credit maps ──
+def _table_columns(fi, table: str) -> set:
+    """Column names present in ``table`` (empty if the table is absent)."""
+    return {r[1] for r in fi.execute(f"PRAGMA table_info({table})")}
+
+
 def build_catalog_map(fi):
-    """{CatalogId -> '<CatAcronym> Catalog, <Publisher>, <Year>'} (fields optional)."""
+    """{CatalogId -> '<CatAcronym> Catalog, <Publisher>, <Year>'} (fields optional).
+
+    ``Publisher``/``YearOfPublishing`` exist in the full FIST.db but not in every
+    FIST schema variant (e.g. the synthetic test fixture). Select only the
+    columns that are present so a leaner schema yields the acronym-only credit
+    instead of raising ``OperationalError`` and aborting the whole credit fill.
+    """
+    cols = _table_columns(fi, "CODE_Catalog")
+    if not {"CatalogId", "CatAcronym"} <= cols:
+        return {}
+    has_pub = "Publisher" in cols
+    has_yr = "YearOfPublishing" in cols
+    select = "CatalogId, CatAcronym, " + (
+        "Publisher" if has_pub else "NULL"
+    ) + ", " + ("YearOfPublishing" if has_yr else "NULL")
     out = {}
-    for r in fi.execute(
-        "SELECT CatalogId, CatAcronym, Publisher, YearOfPublishing FROM CODE_Catalog"
-    ):
-        cid, acr, pub, yr = r
+    for cid, acr, pub, yr in fi.execute(f"SELECT {select} FROM CODE_Catalog"):
         if not acr:
             continue
         parts = [f"{acr} Catalog"]
@@ -176,22 +192,40 @@ def build_catalog_map(fi):
 
 
 def build_book_map(fi):
-    """{TitleId -> '<authors; >, <RunningTitleHeb>'} (title-only when no authors)."""
+    """{TitleId -> '<authors; >, <RunningTitleHeb>'} (title-only when no authors).
+
+    Defensive against FIST schema variants: requires ``CODE_Title`` with at least
+    one title column; ``CODE_TitleAuthor``/``CODE_Author`` are optional (no author
+    join when absent), and ``IsCanceledCode`` is filtered only when present.
+    """
+    title_cols = _table_columns(fi, "CODE_Title")
+    if "TitleId" not in title_cols:
+        return {}
+    avail_titles = [c for c in ("RunningTitleHeb", "FullTitleHeb", "AcronymHeb") if c in title_cols]
+    if not avail_titles:
+        return {}
+
     authors = {}
-    for tid, aid in fi.execute(
-        "SELECT TitleId, AuthorId FROM CODE_TitleAuthor WHERE IsCanceledCode=0 ORDER BY TitleId, rowid"
-    ):
-        authors.setdefault(tid, []).append(aid)
-    aname = {
-        r[0]: r[1]
-        for r in fi.execute("SELECT AuthorId, HebDesc FROM CODE_Author WHERE HebDesc IS NOT NULL")
-    }
+    ta_cols = _table_columns(fi, "CODE_TitleAuthor")
+    if {"TitleId", "AuthorId"} <= ta_cols:
+        where = "WHERE IsCanceledCode=0 " if "IsCanceledCode" in ta_cols else ""
+        for tid, aid in fi.execute(
+            f"SELECT TitleId, AuthorId FROM CODE_TitleAuthor {where}ORDER BY TitleId, rowid"
+        ):
+            authors.setdefault(tid, []).append(aid)
+    aname = {}
+    a_cols = _table_columns(fi, "CODE_Author")
+    if {"AuthorId", "HebDesc"} <= a_cols:
+        aname = {
+            r[0]: r[1]
+            for r in fi.execute("SELECT AuthorId, HebDesc FROM CODE_Author WHERE HebDesc IS NOT NULL")
+        }
+
+    select = "TitleId, " + ", ".join(avail_titles)
     out = {}
-    for r in fi.execute(
-        "SELECT TitleId, RunningTitleHeb, FullTitleHeb, AcronymHeb FROM CODE_Title"
-    ):
-        tid, rt, ft, acr = r
-        title = (rt or ft or acr or "").strip()
+    for row in fi.execute(f"SELECT {select} FROM CODE_Title"):
+        tid = row[0]
+        title = next((str(v).strip() for v in row[1:] if v and str(v).strip()), "")
         if not title:
             continue
         names = [aname[a] for a in authors.get(tid, []) if a in aname]

--- a/scripts/fgp_fill_credits_bilingual.py
+++ b/scripts/fgp_fill_credits_bilingual.py
@@ -1,0 +1,319 @@
+# -*- coding: utf-8 -*-
+"""Bilingual FGP credits + FIST fallback for the NULL ``source_credit`` rows.
+
+Background
+----------
+``scripts/fgp_rebuild_text_and_credit.py`` already populates ``source_credit``
+from FGP's own ``fgp_shelfmark_meta.DataSource`` (rich, per-item: individual
+transcribers, team heads, catalogs, multi-source). That covers ~27,070 rows.
+~17,964 rows are NULL — they have no DataSource credit AND no visual XML
+(e.g. CUL shelfmarks whose MetadataOnShelfmark was never imported, incl.
+T-S Ar.50.45). Those are filled here, deterministically, from FIST (FileName /
+image_id prefix -> team / catalog / book), credited at the **team-head** level
+(the per-item transcriber is not recoverable locally — see the session notes).
+
+This script ALSO splits the credit into two columns so the web/desktop UI can
+show "Hebrew in the Hebrew UI, English in the English UI" (Hillel, 2026-06-24):
+
+    source_credit_he   source_credit_en
+
+For DataSource rows the two languages come from the ``{eng:.., heb:..}`` source
+(usually identical for credits); for catalog/book rows there is one citation
+used in both UIs (the source's own language); for the FIST team fallback we have
+a verified HE + EN per team.
+
+Legacy ``source_credit`` is left untouched (back-compat).
+
+Run on a COPY first, validate the --report sample, then swap.
+
+Usage:
+    python scripts/fgp_fill_credits_bilingual.py <db_path> [--report] [--limit N]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sqlite3
+import sys
+from collections import Counter
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Reuse the existing in-house-team constant so the Genuzos credit stays identical.
+from scripts.fgp_rebuild_text_and_credit import XML_DEFAULT_CREDIT  # noqa: E402
+
+FIST_DB = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "fist_data", "FIST.db"
+)
+
+# In-house "Genuzos" team — HE matches the existing DB form (no space before
+# גנוזות); EN is the FJMS English form (Hillel-verified).
+GENUZOS_HE = XML_DEFAULT_CREDIT  # "צוות FGP להעתקות -גנוזות"
+GENUZOS_EN = "FGP Transcriptions Team - Genuzos"
+
+# ── Verified team-head credits (Hillel via FJMS, 2026-06-24): {team: (he, en)} ──
+# Head-led for pattern-A teams; team+head form for the 5 individual-led teams.
+TEAM_CREDITS = {
+    101: ("אהרן ממן, ראש צוות FGP לחכמת הלשון",
+          "Aharon Maman, Head of FGP Linguistics team"),
+    102: ("איילה מאיר אליהו, ראש צוות FGP לפילוסופיה, תיאולוגיה ופולמוס",
+          "Ayala Meyer Eliyahu, Head of FGP Philosophy, Theology and Polemics team"),
+    103: ("מנחם כהנא, ראש צוות FGP למדרשי הלכה",
+          "Menahem Kahana, Head of FGP Halakhic Midrashim team"),
+    105: ("צוות FGP לספרות ההלכה בערבית-יהודית (דוד סקליר, ראש הצוות)",
+          "FGP Judeo-Arabic Halakhic Literature team (David Sklare, Head)"),
+    106: ("צוות FGP לפרשנות המקרא בערבית-יהודית (דוד סקליר, ראש הצוות)",
+          "FGP Judeo-Arabic Biblical Exegesis team (David Sklare, Head)"),
+    107: ("דוד סקליר, ראש צוות FGP לאוספי פירקוביץ'",
+          "David Sklare, Head of FGP Firkovitch Collections team"),
+    108: ("חיים מיליקובסקי, ראש צוות FGP למדרשי אגדה",
+          "Chaim Milikowsky, Head of FGP Aggadic Midrashim team"),
+    109: ("צוות FGP לשו\"ת (מרדכי עקיבא פרידמן, ראש הצוות)",
+          "FGP Responsa team (Mordechai A. Friedman, Head)"),
+    130: ("אורי ארליך, ראש צוות FGP לתפילה",
+          "Uri Erlich, Head of FGP Liturgy team"),
+    131: ("אברהם דוד, ראש צוות FGP לחומר תיעודי מאוחר (עברית)",
+          "Avraham David, Head of FGP Late Documentary Material (Hebrew) team"),
+    132: ("צוות FGP לחומר תיעודי (גויטין) (מרק כהן, ראש הצוות)",
+          "FGP Princeton Documentary Material (Goitein) team (Mark Cohen, Head)"),
+    133: ("צוות FGP לפרסית-יהודית (שאול שקד, ראש הצוות)",
+          "FGP Judeo-Persian team (Shaul Shaked, Head)"),
+    135: ("יעקב זוסמן, ראש צוות FGP לתלמוד ירושלמי",
+          "Yaacov Sussmann, Head of FGP Yerushalmi team"),
+    136: ("פינחס דוד מנדל, ראש צוות FGP למדרש איכה רבא",
+          "Paul Mandel, Head of FGP Midrash Eikha Rabba team"),
+    151: ("שמואל גליק, ראש צוות FGP לשרידי תשובות – מכון שוקן",
+          "Shmuel Glick, Head of FGP Seride Teshuvot Team: Shocken Institute"),
+    220: ("אלדינה קינטנה, ראש צוות FGP ללאדינו",
+          "Aldina Quintana, Head of FGP Ladino team"),
+}
+INFRA_CREDITS = {
+    200: (GENUZOS_HE, GENUZOS_EN),
+    400: ("יד הרב הרצוג בחסות צוות FGP", "Yad Harav Herzog - FGP sponsored team"),
+}
+
+
+# ── DataSource bilingual parse (keeps BOTH languages; the existing script
+#    collapsed to Hebrew). Same {eng:.., heb:..} pseudo-dict format. ──
+def _kv(block: str, key: str, other: str):
+    m = re.search(rf"{key}\s*:\s*(.*?)(?:\s*,\s*{other}\s*:|$)", block, re.DOTALL)
+    return m.group(1).strip() if m else None
+
+
+def _datasource_parts(ds):
+    """List of (en, he) per source block, alignment preserved (one per source)."""
+    if not ds:
+        return []
+    s = ds if isinstance(ds, str) else json.dumps(ds, ensure_ascii=False)
+    out = []
+    for block in re.findall(r"\{([^{}]*)\}", s):
+        e = _kv(block, "eng", "heb")
+        h = _kv(block, "heb", "eng")
+        if e or h:
+            out.append(((e or "").strip() or None, (h or "").strip() or None))
+    return out
+
+
+def build_credit_parts(conn):
+    """{mms_id -> [(en, he), ...]} — the manuscript's DataSource source-parts,
+    deduped in stable order, alignment preserved (so a team part can be matched
+    by its Hebrew text and its English counterpart kept). NOT pre-joined — the
+    caller selects only the parts matching a transcription's own source."""
+    acc = {}
+    try:
+        rows = conn.execute(
+            "SELECT mms_id, raw_json FROM fgp_shelfmark_meta "
+            "WHERE mms_id IS NOT NULL ORDER BY mms_id, rowid"
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return {}
+    for mms_id, raw in rows:
+        if not raw:
+            continue
+        try:
+            j = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        lst = acc.setdefault(str(mms_id), [])
+        for part in _datasource_parts(j.get("DataSource")):
+            if part not in lst:
+                lst.append(part)
+    return acc
+
+
+def _team_token(he_credit: str) -> str:
+    """The team-name token from a verified HE credit, used to match the right
+    DataSource part (e.g. 105 -> 'ספרות ההלכה בערבית-יהודית', 151 ->
+    'שרידי תשובות'). Everything after 'צוות FGP ל', trimmed at ' (' / ' –'."""
+    m = re.search(r"צוות FGP ל(.+)", he_credit)
+    if not m:
+        return he_credit
+    return re.split(r" \(| –", m.group(1))[0].strip()
+
+
+TEAM_TOKENS = {t: _team_token(he) for t, (he, _en) in TEAM_CREDITS.items()}
+
+
+# ── FIST catalog (500) and book (600) credit maps ──
+def build_catalog_map(fi):
+    """{CatalogId -> '<CatAcronym> Catalog, <Publisher>, <Year>'} (fields optional)."""
+    out = {}
+    for r in fi.execute(
+        "SELECT CatalogId, CatAcronym, Publisher, YearOfPublishing FROM CODE_Catalog"
+    ):
+        cid, acr, pub, yr = r
+        if not acr:
+            continue
+        parts = [f"{acr} Catalog"]
+        if pub and str(pub).strip():
+            parts.append(str(pub).strip())
+        if yr and str(yr).strip():
+            parts.append(str(yr).strip())
+        out[cid] = ", ".join(parts)
+    return out
+
+
+def build_book_map(fi):
+    """{TitleId -> '<authors; >, <RunningTitleHeb>'} (title-only when no authors)."""
+    authors = {}
+    for tid, aid in fi.execute(
+        "SELECT TitleId, AuthorId FROM CODE_TitleAuthor WHERE IsCanceledCode=0 ORDER BY TitleId, rowid"
+    ):
+        authors.setdefault(tid, []).append(aid)
+    aname = {
+        r[0]: r[1]
+        for r in fi.execute("SELECT AuthorId, HebDesc FROM CODE_Author WHERE HebDesc IS NOT NULL")
+    }
+    out = {}
+    for r in fi.execute(
+        "SELECT TitleId, RunningTitleHeb, FullTitleHeb, AcronymHeb FROM CODE_Title"
+    ):
+        tid, rt, ft, acr = r
+        title = (rt or ft or acr or "").strip()
+        if not title:
+            continue
+        names = [aname[a] for a in authors.get(tid, []) if a in aname]
+        out[tid] = (f"{'; '.join(names)}, {title}" if names else title)
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("db_path")
+    ap.add_argument("--report", action="store_true", help="don't write; print coverage + samples")
+    ap.add_argument("--limit", type=int, default=0)
+    args = ap.parse_args()
+
+    conn = sqlite3.connect(args.db_path)
+    conn.row_factory = sqlite3.Row
+    fi = sqlite3.connect(f"file:{FIST_DB}?mode=ro", uri=True)
+
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(fgp_transcriptions)")}
+    if not args.report:
+        for col in ("source_credit_he", "source_credit_en"):
+            if col not in cols:
+                conn.execute(f"ALTER TABLE fgp_transcriptions ADD COLUMN {col} TEXT")
+        conn.commit()
+
+    print("Building indexes ...")
+    credit_parts = build_credit_parts(conn)
+    catalog_map = build_catalog_map(fi)
+    book_map = build_book_map(fi)
+    print(f"  DataSource mms_ids: {len(credit_parts)} | catalogs: {len(catalog_map)} "
+          f"| books: {len(book_map)}")
+
+    def credit_for(row):
+        """(he, en, category) keyed on the transcription's OWN source (image_id),
+        NOT the per-manuscript DataSource aggregate (which mixes in every catalog
+        a manuscript appears in — the VII.E.18 'Schwab; Gil' bug).
+
+        * 500/600 -> the precise catalog/book the image_id points at (these have
+          no FGP individual; the DataSource aggregate is dropped);
+        * scholarly team -> the verified team-head credit, but if the manuscript's
+          DataSource carries a part matching THIS team (often with the real
+          transcriber, e.g. אילה אליהו), the HE keeps that richer part;
+        * 200/400 -> the fixed in-house / sponsored credit (drops catalog noise);
+        * else -> the manuscript's DataSource as-is (rare unmapped teams) or null.
+        EN is always the clean verified team credit (we have no English transcriber
+        names); HE carries the individual where matched."""
+        image_id = row["image_id"]
+        prefix = int(image_id[:3]) if image_id and image_id[:3].isdigit() else None
+        sub = int(image_id[3:7]) if image_id and image_id[3:7].isdigit() else None
+        parts = credit_parts.get(str(row["mms_id"]), []) if row["mms_id"] is not None else []
+
+        if prefix == 500:
+            s = catalog_map.get(sub)
+            return (s, s, "catalog") if s else (None, None, "catalog:unresolved")
+        if prefix == 600:
+            s = book_map.get(sub)
+            return (s, s, "book") if s else (None, None, "book:unresolved")
+        if prefix in TEAM_CREDITS:
+            tok = TEAM_TOKENS[prefix]
+            matched_he = [he for (_en, he) in parts if he and tok in he]
+            he = "; ".join(dict.fromkeys(matched_he)) if matched_he else TEAM_CREDITS[prefix][0]
+            en = TEAM_CREDITS[prefix][1]
+            return he, en, f"team:{prefix}:{'matched' if matched_he else 'fallback'}"
+        if prefix in INFRA_CREDITS:
+            he, en = INFRA_CREDITS[prefix]
+            return he, en, f"infra:{prefix}"
+        # Unmapped team / other: keep the manuscript's DataSource (rare), else null.
+        if parts:
+            he = "; ".join(dict.fromkeys(h for (_e, h) in parts if h)) or None
+            en = "; ".join(dict.fromkeys(e for (e, _h) in parts if e)) or None
+            return he, (en or he), "datasource-other"
+        return None, None, "unknown"
+
+    sel = "SELECT id, mms_id, c_number, image_id, shelfmark, collection, source_credit FROM fgp_transcriptions"
+    if args.limit:
+        sel += f" LIMIT {args.limit}"
+    rows = conn.execute(sel).fetchall()
+
+    cat = Counter()
+    filled_null = Counter()
+    samples = {}
+    updates = []
+    for r in rows:
+        he, en, category = credit_for(r)
+        cat[category.split(":")[0]] += 1
+        was_null = r["source_credit"] is None
+        if was_null and (he or en):
+            filled_null[category.split(":")[0]] += 1
+            samples.setdefault(category.split(":")[0], [])
+            if len(samples[category.split(":")[0]]) < 3:
+                samples[category.split(":")[0]].append(
+                    (r["collection"], r["shelfmark"], he, en))
+        updates.append((he, en, r["id"]))
+
+    print(f"\nRows: {len(rows)}")
+    print("category distribution (all rows):", dict(cat))
+    print("NEWLY-filled (were NULL) by category:", dict(filled_null),
+          "=> total", sum(filled_null.values()))
+    null_after = sum(1 for he, en, _ in updates if not (he or en))
+    print(f"still-null after fill: {null_after}")
+    print("\n--- samples of newly-filled rows (verify on FJMS) ---")
+    for c, items in samples.items():
+        print(f"[{c}]")
+        for coll, sm, he, en in items:
+            print(f"   {coll} {sm}")
+            print(f"      HE: {he}")
+            print(f"      EN: {en}")
+
+    if args.report:
+        print("\nREPORT (no write).")
+    else:
+        print("\nWriting source_credit_he / source_credit_en ...")
+        conn.executemany(
+            "UPDATE fgp_transcriptions SET source_credit_he=?, source_credit_en=? WHERE id=?",
+            updates,
+        )
+        conn.commit()
+        print(f"Updated {len(updates)} rows.")
+    conn.close()
+    fi.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fgp_fill_credits_bilingual.py
+++ b/scripts/fgp_fill_credits_bilingual.py
@@ -102,17 +102,34 @@ def _kv(block: str, key: str, other: str):
     return m.group(1).strip() if m else None
 
 
+def _pair(eng, heb):
+    e = (str(eng).strip() if eng is not None else "") or None
+    h = (str(heb).strip() if heb is not None else "") or None
+    return (e, h) if (e or h) else None
+
+
 def _datasource_parts(ds):
-    """List of (en, he) per source block, alignment preserved (one per source)."""
+    """List of (en, he) per source block, alignment preserved (one per source).
+
+    Real data always stores ``DataSource`` as a ``{eng:.., heb:..}`` pseudo-dict
+    *string* (unquoted keys), so the regex branch is the live path. Genuine
+    dict/list values are handled directly (they would NOT match the unquoted-key
+    regex after ``json.dumps`` quotes the keys — Codex #309 P3)."""
     if not ds:
         return []
-    s = ds if isinstance(ds, str) else json.dumps(ds, ensure_ascii=False)
+    if isinstance(ds, dict):
+        p = _pair(ds.get("eng"), ds.get("heb"))
+        return [p] if p else []
+    if isinstance(ds, list):
+        out = []
+        for item in ds:
+            out.extend(_datasource_parts(item))
+        return out
     out = []
-    for block in re.findall(r"\{([^{}]*)\}", s):
-        e = _kv(block, "eng", "heb")
-        h = _kv(block, "heb", "eng")
-        if e or h:
-            out.append(((e or "").strip() or None, (h or "").strip() or None))
+    for block in re.findall(r"\{([^{}]*)\}", str(ds)):
+        p = _pair(_kv(block, "eng", "heb"), _kv(block, "heb", "eng"))
+        if p:
+            out.append(p)
     return out
 
 
@@ -154,6 +171,41 @@ def _team_token(he_credit: str) -> str:
 
 
 TEAM_TOKENS = {t: _team_token(he) for t, (he, _en) in TEAM_CREDITS.items()}
+
+
+def _token_matches(token: str, text: str) -> bool:
+    """True if ``token`` occurs in ``text`` as a COMPLETE team-name token, not
+    merely as the prefix of a longer one.
+
+    Plain substring matching cross-contaminated overlapping teams (Codex #309 P1):
+    token 132 = 'חומר תיעודי' is a prefix of token 131 = 'חומר תיעודי מאוחר', so a
+    132-prefix row on a manuscript that also carries team 131's DataSource part
+    would wrongly keep Avraham David's (131) credit. We reject an occurrence that
+    is immediately continued by more Hebrew (optionally across a single run of
+    spaces) — 'חומר תיעודי' followed by ' מאוחר' is rejected, while 'חומר תיעודי'
+    followed by ' (גויטין)' (132's own part) or end-of-string is accepted."""
+    if not token or not text:
+        return False
+    for m in re.finditer(re.escape(token), text):
+        if not re.match(r"\s*[א-ת]", text[m.end():]):
+            return True
+    return False
+
+
+def resolve_team_credit(prefix: int, parts):
+    """(he, en, category) for a scholarly-team transcription.
+
+    EN is always the clean verified English team credit (no English transcriber
+    names exist locally). HE is the verified team-head credit by default, but
+    keeps the manuscript DataSource part(s) belonging to THIS team when present
+    (boundary-matched via :func:`_token_matches`, so the richer individual
+    transcriber — e.g. אילה אליהו for Firkovitch — is preserved without pulling
+    in another team's part)."""
+    tok = TEAM_TOKENS[prefix]
+    matched_he = [he for (_en, he) in parts if he and _token_matches(tok, he)]
+    he = "; ".join(dict.fromkeys(matched_he)) if matched_he else TEAM_CREDITS[prefix][0]
+    en = TEAM_CREDITS[prefix][1]
+    return he, en, f"team:{prefix}:{'matched' if matched_he else 'fallback'}"
 
 
 # ── FIST catalog (500) and book (600) credit maps ──
@@ -284,11 +336,7 @@ def main() -> int:
             s = book_map.get(sub)
             return (s, s, "book") if s else (None, None, "book:unresolved")
         if prefix in TEAM_CREDITS:
-            tok = TEAM_TOKENS[prefix]
-            matched_he = [he for (_en, he) in parts if he and tok in he]
-            he = "; ".join(dict.fromkeys(matched_he)) if matched_he else TEAM_CREDITS[prefix][0]
-            en = TEAM_CREDITS[prefix][1]
-            return he, en, f"team:{prefix}:{'matched' if matched_he else 'fallback'}"
+            return resolve_team_credit(prefix, parts)
         if prefix in INFRA_CREDITS:
             he, en = INFRA_CREDITS[prefix]
             return he, en, f"infra:{prefix}"

--- a/shared/fgp_service.py
+++ b/shared/fgp_service.py
@@ -795,8 +795,12 @@ def _row_to_fgp_source(row: sqlite3.Row) -> Dict[str, Any]:
         "attribution": FGP_ATTRIBUTION,
         # Per-source FGP credit (team leader, e.g. "יעקב זוסמן, ראש צוות FGP…").
         # None on an old DB lacking the column (graceful — display falls back to
-        # the generic attribution).
+        # the generic attribution). ``source_credit`` is the legacy single-language
+        # value; ``_he``/``_en`` are the bilingual split (2026-06-24) — the UI picks
+        # by language via :func:`pick_fgp_credit`, falling back across all three.
         "source_credit": d.get("source_credit"),
+        "source_credit_he": d.get("source_credit_he"),
+        "source_credit_en": d.get("source_credit_en"),
         "folio_num": d.get("folio_num"),
         "image_side": d.get("image_side"),
         "folio_label": _fgp_folio_label(d),
@@ -805,6 +809,22 @@ def _row_to_fgp_source(row: sqlite3.Row) -> Dict[str, Any]:
         "sequence_order": d.get("sequence_order") or 0,
     }
     return out
+
+
+def pick_fgp_credit(src: Dict[str, Any], lang: str = "en") -> Optional[str]:
+    """Pick the language-appropriate FGP credit from a chooser source dict.
+
+    Hebrew UI prefers ``source_credit_he``, English UI prefers
+    ``source_credit_en``; either falls back to the other, then to the legacy
+    single-language ``source_credit`` (so an old sidecar still shows something).
+    Returns ``None`` only when no credit exists at all.
+    """
+    he = src.get("source_credit_he")
+    en = src.get("source_credit_en")
+    legacy = src.get("source_credit")
+    if str(lang or "").lower().startswith("he"):
+        return he or en or legacy
+    return en or he or legacy
 
 
 class FgpService:

--- a/tests/test_fgp_credit_picker.py
+++ b/tests/test_fgp_credit_picker.py
@@ -1,0 +1,48 @@
+"""pick_fgp_credit — language-appropriate FGP credit selection (2026-06-24).
+
+HE UI prefers ``source_credit_he``, EN UI prefers ``source_credit_en``; either
+falls back to the other, then to the legacy single-language ``source_credit``.
+"""
+from __future__ import annotations
+
+from shared.fgp_service import pick_fgp_credit
+
+_HE = "צוות FGP לספרות ההלכה בערבית-יהודית (דוד סקליר, ראש הצוות)"
+_EN = "FGP Judeo-Arabic Halakhic Literature team (David Sklare, Head)"
+
+
+def test_he_ui_prefers_hebrew():
+    src = {"source_credit_he": _HE, "source_credit_en": _EN, "source_credit": "legacy"}
+    assert pick_fgp_credit(src, "he") == _HE
+
+
+def test_en_ui_prefers_english():
+    src = {"source_credit_he": _HE, "source_credit_en": _EN, "source_credit": "legacy"}
+    assert pick_fgp_credit(src, "en") == _EN
+
+
+def test_he_falls_back_to_en_then_legacy():
+    assert pick_fgp_credit({"source_credit_en": _EN}, "he") == _EN
+    assert pick_fgp_credit({"source_credit": "legacy"}, "he") == "legacy"
+
+
+def test_en_falls_back_to_he_then_legacy():
+    assert pick_fgp_credit({"source_credit_he": _HE}, "en") == _HE
+    assert pick_fgp_credit({"source_credit": "legacy"}, "en") == "legacy"
+
+
+def test_none_when_no_credit():
+    assert pick_fgp_credit({}, "en") is None
+    assert pick_fgp_credit({}, "he") is None
+
+
+def test_lang_variants_treated_as_hebrew():
+    src = {"source_credit_he": _HE, "source_credit_en": _EN}
+    for lang in ("he", "he-IL", "HE", "heb"):
+        assert pick_fgp_credit(src, lang) == _HE
+
+
+def test_unknown_lang_defaults_to_english_side():
+    src = {"source_credit_he": _HE, "source_credit_en": _EN}
+    assert pick_fgp_credit(src, "fr") == _EN
+    assert pick_fgp_credit(src, "") == _EN

--- a/tests/test_fgp_credit_resolution.py
+++ b/tests/test_fgp_credit_resolution.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+"""Team-credit resolution + DataSource parsing (Codex PR #309 review fixes).
+
+P1 — overlapping team tokens (132 'חומר תיעודי' is a prefix of 131
+'חומר תיעודי מאוחר') must NOT cross-contaminate: a 132-prefix row whose
+manuscript also carries team 131's DataSource part must keep 132's head credit,
+not Avraham David (131).
+
+P3 — ``_datasource_parts`` must handle genuine dict/list values, not only the
+``{eng:.., heb:..}`` pseudo-dict string that the live data always uses.
+"""
+from __future__ import annotations
+
+from scripts.fgp_fill_credits_bilingual import (
+    TEAM_CREDITS,
+    TEAM_TOKENS,
+    _datasource_parts,
+    _token_matches,
+    resolve_team_credit,
+)
+
+# DataSource parts as (en, he) pairs, mirroring build_credit_parts output.
+_PART_131 = (None, "אברהם דוד, צוות FGP לחומר תיעודי מאוחר (עברית)")
+_PART_132 = (None, "מרק כהן, צוות FGP לחומר תיעודי (גויטין)")
+_PART_FIRKOVITCH = (None, "אילה אליהו, צוות FGP לאוספי פירקוביץ' (דוד סקליר, ראש הצוות)")
+
+
+def test_token_132_does_not_match_131_superset():
+    # 132's token must not match team 131's longer credit text.
+    assert _token_matches(TEAM_TOKENS[132], _PART_131[1]) is False
+    # ...but matches its own part and team 131 matches its own.
+    assert _token_matches(TEAM_TOKENS[132], _PART_132[1]) is True
+    assert _token_matches(TEAM_TOKENS[131], _PART_131[1]) is True
+
+
+def test_132_row_with_131_part_keeps_132_head_not_avraham_david():
+    # A 132 transcription on a multi-team manuscript carrying BOTH parts.
+    he, en, cat = resolve_team_credit(132, [_PART_131, _PART_132])
+    assert "אברהם דוד" not in he  # no 131 contamination
+    assert "גויטין" in he  # kept its own (Goitein) part
+    assert en == TEAM_CREDITS[132][1]
+    assert cat == "team:132:matched"
+
+
+def test_132_row_with_only_131_part_falls_back_to_head():
+    # No own part present -> verified head credit, never the wrong team.
+    he, en, cat = resolve_team_credit(132, [_PART_131])
+    assert he == TEAM_CREDITS[132][0]
+    assert cat == "team:132:fallback"
+
+
+def test_firkovitch_keeps_individual_transcriber():
+    he, en, cat = resolve_team_credit(107, [_PART_FIRKOVITCH])
+    assert he == _PART_FIRKOVITCH[1]  # richer individual credit preserved
+    assert "אילה אליהו" in he
+    assert en == TEAM_CREDITS[107][1]
+    assert cat == "team:107:matched"
+
+
+def test_team_with_no_parts_uses_head_credit():
+    he, en, cat = resolve_team_credit(105, [])
+    assert he == TEAM_CREDITS[105][0]
+    assert en == TEAM_CREDITS[105][1]
+    assert cat == "team:105:fallback"
+
+
+def test_token_matches_end_of_string():
+    assert _token_matches("שו\"ת", 'צוות FGP לשו"ת') is True
+
+
+def test_datasource_parts_pseudo_dict_string():
+    parts = _datasource_parts("{eng: Gil, heb: גיל}")
+    assert parts == [("Gil", "גיל")]
+
+
+def test_datasource_parts_multiple_blocks():
+    parts = _datasource_parts("{eng: A, heb: א}{eng: B, heb: ב}")
+    assert parts == [("A", "א"), ("B", "ב")]
+
+
+def test_datasource_parts_real_dict():
+    # A genuine dict would survive json.dumps with quoted keys -> the regex would
+    # miss it; handled directly now.
+    assert _datasource_parts({"eng": "Gil", "heb": "גיל"}) == [("Gil", "גיל")]
+
+
+def test_datasource_parts_real_list():
+    parts = _datasource_parts([{"eng": "A", "heb": "א"}, {"eng": "B", "heb": "ב"}])
+    assert parts == [("A", "א"), ("B", "ב")]
+
+
+def test_datasource_parts_empty():
+    assert _datasource_parts(None) == []
+    assert _datasource_parts("") == []

--- a/tests/test_fgp_fill_credits_columns.py
+++ b/tests/test_fgp_fill_credits_columns.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+"""FIST catalog/book credit builders degrade gracefully on lean schema variants.
+
+Codex PR #309 (P2): ``build_catalog_map`` ran a hardcoded
+``SELECT ... Publisher, YearOfPublishing FROM CODE_Catalog``. Those columns
+exist in the full FIST.db but NOT in every FIST schema variant (the synthetic
+test fixture omits them). Because the builder runs unconditionally at startup,
+a missing column would raise ``OperationalError`` and abort the *entire* credit
+fill — not just catalog rows. These tests pin the column-defensive behaviour.
+"""
+from __future__ import annotations
+
+import sqlite3
+
+from scripts.fgp_fill_credits_bilingual import build_book_map, build_catalog_map
+
+
+def _lean_catalog_conn():
+    """CODE_Catalog without Publisher/YearOfPublishing (synthetic-fixture shape)."""
+    con = sqlite3.connect(":memory:")
+    con.executescript(
+        """
+        CREATE TABLE CODE_Catalog (
+            CatalogId INTEGER PRIMARY KEY, CatalogType TEXT, Author TEXT,
+            CatAcronym TEXT, Title TEXT, Domain TEXT, Collection TEXT
+        );
+        INSERT INTO CODE_Catalog (CatalogId, CatAcronym) VALUES (12, 'CUDL'), (13, NULL);
+        """
+    )
+    return con
+
+
+def test_catalog_map_no_publisher_year_columns():
+    con = _lean_catalog_conn()
+    out = build_catalog_map(con)  # must not raise OperationalError
+    assert out == {12: "CUDL Catalog"}  # acronym-only; NULL acronym skipped
+
+
+def test_catalog_map_full_schema_uses_publisher_year():
+    con = sqlite3.connect(":memory:")
+    con.executescript(
+        """
+        CREATE TABLE CODE_Catalog (
+            CatalogId INTEGER PRIMARY KEY, CatAcronym TEXT,
+            Publisher TEXT, YearOfPublishing TEXT
+        );
+        INSERT INTO CODE_Catalog VALUES (12, 'CUDL', 'Cambridge UP', '1998');
+        INSERT INTO CODE_Catalog VALUES (13, 'X', NULL, NULL);
+        """
+    )
+    out = build_catalog_map(con)
+    assert out[12] == "CUDL Catalog, Cambridge UP, 1998"
+    assert out[13] == "X Catalog"  # optional fields gracefully omitted
+
+
+def test_catalog_map_missing_table_returns_empty():
+    con = sqlite3.connect(":memory:")
+    assert build_catalog_map(con) == {}
+
+
+def test_book_map_without_author_tables():
+    con = sqlite3.connect(":memory:")
+    con.executescript(
+        """
+        CREATE TABLE CODE_Title (
+            TitleId INTEGER PRIMARY KEY, FullTitleHeb TEXT,
+            RunningTitleHeb TEXT, AcronymHeb TEXT
+        );
+        INSERT INTO CODE_Title VALUES (5, 'full', 'running', 'acr');
+        INSERT INTO CODE_Title VALUES (6, NULL, NULL, 'onlyacr');
+        """
+    )
+    out = build_book_map(con)  # no CODE_TitleAuthor / CODE_Author present
+    assert out == {5: "running", 6: "onlyacr"}  # title-only, prefers RunningTitleHeb
+
+
+def test_book_map_missing_title_table_returns_empty():
+    con = sqlite3.connect(":memory:")
+    assert build_book_map(con) == {}

--- a/web/components/version_selector.py
+++ b/web/components/version_selector.py
@@ -175,11 +175,18 @@ def create_version_selector(
                     first_fgp = fgp_sources[0]
                     version_label.text = 'FGP'
                     version_label.style(f'color: {_FGP_COLOR};')
+                    # Same bilingual credit + translation labelling as the menu
+                    # path, so the initial auto-loaded FGP source shows the same
+                    # metadata it would after the user reselects it (Codex #309 P2).
+                    _attr = first_fgp.get('attribution') or first_fgp.get('source_scholar', 'FGP')
+                    _credit = pick_fgp_credit(first_fgp, get_language()) or _attr
                     if on_version_change:
                         on_version_change(first_fgp.get('content', ''), {
                             'source': 'fgp',
-                            'attribution': first_fgp.get('attribution') or first_fgp.get('source_scholar', 'FGP'),
+                            'attribution': _attr,
+                            'source_credit': _credit,
                             'is_fgp': True,
+                            'is_translation': source_relation_kind(first_fgp) == 'translation',
                             'is_default': True,
                             'source_id': first_fgp.get('id'),
                             'uid': first_fgp.get('uid'),

--- a/web/components/version_selector.py
+++ b/web/components/version_selector.py
@@ -12,12 +12,12 @@ Allows users to switch between different versions of a transcription:
 import asyncio
 import logging
 from nicegui import ui
-from web.translations import tr
+from web.translations import tr, get_language
 from web.supabase_client import get_corrections
 from web.auth_state import GlobalAuthState
 from web.corrections_service import get_pending_corrections_for_page
 from web.supabase_client import get_user_client
-from shared.fgp_service import group_transcription_sources, source_relation_kind
+from shared.fgp_service import group_transcription_sources, source_relation_kind, pick_fgp_credit
 from typing import Optional, Callable, List, Dict, Any
 
 logger = logging.getLogger(__name__)
@@ -393,8 +393,10 @@ def create_version_selector(
                         for fed in fgp_sources:
                             attribution = fed.get('attribution') or fed.get('source_scholar') or 'FGP'
                             # Specific FGP team credit (e.g. "יעקב זוסמן, ראש צוות
-                            # FGP…"); falls back to the generic attribution.
-                            credit = fed.get('source_credit') or attribution
+                            # FGP…"), in the UI language (HE/EN bilingual split,
+                            # falling back across languages then to the generic
+                            # attribution).
+                            credit = pick_fgp_credit(fed, get_language()) or attribution
                             # An FGP source can be a transcription OR a translation
                             # (e.g. a Hebrew translation of a Judeo-Arabic letter).
                             # Label it by its actual kind — never call a translation


### PR DESCRIPTION
## FGP transcription credits — bilingual + per-source

Fills the missing FGP `source_credit` (e.g. T-S Ar.50.45 was blank) and fixes a contamination bug, then wires the UI to show the credit in the active language.

### The bug it fixes
The existing credits came from FGP's per-**manuscript** `fgp_shelfmark_meta.DataSource`, which the source script unioned across every source a manuscript appears in — so a Gil-book transcription on a manuscript also catalogued by Schwab got `Schwab Catalog; Gil` (74–95% of populated rows were contaminated).

### The fix — credit from the transcription's own `image_id`
- **500** → `<CatAcronym> Catalog, <Publisher>, <Year>` (`FileName[3:7]` = CatalogId)
- **600** → `<authors; >, <RunningTitleHeb>` (`FileName[3:7]` = TitleId)
- **scholarly team** → verified team-head credit (Hillel via FJMS), keeping the DataSource **individual transcriber** only when its text matches that team (e.g. Firkovitch's *אילה אליהו*); cross-team/catalog noise dropped
- **200** → Genuzos, **400** → Yad Harav Herzog (fixed)
- bilingual `source_credit_he` + `source_credit_en`; legacy `source_credit` untouched; **~97.6% credited**

### Wiring
`shared/fgp_service.py` exposes the two columns + `pick_fgp_credit(src, lang)` (he→en→legacy / en→he→legacy). Web `version_selector.py` and desktop `genizah_app.py` pick by UI language (desktop live-reads `CURRENT_LANG`).

### Verified (Hillel eyeballed)
VII.E.18 → `גיל, משה, במלכות ישמעאל בתקופת הגאונים` (Schwab gone); Firkovitch keeps `אילה אליהו…`; 105 de-contaminated; catalogs/books/Genuzos/Herzog all correct.

### Tests
`tests/test_fgp_credit_picker.py` (7); 94 FGP tests pass; ruff clean.

### Deploy (separate — gitignored sidecar)
Regenerate `fgp_transcriptions.db` via `scripts/fgp_fill_credits_bilingual.py`, then scp to the web server + publish to the desktop sidecar channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
