### PR TITLE
SEED-017 (#10): Rotate + Fullscreen in Joins-Lab / Compare viewers (web + desktop)

### DIFF
--- a/.planning/seeds/SEED-017-lab-viewer-rotate-fullscreen.md
+++ b/.planning/seeds/SEED-017-lab-viewer-rotate-fullscreen.md
@@ -26,13 +26,19 @@ to its toolbar. This automatically reaches BOTH consumers:
 - the main Joins-Lab anchor pane (`web/pages/joins_lab.py`), and
 - the Compare modal's two panes (`web/components/compare_modal.py`, which builds `AnchorViewer`).
 
-**Out of scope (logged, not done — per the answered decision):**
-- The reset-icon taste choice `fit_screen` vs `restart_alt` (#6) — keep `fit_screen`.
-- The rotation **slider** that browse.py carries — buttons match the desktop viewer and are the
-  minimal "Rotate" parity; a slider adds toolbar width + re-render sync cost for little gain.
-- Desktop `CompareDialog` (`desktop/join_workbench.py`) rotate/fullscreen — its panes have zoom
-  only (the audit cited the desktop *ResultDialog* viewer, which already has rotate+fullscreen, as
-  the parity reference; the Lab CompareDialog was never flagged by #10). Candidate follow-up only.
+**Scope expanded after UAT (2026-06-25, user request):** desktop Joins Lab is now IN scope too.
+- **Web reset icon:** switched `fit_screen` → `/browse`'s `restart_alt` "Reset View" (#6 taste choice
+  the user explicitly asked for).
+- **Web rotate-left:** signed accumulation (-90), not `(x-90)%360`=270, so the CSS transition animates
+  90° left instead of a 270° clockwise spin (UAT: "270 right seems odd").
+- **Desktop** (`desktop/join_workbench.py`): added Rotate Left / Rotate Right / Reset / Fullscreen to
+  BOTH the main workbench anchor pane AND the CompareDialog panes, using the same controls as the
+  ResultDialog viewer (glyphs ↺ ↻ ↩ ⛶) — NOT the brightness/contrast/gamma sliders. Rotation via a new
+  `_rotated_pixmap` helper (QTransform on the cached pixmap); Fullscreen reuses
+  `desktop.viewers.FullscreenImageWindow` (the ResultDialog fullscreen window).
+
+**Still out of scope (logged):** the rotation **slider** browse.py carries — buttons match the desktop
+viewer and are the minimal "Rotate" parity; a slider adds toolbar width + re-render sync cost for little gain.
 
 ## Why the JS layer is already ready
 

--- a/.planning/seeds/SEED-017-lab-viewer-rotate-fullscreen.md
+++ b/.planning/seeds/SEED-017-lab-viewer-rotate-fullscreen.md
@@ -1,0 +1,89 @@
+# SEED-017 — Joins-Lab / Compare viewer: Rotate + Fullscreen (audit #10)
+
+> Source: 2026-06-23 product-quality audit, finding **#10** (CONFIRMED, MEDIUM).
+> Register: `.planning/audit-2026-06-23-product-quality/MASTER.md`.
+> Decision gate (ANSWERED 2026-06-23): *"ONLY #10 — add Rotate + Fullscreen to the
+> Lab/Compare viewer. NOT the reset/fit icon (#6), NOT desktop sorting (#18), NOT the
+> puzzle-toolbar icons (#17), NOT the others."* → single-item viewer-control parity seed.
+
+## Problem (finding #10)
+
+The web **Joins-Lab anchor pane** and the **Compare modal** both render images via
+`web/components/anchor_viewer.py::AnchorViewer`, whose toolbar has **zoom out / % / zoom in /
+reset only** (anchor_viewer.py:611-636). Two sibling viewers in the same codebase already offer
+rotate + fullscreen:
+
+- `web/pages/browse.py:4022-4034` — rotate-left, rotation slider, rotate-right, reset, fullscreen.
+- `desktop/viewers.py:682-726` — desktop ResultDialog/Browse viewer: rotate + fullscreen.
+
+So a scholar inspecting a fragment in the Lab/Compare can zoom but **cannot rotate** a
+sideways scan or go **fullscreen** — capabilities they have everywhere else.
+
+## Scope (precisely #10 — web only)
+
+Bring `AnchorViewer` to parity by adding **Rotate Left**, **Rotate Right**, and **Fullscreen**
+to its toolbar. This automatically reaches BOTH consumers:
+- the main Joins-Lab anchor pane (`web/pages/joins_lab.py`), and
+- the Compare modal's two panes (`web/components/compare_modal.py`, which builds `AnchorViewer`).
+
+**Out of scope (logged, not done — per the answered decision):**
+- The reset-icon taste choice `fit_screen` vs `restart_alt` (#6) — keep `fit_screen`.
+- The rotation **slider** that browse.py carries — buttons match the desktop viewer and are the
+  minimal "Rotate" parity; a slider adds toolbar width + re-render sync cost for little gain.
+- Desktop `CompareDialog` (`desktop/join_workbench.py`) rotate/fullscreen — its panes have zoom
+  only (the audit cited the desktop *ResultDialog* viewer, which already has rotate+fullscreen, as
+  the parity reference; the Lab CompareDialog was never flagged by #10). Candidate follow-up only.
+
+## Why the JS layer is already ready
+
+`web/static/manuscript_viewer.js::createManuscriptViewer` already exposes `update(scale, rotation)`,
+`rotateLeft/rotateRight`, `state.rotation`, and `reset()` (which zeroes rotation). AnchorViewer's
+per-instance registry (`window.__msViewers[vid]`, SEED-010) already drives `mv.update(zoom, rotation)`.
+So the only missing pieces are **Python-side rotation state + toolbar buttons + a fullscreen toggle**.
+
+## Plan (all in `web/components/anchor_viewer.py`)
+
+1. **State:** add `self._rotation: int = 0` in `__init__`.
+2. **`_apply_transform()`** (rename of `_apply_zoom`): push BOTH `self._zoom` and `self._rotation`
+   to `mv.update(zoom, rotation)`; the no-`mv` fallback transform must also include
+   `rotate({rotation}deg)` (previously dropped rotation). Callers: `zoom_in/out/reset`, the new
+   `rotate_*`.
+3. **`rotate_left()` / `rotate_right()`:** `self._rotation = (self._rotation ∓ 90) % 360` →
+   `_apply_transform()`.
+4. **`zoom_reset()`:** also set `self._rotation = 0` (JS `mv.reset()` already zeroes it; sync Python).
+5. **`update_content(direction != 0)`:** reset `self._rotation = 0` alongside the existing
+   `self._zoom = 1.0` so rotation clears on folio change (matches the re-rendered `<img>` which
+   carries no rotation).
+6. **`toggle_fullscreen()`:** native Fullscreen API on this viewer's `.anchor-image-pane` wrapper
+   (image + controls bar). Native fullscreen **escapes the Compare dialog's stacking/transform
+   context** (a `position:fixed` overlay would be trapped inside the maximized `ui.dialog`) and ESC
+   exits natively. Transcription stays out of fullscreen (full-bleed image, like /browse).
+7. **Markup:** wrap `image_container` + the controls bar in
+   `ui.element('div').classes('anchor-image-pane')` so the fullscreen target carries both. Existing
+   CSS (`.anchor-viewer-container .image-container`, `.anchor-controls-bar`) is descendant/class-based
+   → unaffected by the extra wrapper.
+8. **CSS** in `_VIEWER_HEAD`: `.anchor-image-pane:fullscreen { … }` + `:fullscreen .image-container`
+   override (fill viewport, square corners) + `:fullscreen .anchor-controls-bar` (no rounded corners).
+9. **Buttons:** add `rotate_left`, `rotate_right`, `fullscreen` Material icons to the toolbar's right
+   group, same `flat round dense` + `aria-label` + tooltip pattern as the zoom buttons. Strings
+   `tr("Rotate left")`, `tr("Rotate right")`, `tr("Fullscreen")` — all already in
+   `genizah_translations.TRANSLATIONS` (HE: סובב שמאלה / סובב ימינה / מסך מלא), no English leak.
+
+## HIGH-2 invariant (must hold)
+
+No `handleImageError`, no `fetchFlIdsFromManifest`, no `iiif.nli.org.il` introduced. The fullscreen
+JS only toggles `requestFullscreen()/exitFullscreen()` on a viewer-scoped DOM node.
+
+## Tests (`tests/test_anchor_viewer.py`)
+
+- rotation arithmetic: initial 0; rotate_right → 90; rotate_left → 270; 4×right wraps to 0.
+- `zoom_reset` zeroes rotation; folio-change (`update_content` direction≠0) zeroes rotation.
+- source/`_VIEWER_HEAD` assertions: `rotate_left`/`rotate_right`/`fullscreen` icons present;
+  `.anchor-image-pane` wrapper present; `:fullscreen` CSS present; HIGH-2 still holds
+  (`_VIEWER_HEAD` has no `handleImageError` / `iiif.nli.org.il`).
+
+## Verification
+
+Targeted suite (`test_anchor_viewer.py`, `test_compare_modal.py`) + ruff + Codex code-review of the
+diff, then PR. Manual: live Joins-Lab anchor pane + Compare modal — rotate ±90 works on both panes
+independently, fullscreen on each pane escapes the modal, ESC exits.

--- a/desktop/join_workbench.py
+++ b/desktop/join_workbench.py
@@ -213,6 +213,24 @@ def _clamp_zoom(z):
     return max(0.25, min(4.0, z))
 
 
+def _rotated_pixmap(pix, degrees):
+    """Return ``pix`` rotated ``degrees`` clockwise via QTransform (SEED-017 #10 desktop).
+
+    Qt pixmap rotation is an instantaneous re-render (no CSS-style animation), so a
+    signed angle (-90) and its %360 equivalent (270) look identical — we pass the
+    signed value straight through. Returns ``pix`` unchanged when ``degrees`` is
+    0/falsy or ``pix`` is None. Lazy Qt imports keep the module import-safe headlessly.
+    """
+    if pix is None or not degrees:
+        return pix
+    from PyQt6.QtCore import Qt
+    from PyQt6.QtGui import QTransform
+    return pix.transformed(
+        QTransform().rotate(degrees),
+        Qt.TransformationMode.SmoothTransformation,
+    )
+
+
 def _image_url_for_idx(images, idx, width=2000):
     """Return the IIIF full URL for images[idx], or '' if out of range.
 
@@ -3940,6 +3958,30 @@ if _QT_AVAILABLE:
             ctrl_row.addWidget(zoom_lbl)
             ctrl_row.addWidget(btn_zoom_in)
 
+            # SEED-017 (#10): rotate + reset + fullscreen — same controls as the
+            # ResultDialog viewer (↺ ↻ ↩ ⛶), NOT brightness/contrast/gamma. Wired
+            # below once pane_dict exists (captured by reference like the zoom buttons).
+            btn_rot_left = QPushButton("↺")
+            btn_rot_left.setFixedSize(26, 22)
+            btn_rot_left.setToolTip(tr("Rotate Left 90°"))
+            btn_rot_left.setAccessibleName(tr("Rotate Left 90°"))
+            btn_rot_right = QPushButton("↻")
+            btn_rot_right.setFixedSize(26, 22)
+            btn_rot_right.setToolTip(tr("Rotate Right 90°"))
+            btn_rot_right.setAccessibleName(tr("Rotate Right 90°"))
+            btn_view_reset = QPushButton("↩")
+            btn_view_reset.setFixedSize(26, 22)
+            btn_view_reset.setToolTip(tr("Reset View"))
+            btn_view_reset.setAccessibleName(tr("Reset View"))
+            btn_fullscreen = QPushButton("⛶")
+            btn_fullscreen.setFixedSize(26, 22)
+            btn_fullscreen.setToolTip(tr("Fullscreen"))
+            btn_fullscreen.setAccessibleName(tr("Fullscreen"))
+            ctrl_row.addWidget(btn_rot_left)
+            ctrl_row.addWidget(btn_rot_right)
+            ctrl_row.addWidget(btn_view_reset)
+            ctrl_row.addWidget(btn_fullscreen)
+
             img = QLabel(tr("…"))
             img.setAlignment(Qt.AlignmentFlag.AlignCenter)
             img.setStyleSheet("background:#e2e8f0;color:#64748b;")
@@ -3979,6 +4021,7 @@ if _QT_AVAILABLE:
                 "sys_id": "",
                 "page": 1,
                 "zoom": 1.0,
+                "rotation": 0,  # SEED-017 (#10): degrees CW; reset on each fresh load
                 "full_pix": None,
             }
             # Wire folio buttons — capture pane_dict by reference
@@ -3987,6 +4030,11 @@ if _QT_AVAILABLE:
             # Wire zoom — capture pane_dict by reference
             btn_zoom_out.clicked.connect(lambda _=False, pd=pane_dict: self._pane_zoom(pd, 1/1.25))
             btn_zoom_in.clicked.connect(lambda _=False, pd=pane_dict: self._pane_zoom(pd, 1.25))
+            # SEED-017 (#10): wire rotate / reset / fullscreen — capture pane_dict by reference
+            btn_rot_left.clicked.connect(lambda _=False, pd=pane_dict: self._pane_rotate(pd, -90))
+            btn_rot_right.clicked.connect(lambda _=False, pd=pane_dict: self._pane_rotate(pd, 90))
+            btn_view_reset.clicked.connect(lambda _=False, pd=pane_dict: self._pane_reset_view(pd))
+            btn_fullscreen.clicked.connect(lambda _=False, pd=pane_dict: self._open_pane_fullscreen(pd))
             return pane_dict
 
         def _pane_zoom(self, pane: dict, factor: float):
@@ -4016,9 +4064,11 @@ if _QT_AVAILABLE:
             if pix is None or lbl is None:
                 return
             try:
-                scaled = pix.scaled(
-                    max(1, int(pix.width() * z)),
-                    max(1, int(pix.height() * z)),
+                # SEED-017 (#10): rotate the cached pixmap first, then scale.
+                base = _rotated_pixmap(pix, pane.get("rotation", 0))
+                scaled = base.scaled(
+                    max(1, int(base.width() * z)),
+                    max(1, int(base.height() * z)),
                     Qt.AspectRatioMode.KeepAspectRatio,
                     Qt.TransformationMode.SmoothTransformation,
                 )
@@ -4027,12 +4077,41 @@ if _QT_AVAILABLE:
             except RuntimeError:
                 pass
 
+        def _pane_rotate(self, pane: dict, delta: int):
+            """SEED-017 (#10): rotate a compare pane image by ±90° (signed accumulation)."""
+            pane["rotation"] = pane.get("rotation", 0) + delta
+            self._render_pane_image(pane)
+
+        def _pane_reset_view(self, pane: dict):
+            """SEED-017 (#10): reset a compare pane to rotation 0 + fit-to-view zoom."""
+            pix = pane.get("full_pix")
+            if pix is not None:
+                # _set_pane_pix re-fits zoom AND resets rotation to 0, then renders.
+                self._set_pane_pix(pane, pix)
+
+        def _open_pane_fullscreen(self, pane: dict):
+            """SEED-017 (#10): open this pane's image in the shared FullscreenImageWindow
+            (desktop.viewers — same as ResultDialog), with the current rotation baked in."""
+            pix = pane.get("full_pix")
+            if pix is None:
+                return
+            try:
+                from desktop.viewers import FullscreenImageWindow
+            except ImportError:
+                return
+            shown = _rotated_pixmap(pix, pane.get("rotation", 0))
+            # Keep a ref so it isn't GC'd before the user closes it (WA_DeleteOnClose
+            # tears it down). parent_viewer=None: standalone, no page-nav sync.
+            self._fs_window = FullscreenImageWindow(shown, parent_viewer=None)
+            self._fs_window.showFullScreen()
+
         def _set_pane_pix(self, pane: dict, pix):
             """Store a freshly-loaded full pixmap and fit it to the viewport on (re)load.
 
             Fit-to-view never upscales past native (min(ratio, 1.0)) — same rule as the main
             anchor image — so a fresh image fills the pane and the user zooms IN from there."""
             pane["full_pix"] = pix
+            pane["rotation"] = 0  # SEED-017 (#10): a fresh image starts unrotated
             vw = vh = 0
             try:
                 scroll = pane.get("img_scroll")
@@ -4354,6 +4433,7 @@ if _QT_AVAILABLE:
             self._anchor_images = []
             self._anchor_idx = 0
             self._zoom = 1.0
+            self._rotation = 0  # SEED-017 (#10): degrees CW; reset on fresh anchor
             self._anchor_full_pix = None
             # UAT follow-up: fit-the-whole-fragment-to-view on each fresh anchor image
             self._fit_pending = False
@@ -4458,6 +4538,37 @@ if _QT_AVAILABLE:
             btn_zoom_in.setAccessibleName(tr("Zoom in"))
             btn_zoom_in.clicked.connect(self._zoom_in)
             toolbar.addWidget(btn_zoom_in)
+
+            # SEED-017 (#10): rotate + reset + fullscreen — same controls as the
+            # ResultDialog viewer (glyphs ↺ ↻ ↩ ⛶), NOT the brightness/contrast/gamma
+            # sliders. Fullscreen reuses desktop.viewers.FullscreenImageWindow.
+            btn_rot_left = QPushButton("↺")
+            btn_rot_left.setFixedWidth(30)
+            btn_rot_left.setToolTip(tr("Rotate Left 90°"))
+            btn_rot_left.setAccessibleName(tr("Rotate Left 90°"))
+            btn_rot_left.clicked.connect(lambda: self._rotate_anchor(-90))
+            toolbar.addWidget(btn_rot_left)
+
+            btn_rot_right = QPushButton("↻")
+            btn_rot_right.setFixedWidth(30)
+            btn_rot_right.setToolTip(tr("Rotate Right 90°"))
+            btn_rot_right.setAccessibleName(tr("Rotate Right 90°"))
+            btn_rot_right.clicked.connect(lambda: self._rotate_anchor(90))
+            toolbar.addWidget(btn_rot_right)
+
+            btn_view_reset = QPushButton("↩")
+            btn_view_reset.setFixedWidth(30)
+            btn_view_reset.setToolTip(tr("Reset View"))
+            btn_view_reset.setAccessibleName(tr("Reset View"))
+            btn_view_reset.clicked.connect(self._reset_anchor_view)
+            toolbar.addWidget(btn_view_reset)
+
+            btn_fullscreen = QPushButton("⛶")
+            btn_fullscreen.setFixedWidth(30)
+            btn_fullscreen.setToolTip(tr("Fullscreen"))
+            btn_fullscreen.setAccessibleName(tr("Fullscreen"))
+            btn_fullscreen.clicked.connect(self._open_anchor_fullscreen)
+            toolbar.addWidget(btn_fullscreen)
 
             toolbar.addStretch()
 
@@ -4788,6 +4899,7 @@ if _QT_AVAILABLE:
 
             self._anchor_idx = max(0, page - 1)
             self._zoom = 1.0
+            self._rotation = 0  # SEED-017 (#10): reset rotation on fresh anchor
             self._fit_pending = True  # fit the whole fragment to view on first image
             self._anchor_full_pix = None
             self._anchor_images = []
@@ -4943,12 +5055,14 @@ if _QT_AVAILABLE:
                 pass
 
         def _apply_zoom(self):
-            """Rescale the cached full pixmap by the current zoom factor."""
+            """Rescale the cached full pixmap by the current zoom factor (and rotation)."""
             if not self._anchor_full_pix:
                 return
-            scaled = self._anchor_full_pix.scaled(
-                int(self._anchor_full_pix.width() * self._zoom),
-                int(self._anchor_full_pix.height() * self._zoom),
+            # SEED-017 (#10): rotate the cached pixmap first, then scale the result.
+            base = _rotated_pixmap(self._anchor_full_pix, getattr(self, "_rotation", 0))
+            scaled = base.scaled(
+                max(1, int(base.width() * self._zoom)),
+                max(1, int(base.height() * self._zoom)),
                 Qt.AspectRatioMode.KeepAspectRatio,
                 Qt.TransformationMode.SmoothTransformation,
             )
@@ -4967,6 +5081,35 @@ if _QT_AVAILABLE:
         def _zoom_out(self):
             self._zoom = _clamp_zoom(self._zoom / 1.25)
             self._apply_zoom()
+
+        def _rotate_anchor(self, delta):
+            """SEED-017 (#10): rotate the anchor image by ±90° (signed accumulation)."""
+            self._rotation = getattr(self, "_rotation", 0) + delta
+            self._apply_zoom()
+
+        def _reset_anchor_view(self):
+            """SEED-017 (#10): reset rotation to 0 and fit the whole fragment to view."""
+            self._rotation = 0
+            self._fit_to_view()
+            self._apply_zoom()
+
+        def _open_anchor_fullscreen(self):
+            """SEED-017 (#10): open the current anchor image in the shared fullscreen
+            viewer (desktop.viewers.FullscreenImageWindow — same as ResultDialog),
+            with the current rotation already baked in. The window carries its own
+            zoom/rotate controls and Escape-to-close."""
+            if not self._anchor_full_pix:
+                return
+            try:
+                from desktop.viewers import FullscreenImageWindow
+            except ImportError:
+                return
+            pix = _rotated_pixmap(self._anchor_full_pix, getattr(self, "_rotation", 0))
+            # Keep a reference so the window is not GC'd before the user closes it
+            # (WA_DeleteOnClose handles teardown). parent_viewer=None: standalone,
+            # no page-nav sync (the fullscreen prev/next are inert here).
+            self._fs_window = FullscreenImageWindow(pix, parent_viewer=None)
+            self._fs_window.showFullScreen()
 
         def _folio_prev(self):
             """Navigate to the previous folio image (same anchor, D-07)."""

--- a/docs/OPEN_ISSUES.md
+++ b/docs/OPEN_ISSUES.md
@@ -75,12 +75,21 @@ move + glyph de-dup), #298 (SEED-013+018-core guards/cleanup), #297 (SEED-016 la
 executor), #299 (SEED-021 image observability + desktop polish), #300 (SEED-014 a11y/RTL). All Codex-reviewed
 (2 found real bugs, fixed before merge: #297 executor-semaphore lifetime, #300 aria/lazy-load). **#300 still
 needs a manual Hebrew-UI visual+keyboard pass** (1 open ARIA nit: result-card `role=button` contains nested
-buttons). **Still OPEN (decision-gated):** SEED-015 (image-loading/NLI minimal: breaker-wire desktop + TLS
-host-restrict — full unification deferred), SEED-017 (#10 rotate/fullscreen in Lab viewer only), SEED-019
-(stale-index diagnostics + desktop XLSX export), SEED-020 (resume v7.9 decomposition), SEED-022 (new
-"has manual transcription" tag — PGP∪FGP, additive; now unblocked), #27 (a11y statement), #31 (`_tmp/` policy).
+buttons). **SEED-017 (#10) IMPLEMENTED 2026-06-25** on branch `audit/seed-017-viewer-rotate-fullscreen`
+(pending PR + Hebrew-UI UAT): added Rotate Left / Rotate Right / Fullscreen to the web `AnchorViewer`
+toolbar (so the Joins-Lab anchor pane **and** the Compare modal's two panes reach parity with the
+`/browse` viewer + desktop). Rotation uses the per-instance JS viewer (`mv.update(scale, rotation)`);
+Fullscreen uses the native Fullscreen API on a per-instance `.anchor-image-pane` wrapper, bound
+**client-side** via `js_handler` (a server round-trip loses the user-activation the Fullscreen API
+requires). Codex-reviewed → 2 findings fixed pre-PR (HIGH: server-side `requestFullscreen` rejected →
+client-side js_handler; MEDIUM: reused JS viewer kept stale `state.rotation` on folio nav → `_show_image`
+now syncs JS state). 13 new tests in `tests/test_anchor_viewer.py`. Desktop `CompareDialog` rotate/fullscreen
+left OUT (not part of #10; logged as a candidate follow-up). **Still OPEN (decision-gated):** SEED-015
+(image-loading/NLI minimal: breaker-wire desktop + TLS host-restrict — full unification deferred), SEED-019
+(stale-index diagnostics + desktop XLSX export), SEED-020 (resume v7.9 decomposition), #27 (a11y statement),
+#31 (`_tmp/` policy). (SEED-022 shipped in v8.2.2.)
 Full register + execution-mode + seed map: **`.planning/audit-2026-06-23-product-quality/MASTER.md`**.
-Codex evidence: `_tmp/codex-audit-output.md`, `_tmp/codex-pr-review-output.md`.
+Codex evidence: `_tmp/codex-audit-output.md`, `_tmp/codex-pr-review-output.md`, `_tmp/seed017-codex-output*.md`.
 
 ---
 

--- a/docs/OPEN_ISSUES.md
+++ b/docs/OPEN_ISSUES.md
@@ -75,16 +75,18 @@ move + glyph de-dup), #298 (SEED-013+018-core guards/cleanup), #297 (SEED-016 la
 executor), #299 (SEED-021 image observability + desktop polish), #300 (SEED-014 a11y/RTL). All Codex-reviewed
 (2 found real bugs, fixed before merge: #297 executor-semaphore lifetime, #300 aria/lazy-load). **#300 still
 needs a manual Hebrew-UI visual+keyboard pass** (1 open ARIA nit: result-card `role=button` contains nested
-buttons). **SEED-017 (#10) IMPLEMENTED 2026-06-25** on branch `audit/seed-017-viewer-rotate-fullscreen`
-(pending PR + Hebrew-UI UAT): added Rotate Left / Rotate Right / Fullscreen to the web `AnchorViewer`
-toolbar (so the Joins-Lab anchor pane **and** the Compare modal's two panes reach parity with the
-`/browse` viewer + desktop). Rotation uses the per-instance JS viewer (`mv.update(scale, rotation)`);
-Fullscreen uses the native Fullscreen API on a per-instance `.anchor-image-pane` wrapper, bound
-**client-side** via `js_handler` (a server round-trip loses the user-activation the Fullscreen API
-requires). Codex-reviewed → 2 findings fixed pre-PR (HIGH: server-side `requestFullscreen` rejected →
-client-side js_handler; MEDIUM: reused JS viewer kept stale `state.rotation` on folio nav → `_show_image`
-now syncs JS state). 13 new tests in `tests/test_anchor_viewer.py`. Desktop `CompareDialog` rotate/fullscreen
-left OUT (not part of #10; logged as a candidate follow-up). **Still OPEN (decision-gated):** SEED-015
+buttons). **SEED-017 (#10) IMPLEMENTED + UAT-PASSED 2026-06-25** on branch `audit/seed-017-viewer-rotate-fullscreen`
+(PR #310): Rotate Left / Rotate Right / Reset / Fullscreen on **both apps' Joins-Lab + Compare viewers**.
+**Web** (`AnchorViewer` → Joins-Lab anchor pane + Compare modal's two panes): rotation via the per-instance
+JS viewer (`mv.update(scale, rotation)`, signed accumulation so rotate-left animates 90° left, not a 270°
+spin); Fullscreen via the native Fullscreen API on a per-instance `.anchor-image-pane` wrapper bound
+**client-side** via `js_handler` (a server round-trip loses the user-activation the Fullscreen API requires);
+reset icon switched to `/browse`'s `restart_alt` "Reset View". **Desktop** (`join_workbench.py`): same controls
+(glyphs ↺ ↻ ↩ ⛶, NOT brightness/contrast/gamma) on the main workbench anchor pane **and** the CompareDialog
+panes — rotation via `_rotated_pixmap` (QTransform on the cached pixmap), Fullscreen reuses
+`desktop.viewers.FullscreenImageWindow` (the ResultDialog fullscreen). Codex-reviewed → 3 findings fixed pre-merge
+(HIGH client-side fullscreen; MED stale JS `state.rotation`; MED Compare inline-`40vh`-cap vs fullscreen via
+`!important`). +26 tests (`tests/test_anchor_viewer.py`, `tests/test_join_workbench_rotate.py`). **Still OPEN (decision-gated):** SEED-015
 (image-loading/NLI minimal: breaker-wire desktop + TLS host-restrict — full unification deferred), SEED-019
 (stale-index diagnostics + desktop XLSX export), SEED-020 (resume v7.9 decomposition), #27 (a11y statement),
 #31 (`_tmp/` policy). (SEED-022 shipped in v8.2.2.)

--- a/tests/test_anchor_viewer.py
+++ b/tests/test_anchor_viewer.py
@@ -668,6 +668,25 @@ class TestFolioBoundary:
             for c in ctxs:
                 c.stop()
 
+    def test_rotation_reset_on_folio_change(self):
+        """SEED-017 (#10): rotation resets to 0 on folio navigation (mirrors zoom).
+
+        The reset happens BEFORE the off-loop resolve, so it holds regardless of
+        whether the resolver returns a page or a boundary (None).
+        """
+        import asyncio
+        page = _make_page(p_num=1, total_pages=4, library_code="CUL")
+        v, mock_ui, ctxs = self._viewer_with_async_run(lambda *a, **kw: page)
+        try:
+            v._rotation = 90
+            v._zoom = 2.0
+            asyncio.run(v.update_content(direction=+1))
+            assert v._rotation == 0, "folio change must reset rotation to 0"
+            assert v._zoom == pytest.approx(1.0), "folio change must reset zoom to 1.0"
+        finally:
+            for c in ctxs:
+                c.stop()
+
 
 # ─── Task 1 (Plan 119-06): highlight_pattern + _highlight_html_line_safe ────────
 
@@ -1106,3 +1125,187 @@ class TestSuppressShelfmarkHeader:
         assert "max-height" in source, (
             "R2-3: anchor_viewer.py must apply max-height inline style when image_max_height is set"
         )
+
+
+# ─── SEED-017 (audit #10): Rotate + Fullscreen parity ─────────────────────────
+
+class TestRotation:
+    """SEED-017 (#10): per-instance rotation state + arithmetic (parity /browse + desktop).
+
+    The viewer methods call ui.run_javascript, so each method-under-test runs
+    inside a patched-`ui` context (mirrors the JS-mocked construction pattern; the
+    existing zoom tests simulate the arithmetic inline because they don't patch ui
+    around the call).
+    """
+
+    def _viewer(self) -> "Any":
+        return _make_viewer(
+            browse_resolver=lambda *a, **kw: None,
+            external_resolver=_noop_external,
+        )
+
+    def test_initial_rotation_is_0(self):
+        v = self._viewer()
+        assert v._rotation == 0
+
+    def test_rotate_right_increments_90(self):
+        v = self._viewer()
+        with patch("web.components.anchor_viewer.ui"):
+            v.rotate_right()
+        assert v._rotation == 90
+
+    def test_rotate_left_wraps_to_270(self):
+        v = self._viewer()
+        with patch("web.components.anchor_viewer.ui"):
+            v.rotate_left()
+        assert v._rotation == 270
+
+    def test_rotate_right_four_times_wraps_to_0(self):
+        v = self._viewer()
+        with patch("web.components.anchor_viewer.ui"):
+            for _ in range(4):
+                v.rotate_right()
+        assert v._rotation == 0
+
+    def test_rotate_left_then_right_returns_to_0(self):
+        v = self._viewer()
+        with patch("web.components.anchor_viewer.ui"):
+            v.rotate_left()
+            v.rotate_right()
+        assert v._rotation == 0
+
+    def test_zoom_reset_clears_rotation(self):
+        v = self._viewer()
+        with patch("web.components.anchor_viewer.ui"):
+            v.rotate_right()
+            assert v._rotation == 90
+            v.zoom_reset()
+        assert v._rotation == 0
+        assert v._zoom == pytest.approx(1.0)
+
+    def test_apply_transform_sends_zoom_and_rotation(self):
+        """_apply_transform pushes mv.update(zoom, rotation) — rotation is NOT dropped."""
+        v = self._viewer()
+        with patch("web.components.anchor_viewer.ui") as mock_ui:
+            v._zoom = 1.5
+            v._rotation = 90
+            v._apply_transform()
+            assert mock_ui.run_javascript.called
+            js = mock_ui.run_javascript.call_args[0][0]
+        assert "mv.update(1.5, 90)" in js, f"expected mv.update(1.5, 90) in JS, got: {js!r}"
+        # Fallback transform must also carry rotation (was dropped before #10).
+        assert "rotate(90deg)" in js
+
+    def test_show_image_syncs_js_viewer_state(self):
+        """Codex MEDIUM: rendering a folio syncs the REUSED JS viewer state to the
+        current (rotation, zoom) so a stale rotation can't snap back on wheel/drag."""
+        v = self._viewer()
+        v._rotation = 0
+        v._zoom = 1.0
+        with patch("web.components.anchor_viewer.ui") as mock_ui:
+            v._show_image("/api/nli_image_by_sysid/990025143260205171?page=0")
+            calls = [c.args[0] for c in mock_ui.run_javascript.call_args_list if c.args]
+        joined = "\n".join(calls)
+        assert "mv.state.rotation" in joined, "must reset the reused JS viewer's rotation"
+        assert "mv.state.scale" in joined
+        assert "applyTransform" in joined
+
+    def test_build_img_html_carries_rotation(self):
+        """The inline <img> transform carries rotation so it renders rotated before JS sync."""
+        v = self._viewer()
+        v._rotation = 90
+        v._zoom = 1.0
+        html = v._build_img_html("/api/nli_image_by_sysid/990025143260205171?page=0")
+        assert "rotate(90deg)" in html
+
+
+class TestFullscreenControls:
+    """SEED-017 (#10): fullscreen toggle + toolbar/markup/CSS presence."""
+
+    def _viewer(self) -> "Any":
+        return _make_viewer(
+            browse_resolver=lambda *a, **kw: None,
+            external_resolver=_noop_external,
+        )
+
+    def test_fullscreen_handler_targets_scoped_pane(self):
+        """The fullscreen js_handler targets THIS viewer's .anchor-image-pane via the native API."""
+        v = self._viewer()
+        js = v._fullscreen_js_handler()
+        assert "requestFullscreen" in js
+        assert "exitFullscreen" in js
+        assert "anchor-image-pane" in js
+        assert v._viewer_id in js, "fullscreen must be scoped to this viewer's container"
+        # It must be a client-side arrow handler, not a server call.
+        assert js.lstrip().startswith("(e) =>"), "fullscreen must be a client-side js_handler"
+
+    def test_fullscreen_handler_has_webkit_fallback(self):
+        """Older Safari needs the webkit-prefixed API (graceful fallback)."""
+        v = self._viewer()
+        js = v._fullscreen_js_handler()
+        assert "webkitRequestFullscreen" in js
+        assert "webkitExitFullscreen" in js
+
+    def test_fullscreen_handler_no_high2_violation(self):
+        """HIGH-2: the fullscreen path introduces no direct-NLI fallback."""
+        v = self._viewer()
+        js = v._fullscreen_js_handler()
+        assert "handleImageError" not in js
+        assert "iiif.nli.org.il" not in js
+        assert "fetchFlIdsFromManifest" not in js
+
+    def test_fullscreen_bound_client_side_not_server(self):
+        """Codex HIGH: the Fullscreen API must run in the click's user-activation
+        window — bound via js_handler, NOT a server-side on_click round-trip."""
+        import pathlib
+        source = pathlib.Path("web/components/anchor_viewer.py").read_text(encoding="utf-8")
+        assert "js_handler=self._fullscreen_js_handler()" in source, (
+            "fullscreen button must be bound client-side via js_handler"
+        )
+        assert "on_click=self.toggle_fullscreen" not in source, (
+            "fullscreen must NOT use a server-side on_click (Fullscreen API needs user activation)"
+        )
+
+    def test_source_has_rotate_and_fullscreen_buttons(self):
+        import pathlib
+        source = pathlib.Path("web/components/anchor_viewer.py").read_text(encoding="utf-8")
+        assert 'icon="rotate_left"' in source
+        assert 'icon="rotate_right"' in source
+        assert 'icon="fullscreen"' in source
+        assert "_fullscreen_js_handler" in source
+
+    def test_source_wraps_image_in_anchor_image_pane(self):
+        import pathlib
+        source = pathlib.Path("web/components/anchor_viewer.py").read_text(encoding="utf-8")
+        assert "anchor-image-pane" in source, (
+            "#10: image + controls must live in .anchor-image-pane (the fullscreen target)"
+        )
+
+    def test_viewer_head_has_fullscreen_css(self):
+        from web.components.anchor_viewer import _VIEWER_HEAD
+        assert ".anchor-image-pane:fullscreen" in _VIEWER_HEAD, (
+            "#10: _VIEWER_HEAD must style the .anchor-image-pane fullscreen state"
+        )
+
+    def test_fullscreen_image_override_uses_important(self):
+        """Codex MED: Compare sets an INLINE max-height (40vh) on .image-container, which
+        beats a plain stylesheet rule — the fullscreen height override must use !important
+        or Compare panes stay capped at 40vh in fullscreen."""
+        import re
+        from web.components.anchor_viewer import _VIEWER_HEAD
+        # Find the standard :fullscreen .image-container block and assert !important on heights.
+        m = re.search(
+            r"\.anchor-image-pane:fullscreen\s+\.image-container\s*\{([^}]*)\}",
+            _VIEWER_HEAD,
+        )
+        assert m, ":fullscreen .image-container rule must exist"
+        block = m.group(1)
+        assert "max-height" in block and "!important" in block, (
+            "fullscreen .image-container max-height must be !important to beat Compare's inline cap"
+        )
+
+    def test_rotate_buttons_use_translated_strings(self):
+        """Rotate/Fullscreen aria/tooltips use keys present in TRANSLATIONS (no HE leak)."""
+        from genizah_translations import TRANSLATIONS
+        for key in ("Rotate left", "Rotate right", "Fullscreen"):
+            assert key in TRANSLATIONS, f"{key!r} must be translated (Hebrew UI would leak English)"

--- a/tests/test_anchor_viewer.py
+++ b/tests/test_anchor_viewer.py
@@ -1154,18 +1154,21 @@ class TestRotation:
             v.rotate_right()
         assert v._rotation == 90
 
-    def test_rotate_left_wraps_to_270(self):
+    def test_rotate_left_is_minus_90(self):
+        """UAT: rotate-left from 0 yields -90 (signed) so it animates 90° left,
+        not a 270° spin to the right."""
         v = self._viewer()
         with patch("web.components.anchor_viewer.ui"):
             v.rotate_left()
-        assert v._rotation == 270
+        assert v._rotation == -90
 
-    def test_rotate_right_four_times_wraps_to_0(self):
+    def test_rotate_right_accumulates_signed(self):
+        """Signed accumulation: 4× right = 360 (no % 360 wrap)."""
         v = self._viewer()
         with patch("web.components.anchor_viewer.ui"):
             for _ in range(4):
                 v.rotate_right()
-        assert v._rotation == 0
+        assert v._rotation == 360
 
     def test_rotate_left_then_right_returns_to_0(self):
         v = self._viewer()
@@ -1195,6 +1198,28 @@ class TestRotation:
         assert "mv.update(1.5, 90)" in js, f"expected mv.update(1.5, 90) in JS, got: {js!r}"
         # Fallback transform must also carry rotation (was dropped before #10).
         assert "rotate(90deg)" in js
+
+    def test_apply_rotation_preserves_live_scale(self):
+        """P2 review: rotating must preserve the LIVE mv.state.scale (wheel zoom), not
+        force the stale server self._zoom — so rotate-after-wheel-zoom doesn't snap to 100%."""
+        v = self._viewer()
+        with patch("web.components.anchor_viewer.ui") as mock_ui:
+            v._rotation = 90
+            v._apply_rotation()
+            js = mock_ui.run_javascript.call_args[0][0]
+        # Reads the live client scale rather than hardcoding self._zoom.
+        assert "mv.state.scale" in js, "rotation must read the live client scale"
+        assert "mv.update((mv.state ? mv.state.scale" in js
+        assert "90" in js  # the rotation angle is pushed
+
+    def test_rotate_buttons_use_apply_rotation_not_apply_transform(self):
+        """rotate_left/right go through _apply_rotation (scale-preserving), not _apply_transform."""
+        import pathlib
+        source = pathlib.Path("web/components/anchor_viewer.py").read_text(encoding="utf-8")
+        # Both rotate methods must call _apply_rotation.
+        assert source.count("self._apply_rotation()") >= 2, (
+            "rotate_left and rotate_right must call _apply_rotation (preserves wheel zoom)"
+        )
 
     def test_show_image_syncs_js_viewer_state(self):
         """Codex MEDIUM: rendering a folio syncs the REUSED JS viewer state to the

--- a/tests/test_join_workbench_rotate.py
+++ b/tests/test_join_workbench_rotate.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+"""SEED-017 (#10) — desktop Joins Lab + Compare rotate/fullscreen parity.
+
+Mirrors the stub pattern in test_join_workbench_vs.py (pytest-qt-free) so the
+CompareDialog pane handlers and the workbench anchor handlers are exercised
+under a real QApplication without a full dialog.
+"""
+import sys
+import types
+
+import pytest
+
+try:
+    from PyQt6.QtCore import Qt  # noqa: F401
+    from PyQt6.QtGui import QImage, QPixmap
+    from PyQt6.QtWidgets import QApplication
+    QT_AVAILABLE = True
+except Exception:  # pragma: no cover - headless without PyQt6
+    QT_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not QT_AVAILABLE, reason="PyQt6 not available")
+
+
+@pytest.fixture(autouse=True)
+def _ensure_app():
+    if QT_AVAILABLE and QApplication.instance() is None:
+        QApplication(sys.argv)
+
+
+def _make_pixmap(w, h):
+    img = QImage(w, h, QImage.Format.Format_RGB32)
+    img.fill(0)
+    return QPixmap.fromImage(img)
+
+
+class TestRotatedPixmapHelper:
+    def test_none_passthrough(self):
+        from desktop.join_workbench import _rotated_pixmap
+        assert _rotated_pixmap(None, 90) is None
+
+    def test_zero_degrees_passthrough(self):
+        from desktop.join_workbench import _rotated_pixmap
+        pix = _make_pixmap(100, 50)
+        assert _rotated_pixmap(pix, 0) is pix
+
+    def test_90_swaps_dimensions(self):
+        from desktop.join_workbench import _rotated_pixmap
+        out = _rotated_pixmap(_make_pixmap(100, 50), 90)
+        assert (out.width(), out.height()) == (50, 100)
+
+    def test_negative_90_swaps_dimensions(self):
+        from desktop.join_workbench import _rotated_pixmap
+        out = _rotated_pixmap(_make_pixmap(100, 50), -90)
+        assert (out.width(), out.height()) == (50, 100)
+
+    def test_180_keeps_dimensions(self):
+        from desktop.join_workbench import _rotated_pixmap
+        out = _rotated_pixmap(_make_pixmap(100, 50), 180)
+        assert (out.width(), out.height()) == (100, 50)
+
+
+class TestCompareDialogRotation:
+    def test_pane_rotate_accumulates_and_renders(self):
+        from desktop.join_workbench import CompareDialog
+        rendered = []
+        stub = types.SimpleNamespace()
+        stub._render_pane_image = lambda pd: rendered.append(pd.get("rotation"))
+        pane = {"rotation": 0}
+        CompareDialog._pane_rotate(stub, pane, 90)
+        CompareDialog._pane_rotate(stub, pane, 90)
+        CompareDialog._pane_rotate(stub, pane, -90)
+        assert pane["rotation"] == 90
+        assert rendered == [90, 180, 90], "render must run after each rotate"
+
+    def test_pane_reset_view_delegates_to_set_pane_pix(self):
+        from desktop.join_workbench import CompareDialog
+        calls = {}
+        stub = types.SimpleNamespace()
+        stub._set_pane_pix = lambda pd, p: calls.setdefault("set", True)
+        pane = {"rotation": 90, "full_pix": _make_pixmap(10, 10)}
+        CompareDialog._pane_reset_view(stub, pane)
+        assert calls.get("set"), "_pane_reset_view must delegate to _set_pane_pix (re-fit + clear rotation)"
+
+    def test_pane_reset_view_no_pixmap_is_safe(self):
+        from desktop.join_workbench import CompareDialog
+        stub = types.SimpleNamespace()
+        stub._set_pane_pix = lambda pd, p: (_ for _ in ()).throw(AssertionError("should not be called"))
+        CompareDialog._pane_reset_view(stub, {"rotation": 90, "full_pix": None})  # no raise
+
+    def test_render_pane_image_applies_rotation_before_scale(self):
+        from desktop.join_workbench import CompareDialog
+        captured = {}
+
+        class _Lbl:
+            def setPixmap(self, p):
+                captured["pix"] = p
+
+            def resize(self, s):
+                captured["size"] = s
+
+        pane = {
+            "full_pix": _make_pixmap(100, 50),
+            "img": _Lbl(),
+            "zoom": 1.0,
+            "rotation": 90,
+            "zoom_lbl": None,
+        }
+        stub = types.SimpleNamespace()
+        CompareDialog._render_pane_image(stub, pane)
+        # 100x50 rotated 90 -> 50x100, scaled by zoom 1.0
+        assert captured["pix"].width() == 50 and captured["pix"].height() == 100
+
+
+class TestWorkbenchAnchorRotation:
+    def _win(self):
+        from unittest.mock import MagicMock
+        from desktop.join_workbench import JoinWorkbenchWindow
+        return JoinWorkbenchWindow(parent=None, app=MagicMock())
+
+    def test_initial_rotation_is_0(self):
+        win = self._win()
+        assert win._rotation == 0
+
+    def test_rotate_anchor_accumulates(self):
+        win = self._win()
+        win._rotate_anchor(90)
+        assert win._rotation == 90
+        win._rotate_anchor(-90)
+        assert win._rotation == 0
+        win._rotate_anchor(-90)
+        assert win._rotation == -90
+
+    def test_reset_anchor_view_resets_rotation(self):
+        win = self._win()
+        win._rotation = 180
+        win._reset_anchor_view()
+        assert win._rotation == 0
+
+    def test_open_anchor_fullscreen_no_pixmap_is_safe(self):
+        win = self._win()
+        win._anchor_full_pix = None
+        win._open_anchor_fullscreen()  # must not raise
+
+
+def test_desktop_source_has_rotate_fullscreen_controls():
+    """Static guard: both panes wire rotate/reset/fullscreen and reuse FullscreenImageWindow."""
+    import pathlib
+    src = pathlib.Path("desktop/join_workbench.py").read_text(encoding="utf-8")
+    for name in (
+        "_rotate_anchor", "_reset_anchor_view", "_open_anchor_fullscreen",
+        "_pane_rotate", "_pane_reset_view", "_open_pane_fullscreen",
+        "FullscreenImageWindow",
+    ):
+        assert name in src, f"missing {name} (desktop rotate/fullscreen parity)"
+    for glyph in ("↺", "↻", "⛶"):
+        assert glyph in src, f"missing rotate/fullscreen glyph {glyph!r}"

--- a/web/components/anchor_viewer.py
+++ b/web/components/anchor_viewer.py
@@ -464,14 +464,42 @@ class AnchorViewer:
     # ──────────────────────────────────────────────────────────────────────────
 
     def rotate_left(self) -> None:
-        """Rotate the image 90° counter-clockwise (parity /browse + desktop, #10)."""
-        self._rotation = (self._rotation - 90) % 360
-        self._apply_transform()
+        """Rotate the image 90° counter-clockwise (parity /browse + desktop, #10).
+
+        Signed accumulation (NO ``% 360``): clicking left from 0 yields -90 so the CSS
+        ``transition: transform`` animates a 90° counter-clockwise turn — not a 270°
+        clockwise spin to the same visual position (UAT: "270 right seems odd"). CSS
+        handles arbitrary degree values; folio change re-renders a fresh <img> at 0.
+        """
+        self._rotation -= 90
+        self._apply_rotation()
 
     def rotate_right(self) -> None:
-        """Rotate the image 90° clockwise (parity /browse + desktop, #10)."""
-        self._rotation = (self._rotation + 90) % 360
-        self._apply_transform()
+        """Rotate the image 90° clockwise (signed accumulation; see rotate_left)."""
+        self._rotation += 90
+        self._apply_rotation()
+
+    def _apply_rotation(self) -> None:
+        """Push ONLY rotation, preserving the LIVE client scale (P2 review fix).
+
+        Mouse-wheel zoom (manuscript_viewer.js ``onWheel``) updates ``mv.state.scale``
+        client-side only — ``self._zoom`` stays at its last server value (often 1.0).
+        If rotation went through ``_apply_transform`` (which forces ``scale=self._zoom``),
+        rotating after a wheel-zoom would snap the image back to 100%. So the rotation
+        path reads the live ``mv.state.scale`` and leaves the zoom label untouched (the
+        wheel handler keeps it in sync). The fallback (no ``mv``) uses ``self._zoom``.
+        """
+        ui.run_javascript(
+            "(function(){"
+            f"  var mv = (window.__msViewers || {{}})['{self._viewer_id}'];"
+            "  if (mv && typeof mv.update === 'function') {"
+            f"    mv.update((mv.state ? mv.state.scale : {self._zoom}), {self._rotation});"
+            "  } else {"
+            f"    var im = document.querySelector('.{self._viewer_id} .zoomable-image');"
+            f"    if (im) im.style.transform = 'translate(0px,0px) rotate({self._rotation}deg) scale({self._zoom})';"
+            "  }"
+            "})();"
+        )
 
     def _fullscreen_js_handler(self) -> str:
         """Return the CLIENT-SIDE click-handler JS that toggles native fullscreen.
@@ -756,12 +784,14 @@ class AnchorViewer:
                         )
                         ui.tooltip(tr("Rotate right")).bind_visibility_from(_rotate_right_btn)
 
+                        # Reset icon matches the /browse viewer (restart_alt "Reset View")
+                        # per UAT — resets zoom + rotation + pan.
                         _zoom_reset_btn = (
-                            ui.button(icon="fit_screen", on_click=self.zoom_reset)
-                            .props(f'flat round dense aria-label="{tr("Reset zoom")}"')
+                            ui.button(icon="restart_alt", on_click=self.zoom_reset)
+                            .props(f'flat round dense aria-label="{tr("Reset View")}"')
                             .classes("text-white min-h-[44px] min-w-[44px]")
                         )
-                        ui.tooltip(tr("Reset zoom")).bind_visibility_from(_zoom_reset_btn)
+                        ui.tooltip(tr("Reset View")).bind_visibility_from(_zoom_reset_btn)
 
                         # Fullscreen is bound CLIENT-SIDE (js_handler, no on_click) so the
                         # Fullscreen API call stays inside the browser's user-activation

--- a/web/components/anchor_viewer.py
+++ b/web/components/anchor_viewer.py
@@ -159,6 +159,55 @@ _VIEWER_HEAD = '''
         border-radius: 0 0 8px 8px;
     }
 
+    /* SEED-017 (#10): the image + controls bar live inside .anchor-image-pane so
+       the native Fullscreen API can expand BOTH (the transcription stays out of
+       fullscreen — full-bleed image, like /browse). Native :fullscreen escapes the
+       Compare dialog's stacking/transform context; a position:fixed overlay would
+       be trapped inside the maximized ui.dialog. Specificity (.anchor-image-pane +
+       :fullscreen + .image-container = 3) beats the base
+       .anchor-viewer-container .image-container rule (2). */
+    .anchor-image-pane:-webkit-full-screen {
+        background: #000;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        width: 100vw;
+        height: 100vh;
+    }
+    .anchor-image-pane:fullscreen {
+        background: #000;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        width: 100vw;
+        height: 100vh;
+    }
+    /* !important is required: Compare sets an inline `max-height: {image_max_height}`
+       (e.g. 40vh) on .image-container, and an inline style beats a stylesheet rule.
+       Without !important the Compare panes would stay capped at 40vh in fullscreen. */
+    .anchor-image-pane:-webkit-full-screen .image-container {
+        max-height: calc(100vh - 56px) !important;
+        height: calc(100vh - 56px) !important;
+        min-height: 0;
+        flex: 1 1 auto;
+        border-radius: 0;
+    }
+    .anchor-image-pane:fullscreen .image-container {
+        max-height: calc(100vh - 56px) !important;
+        height: calc(100vh - 56px) !important;
+        min-height: 0;
+        flex: 1 1 auto;
+        border-radius: 0;
+    }
+    .anchor-image-pane:-webkit-full-screen .anchor-controls-bar {
+        border-radius: 0;
+        flex-shrink: 0;
+    }
+    .anchor-image-pane:fullscreen .anchor-controls-bar {
+        border-radius: 0;
+        flex-shrink: 0;
+    }
+
     /* Transcription panel — light cream background, so force DARK text.
        Without this the body inherited the dark-theme's light text colour
        and rendered white-on-cream (illegible). */
@@ -339,6 +388,10 @@ class AnchorViewer:
 
         # Per-instance zoom state (mirrors browse.py state.zoom_level)
         self._zoom: float = 1.0
+        # SEED-017 (#10): per-instance rotation in degrees (0/90/180/270), mirrors
+        # browse.py state.rotation. Pushed to the JS viewer via _apply_transform;
+        # reset to 0 on zoom-reset and on folio change.
+        self._rotation: int = 0
         # SEED-010: per-instance image source (persisted across folio nav so the
         # chosen provider sticks) + a unique container CLASS so this viewer's
         # zoom/pan is scoped to ITS OWN image, not the first .zoomable-image on
@@ -356,6 +409,7 @@ class AnchorViewer:
         self._nav_gen: int = 0
 
         # UI element references set during _build_ui()
+        self._image_pane: Optional[Any] = None  # SEED-017 (#10) fullscreen target
         self._image_container: Optional[Any] = None
         self._controls_row: Optional[Any] = None
         self._transcription_container: Optional[Any] = None
@@ -387,29 +441,81 @@ class AnchorViewer:
     def zoom_in(self) -> None:
         """Increase zoom by 0.25, clamped at 4.0."""
         self._zoom = min(self._zoom + 0.25, 4.0)
-        self._apply_zoom()
+        self._apply_transform()
 
     def zoom_out(self) -> None:
         """Decrease zoom by 0.25, clamped at 0.25."""
         self._zoom = max(self._zoom - 0.25, 0.25)
-        self._apply_zoom()
+        self._apply_transform()
 
     def zoom_reset(self) -> None:
         """Reset zoom to 1.0 and reset the viewer pan/rotation."""
         self._zoom = 1.0
+        # SEED-017 (#10): mv.reset() already zeroes the JS rotation; sync the
+        # Python state so the next rotate starts from 0 and the % label is right.
+        self._rotation = 0
         ui.run_javascript(
             f"(function(){{ var mv=(window.__msViewers||{{}})['{self._viewer_id}']; if(mv) mv.reset(); }})();"
         )
-        self._apply_zoom()
+        self._apply_transform()
 
-    def _apply_zoom(self) -> None:
-        """Push the current zoom level to the client.
+    # ──────────────────────────────────────────────────────────────────────────
+    # Rotation + fullscreen (SEED-017 / audit #10 — parity with /browse + desktop)
+    # ──────────────────────────────────────────────────────────────────────────
 
-        Mirrors browse.py's proven path: drive the shared ``manuscriptViewer``
-        via ``update(scale, rotation)`` (which sets the scale and re-applies the
-        transform). The % label is updated SERVER-SIDE here rather than relying
-        on the viewer's JS ``updateLabel()`` selector. A direct-transform
-        fallback keeps zoom working even if the viewer object never initialised.
+    def rotate_left(self) -> None:
+        """Rotate the image 90° counter-clockwise (parity /browse + desktop, #10)."""
+        self._rotation = (self._rotation - 90) % 360
+        self._apply_transform()
+
+    def rotate_right(self) -> None:
+        """Rotate the image 90° clockwise (parity /browse + desktop, #10)."""
+        self._rotation = (self._rotation + 90) % 360
+        self._apply_transform()
+
+    def _fullscreen_js_handler(self) -> str:
+        """Return the CLIENT-SIDE click-handler JS that toggles native fullscreen.
+
+        Bound via ``button.on("click", js_handler=...)`` — NOT server-side
+        ``ui.run_javascript`` — because the Fullscreen API requires transient user
+        activation, which is lost when a click round-trips to the server (Codex HIGH).
+        A pure ``js_handler`` runs synchronously inside the browser click, preserving
+        activation (the same pattern compare_modal.py uses for window.open).
+
+        Targets the per-instance ``.anchor-image-pane`` wrapper (image + controls) so
+        BOTH expand together (transcription stays out — full-bleed image, like /browse).
+        Native fullscreen escapes the Compare dialog's stacking/transform context (a
+        ``position:fixed`` overlay would be trapped inside the maximized ``ui.dialog``)
+        and ESC exits natively. Scoped to this viewer's unique ``{viewer_id}`` class so
+        Compare's two panes fullscreen independently. ``webkit``-prefixed fallbacks
+        cover older Safari.
+
+        HIGH-2: only requestFullscreen/exitFullscreen on a DOM node — no
+        handleImageError / iiif.nli.org.il / fetchFlIdsFromManifest.
+        """
+        return (
+            "(e) => {"
+            f"  const pane = document.querySelector('.{self._viewer_id} .anchor-image-pane');"
+            "  if (!pane) return;"
+            "  const fsEl = document.fullscreenElement || document.webkitFullscreenElement;"
+            "  if (!fsEl) {"
+            "    const rfs = pane.requestFullscreen || pane.webkitRequestFullscreen;"
+            "    if (rfs) rfs.call(pane);"
+            "  } else {"
+            "    const efs = document.exitFullscreen || document.webkitExitFullscreen;"
+            "    if (efs) efs.call(document);"
+            "  }"
+            "}"
+        )
+
+    def _apply_transform(self) -> None:
+        """Push the current zoom + rotation to the client.
+
+        Mirrors browse.py's proven path: drive the per-instance ``manuscriptViewer``
+        via ``update(scale, rotation)`` (which sets scale + rotation and re-applies
+        the transform). The % label is updated SERVER-SIDE here rather than relying
+        on the viewer's JS ``updateLabel()`` selector. A direct-transform fallback
+        keeps zoom + rotation working even if the viewer object never initialised.
         """
         if self._zoom_label is not None:
             self._zoom_label.set_text(f"{int(self._zoom * 100)}%")
@@ -417,10 +523,10 @@ class AnchorViewer:
             "(function(){"
             f"  var mv = (window.__msViewers || {{}})['{self._viewer_id}'];"
             "  if (mv && typeof mv.update === 'function') {"
-            f"    mv.update({self._zoom}, (mv.state ? mv.state.rotation : 0));"
+            f"    mv.update({self._zoom}, {self._rotation});"
             "  } else {"
             f"    var im = document.querySelector('.{self._viewer_id} .zoomable-image');"
-            f"    if (im) im.style.transform = 'translate(0px,0px) scale({self._zoom})';"
+            f"    if (im) im.style.transform = 'translate(0px,0px) rotate({self._rotation}deg) scale({self._zoom})';"
             "  }"
             "})();"
         )
@@ -510,7 +616,7 @@ class AnchorViewer:
         return (
             f'<img src="{img_url}" '
             f'class="zoomable-image" '
-            f'style="transform: translate(0px,0px) scale({self._zoom}); cursor: grab;" '
+            f'style="transform: translate(0px,0px) rotate({self._rotation}deg) scale({self._zoom}); cursor: grab;" '
             f'draggable="false" '
             f'onload="if(window.__msInitViewer) window.__msInitViewer(\'{self._viewer_id}\')" '
             f'/>'
@@ -548,92 +654,125 @@ class AnchorViewer:
             # When suppressed, _info_header/_shelfmark_label/_meta_label remain None
             # (set in __init__). update_content guards all three with `is not None`.
 
-            # Image container (shows skeleton initially).
-            # .mark("anchor-viewer-image-pane") enables Plan-08 render-smoke to
-            # assert that the skeleton is gone after update_content resolves (F-A3).
-            # R2-3: when image_max_height is set (Compare context), apply it as an
-            # inline style override so both image + transcription fit in the pane.
-            image_container_style = ""
-            if self._image_max_height:
-                # Compare context: cap the image to the given (viewport-relative)
-                # height and drop the 200px min-height floor so it can shrink on a
-                # short window. The transcription below gets its own bounded inner
-                # scroll (see _transcription_container) so the pane fits the window.
-                image_container_style = (
-                    f"max-height: {self._image_max_height}; min-height: 0;"
+            # SEED-017 (#10): wrap the image + controls bar in .anchor-image-pane so
+            # toggle_fullscreen's native Fullscreen API can expand BOTH together (the
+            # transcription stays out of fullscreen). The wrapper is a descendant of
+            # .anchor-viewer-container, so the existing .image-container /
+            # .anchor-controls-bar CSS (descendant/class selectors) is unaffected.
+            self._image_pane = ui.element("div").classes("anchor-image-pane w-full")
+            with self._image_pane:
+                # Image container (shows skeleton initially).
+                # .mark("anchor-viewer-image-pane") enables Plan-08 render-smoke to
+                # assert that the skeleton is gone after update_content resolves (F-A3).
+                # R2-3: when image_max_height is set (Compare context), apply it as an
+                # inline style override so both image + transcription fit in the pane.
+                image_container_style = ""
+                if self._image_max_height:
+                    # Compare context: cap the image to the given (viewport-relative)
+                    # height and drop the 200px min-height floor so it can shrink on a
+                    # short window. The transcription below gets its own bounded inner
+                    # scroll (see _transcription_container) so the pane fits the window.
+                    image_container_style = (
+                        f"max-height: {self._image_max_height}; min-height: 0;"
+                    )
+                self._image_container = (
+                    ui.element("div")
+                    .classes("image-container relative")
+                    .mark("anchor-viewer-image-pane")
                 )
-            self._image_container = (
-                ui.element("div")
-                .classes("image-container relative")
-                .mark("anchor-viewer-image-pane")
-            )
-            if image_container_style:
-                self._image_container.style(image_container_style)
-            with self._image_container:
-                self._skeleton = ui.element("div").classes("anchor-viewer-skeleton")
-                self._img_html_elem: Optional[Any] = None
-                self._error_elem: Optional[Any] = None
+                if image_container_style:
+                    self._image_container.style(image_container_style)
+                with self._image_container:
+                    self._skeleton = ui.element("div").classes("anchor-viewer-skeleton")
+                    self._img_html_elem: Optional[Any] = None
+                    self._error_elem: Optional[Any] = None
 
-            # Controls bar (below image, full width).
-            # #41: folio arrows follow the UI reading direction, mirroring the
-            # canonical browse-page pager (web/pages/browse.py): in an RTL UI
-            # "previous" points right (chevron_right) and "next" points left
-            # (chevron_left), and the row itself follows page direction so the
-            # arrows physically sit on the side a Hebrew reader expects. This
-            # replaces the earlier hard-coded direction:ltr override, which made
-            # the arrows read backwards under the RTL Hebrew interface.
-            _rtl = is_rtl()
-            with ui.row().classes("anchor-controls-bar w-full justify-between"):
-                # Folio navigation group
-                with ui.row().classes("gap-1 items-center"):
-                    self._prev_btn = (
-                        ui.button(
-                            icon="chevron_right" if _rtl else "chevron_left",
-                            on_click=self._on_prev_folio,
+                # Controls bar (below image, full width).
+                # #41: folio arrows follow the UI reading direction, mirroring the
+                # canonical browse-page pager (web/pages/browse.py): in an RTL UI
+                # "previous" points right (chevron_right) and "next" points left
+                # (chevron_left), and the row itself follows page direction so the
+                # arrows physically sit on the side a Hebrew reader expects. This
+                # replaces the earlier hard-coded direction:ltr override, which made
+                # the arrows read backwards under the RTL Hebrew interface.
+                _rtl = is_rtl()
+                with ui.row().classes("anchor-controls-bar w-full justify-between"):
+                    # Folio navigation group
+                    with ui.row().classes("gap-1 items-center"):
+                        self._prev_btn = (
+                            ui.button(
+                                icon="chevron_right" if _rtl else "chevron_left",
+                                on_click=self._on_prev_folio,
+                            )
+                            .props(f'flat round dense aria-label="{tr("Previous folio")}"')
+                            .classes("text-white min-h-[44px] min-w-[44px]")
                         )
-                        .props(f'flat round dense aria-label="{tr("Previous folio")}"')
-                        .classes("text-white min-h-[44px] min-w-[44px]")
-                    )
-                    ui.tooltip(tr("Previous folio")).bind_visibility_from(self._prev_btn)
+                        ui.tooltip(tr("Previous folio")).bind_visibility_from(self._prev_btn)
 
-                    self._page_label = ui.label("…").classes("text-white text-sm px-2")
+                        self._page_label = ui.label("…").classes("text-white text-sm px-2")
 
-                    self._next_btn = (
-                        ui.button(
-                            icon="chevron_left" if _rtl else "chevron_right",
-                            on_click=self._on_next_folio,
+                        self._next_btn = (
+                            ui.button(
+                                icon="chevron_left" if _rtl else "chevron_right",
+                                on_click=self._on_next_folio,
+                            )
+                            .props(f'flat round dense aria-label="{tr("Next folio")}"')
+                            .classes("text-white min-h-[44px] min-w-[44px]")
                         )
-                        .props(f'flat round dense aria-label="{tr("Next folio")}"')
-                        .classes("text-white min-h-[44px] min-w-[44px]")
-                    )
-                    ui.tooltip(tr("Next folio")).bind_visibility_from(self._next_btn)
+                        ui.tooltip(tr("Next folio")).bind_visibility_from(self._next_btn)
 
-                # Zoom controls group
-                with ui.row().classes("gap-1 items-center"):
-                    _zoom_out_btn = (
-                        ui.button(icon="remove", on_click=self.zoom_out)
-                        .props(f'flat round dense aria-label="{tr("Zoom out")}"')
-                        .classes("text-white min-h-[44px] min-w-[44px]")
-                    )
-                    ui.tooltip(tr("Zoom out")).bind_visibility_from(_zoom_out_btn)
+                    # Zoom + rotate + fullscreen group (SEED-017 #10: rotate/fullscreen
+                    # bring the Lab/Compare viewer to parity with /browse + desktop).
+                    with ui.row().classes("gap-1 items-center"):
+                        _zoom_out_btn = (
+                            ui.button(icon="remove", on_click=self.zoom_out)
+                            .props(f'flat round dense aria-label="{tr("Zoom out")}"')
+                            .classes("text-white min-h-[44px] min-w-[44px]")
+                        )
+                        ui.tooltip(tr("Zoom out")).bind_visibility_from(_zoom_out_btn)
 
-                    self._zoom_label = ui.label("100%").classes(
-                        "zoom-level-label text-white text-sm px-1"
-                    )
+                        self._zoom_label = ui.label("100%").classes(
+                            "zoom-level-label text-white text-sm px-1"
+                        )
 
-                    _zoom_in_btn = (
-                        ui.button(icon="add", on_click=self.zoom_in)
-                        .props(f'flat round dense aria-label="{tr("Zoom in")}"')
-                        .classes("text-white min-h-[44px] min-w-[44px]")
-                    )
-                    ui.tooltip(tr("Zoom in")).bind_visibility_from(_zoom_in_btn)
+                        _zoom_in_btn = (
+                            ui.button(icon="add", on_click=self.zoom_in)
+                            .props(f'flat round dense aria-label="{tr("Zoom in")}"')
+                            .classes("text-white min-h-[44px] min-w-[44px]")
+                        )
+                        ui.tooltip(tr("Zoom in")).bind_visibility_from(_zoom_in_btn)
 
-                    _zoom_reset_btn = (
-                        ui.button(icon="fit_screen", on_click=self.zoom_reset)
-                        .props(f'flat round dense aria-label="{tr("Reset zoom")}"')
-                        .classes("text-white min-h-[44px] min-w-[44px]")
-                    )
-                    ui.tooltip(tr("Reset zoom")).bind_visibility_from(_zoom_reset_btn)
+                        _rotate_left_btn = (
+                            ui.button(icon="rotate_left", on_click=self.rotate_left)
+                            .props(f'flat round dense aria-label="{tr("Rotate left")}"')
+                            .classes("text-white min-h-[44px] min-w-[44px]")
+                        )
+                        ui.tooltip(tr("Rotate left")).bind_visibility_from(_rotate_left_btn)
+
+                        _rotate_right_btn = (
+                            ui.button(icon="rotate_right", on_click=self.rotate_right)
+                            .props(f'flat round dense aria-label="{tr("Rotate right")}"')
+                            .classes("text-white min-h-[44px] min-w-[44px]")
+                        )
+                        ui.tooltip(tr("Rotate right")).bind_visibility_from(_rotate_right_btn)
+
+                        _zoom_reset_btn = (
+                            ui.button(icon="fit_screen", on_click=self.zoom_reset)
+                            .props(f'flat round dense aria-label="{tr("Reset zoom")}"')
+                            .classes("text-white min-h-[44px] min-w-[44px]")
+                        )
+                        ui.tooltip(tr("Reset zoom")).bind_visibility_from(_zoom_reset_btn)
+
+                        # Fullscreen is bound CLIENT-SIDE (js_handler, no on_click) so the
+                        # Fullscreen API call stays inside the browser's user-activation
+                        # window — a server round-trip would have it rejected (Codex HIGH).
+                        _fullscreen_btn = (
+                            ui.button(icon="fullscreen")
+                            .props(f'flat round dense aria-label="{tr("Fullscreen")}"')
+                            .classes("text-white min-h-[44px] min-w-[44px]")
+                        )
+                        _fullscreen_btn.on("click", js_handler=self._fullscreen_js_handler())
+                        ui.tooltip(tr("Fullscreen")).bind_visibility_from(_fullscreen_btn)
 
             # Transcription area.
             # .mark("anchor-viewer-transcription-pane") enables Plan-08 render-smoke
@@ -692,9 +831,12 @@ class AnchorViewer:
         # Show loading skeleton while resolving
         self._show_loading()
 
-        # Reset zoom on folio change (mirrors /browse behaviour)
+        # Reset zoom + rotation on folio change (mirrors /browse behaviour). The
+        # re-rendered <img> carries no rotation, and the fresh per-instance viewer
+        # inits at rotation 0, so clearing _rotation here keeps Python state in sync.
         if direction != 0:
             self._zoom = 1.0
+            self._rotation = 0
 
         # Capture resolution params for the worker closure.
         #
@@ -818,8 +960,26 @@ class AnchorViewer:
             # the <img> onload (covers a cached image whose onload already fired).
             img_html = self._build_img_html(img_url)
             ui.html(img_html, sanitize=False)
+            # SEED-010 init + SEED-017 (#10) state-sync: the per-instance viewer
+            # object is reused across folios, so after re-init we MUST push the
+            # current Python (rotation, zoom, pan) into mv.state — otherwise a
+            # rotation/zoom from the previous folio survives in mv.state and snaps
+            # back on the next wheel/drag/applyTransform (Codex MEDIUM). _build_img_html
+            # already renders the <img> with this transform; this keeps mv.state in sync.
             ui.run_javascript(
-                f"if(window.__msInitViewer) setTimeout(() => window.__msInitViewer('{self._viewer_id}'), 50);"
+                "(function(){"
+                f"  var vid='{self._viewer_id}';"
+                "  function sync(){"
+                "    if(window.__msInitViewer) window.__msInitViewer(vid);"
+                "    var mv=(window.__msViewers||{})[vid];"
+                "    if(mv && mv.state){"
+                "      mv.state.x=0; mv.state.y=0;"
+                f"      mv.state.rotation={self._rotation}; mv.state.scale={self._zoom};"
+                "      if(typeof mv.applyTransform==='function') mv.applyTransform();"
+                "    }"
+                "  }"
+                "  sync(); setTimeout(sync, 50);"
+                "})();"
             )
 
     def _show_image_error(self) -> None:


### PR DESCRIPTION
## SEED-017 — audit finding #10 (CONFIRMED, MEDIUM) — UAT-PASSED ✅

Brings the **Joins-Lab + Compare image viewers to parity** with the `/browse` viewer and the desktop ResultDialog viewer by adding **Rotate Left / Rotate Right / Reset / Fullscreen** — on **both apps**.

### Web (`web/components/anchor_viewer.py`)
Reaches the Joins-Lab anchor pane (`web/pages/joins_lab.py`) and the Compare modal's two panes (`web/components/compare_modal.py`).
- **Rotation** via the per-instance JS viewer `mv.update(scale, rotation)`. **Signed accumulation** (`-90`, not `%360`=270) so rotate-left animates 90° left, not a 270° spin (UAT).
- **Rotate preserves live (wheel) zoom** — `_apply_rotation()` reads the live `mv.state.scale` rather than forcing the stale server `self._zoom` (Codex P2).
- **Fullscreen** via the native Fullscreen API on a per-instance `.anchor-image-pane` wrapper, bound **client-side via `js_handler`** (a server round-trip loses the user-activation the Fullscreen API requires). Escapes the maximized Compare dialog's stacking context; webkit-prefixed JS+CSS fallbacks.
- **Reset** icon switched to `/browse`'s `restart_alt` "Reset View" (resets zoom + rotation + pan).
- `_show_image` syncs the reused JS viewer state so a prior folio's rotation can't snap back; fullscreen `.image-container` override uses `!important` to beat Compare's inline `40vh` cap.

### Desktop (`desktop/join_workbench.py`)
Same controls (glyphs **↺ ↻ ↩ ⛶**, **not** brightness/contrast/gamma) on the **main workbench anchor pane** and the **CompareDialog panes**.
- Rotation via a new `_rotated_pixmap` helper (`QTransform` on the cached pixmap), applied before scaling.
- **Fullscreen reuses `desktop.viewers.FullscreenImageWindow`** — the same window ResultDialog uses.
- Rotation resets on fresh anchor / fresh pane image (mirrors the existing zoom-refit behavior).

### Invariants
- **HIGH-2** preserved (no `handleImageError` / `iiif.nli.org.il` / `fetchFlIdsFromManifest`).
- **SEED-010** per-instance isolation: web rotate/fullscreen scoped by `{viewer_id}` (Compare's two panes act independently).

### Review & tests
- **Codex-reviewed** (2 local rounds + the GitHub review): 4 findings fixed — HIGH (server-side `requestFullscreen` → client-side `js_handler`), MED (stale JS `state.rotation`), MED (Compare inline `40vh` cap vs fullscreen → `!important`), **P2 (wheel-zoom snap on rotate → `_apply_rotation` reads live scale)**.
- **+26 tests** (`tests/test_anchor_viewer.py`, `tests/test_join_workbench_rotate.py`); ruff clean; **226 green** locally.
- **UAT-passed on both apps** (user-confirmed live: rotate ±90, fullscreen, Compare panes independent).

### Out of scope (logged)
The rotation **slider** that `/browse` carries — buttons match the desktop viewer and are the minimal "Rotate" parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)