### PR TITLE
Discovery V4 reference expansion and locus range filters

### DIFF
--- a/docs/guides/DEVELOPER_GUIDE.md
+++ b/docs/guides/DEVELOPER_GUIDE.md
@@ -53,6 +53,7 @@ SUPABASE_ANON_KEY=your-anon-key
 
 # Optional
 GENIZAH_PORT=8081
+GENIZAH_FJMS_DB_PATH=  # optional absolute fjms_enrichment.db path; useful from git worktrees
 WEB_PUZZLE_ENABLED=true   # enables web puzzle page (set false to hide)
 ATLAS_PREVIEW_ENABLED=false  # Phase 133 Visual Atlas Preview beta (/atlas); default OFF, ANDed with baked-asset readiness
 MASKING_SCAN_PATTERNS_FILE=  # path to a gitignored restricted-string pattern file for scripts/check_atlas_masking.py (dev/CI only)

--- a/docs/specs/discovery-public-projection-exclusions-v1.json
+++ b/docs/specs/discovery-public-projection-exclusions-v1.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "discovery-public-projection-exclusions-v1",
+  "policy_version": "public-projection-exclusions-v1",
+  "ruled_date": "2026-08-14",
+  "ruling": "Retain curated anthology works in the private research bake as routing competitors, but structurally exclude them and their dependent rows from the public projection.",
+  "entries": [
+    {
+      "canonical_work_id": "w001383",
+      "title": "ילקוט שמעוני על נ\"ך",
+      "reason": "Later anthology overlapping many cited works; public attribution is systematically misleading."
+    },
+    {
+      "canonical_work_id": "w001384",
+      "title": "ילקוט שמעוני על התורה",
+      "reason": "Later anthology overlapping many cited works; public attribution is systematically misleading."
+    }
+  ]
+}

--- a/docs/specs/discovery-v4-public-reference-expansion.md
+++ b/docs/specs/discovery-v4-public-reference-expansion.md
@@ -1,0 +1,92 @@
+# Discovery V4 public-reference expansion
+
+## Scope
+
+V4 adds public Sefaria and Hebrew Wikisource editions for private Discovery
+work identities that already passed owner review. It does not infer new work
+identity from title similarity: every acquired source is mapped explicitly to
+one existing opaque private work id in `scripts/discovery_v4_sources.json`.
+
+The 2026-08-14 audit selected 45 target identities from 43 source containers.
+Forty-one containers were acquired, yielding 43 reference streams; two
+too-short sources were quarantined. Generated text, audit snapshots, match
+databases, and candidates stay in the ignored data depot. Only deterministic
+transformations and the reviewed source map are tracked.
+
+## Frozen input chain
+
+The V4 reference corpus is an append-only extension of `ref_corpus_v2.pkl`.
+The complete V2 prefix must compare equal after unpickling. Matcher streams use
+the established final-letter fold (`ךםןףץ` to `כמנפצ`); readable source text
+keeps final letters and is checked against that folded stream before excerpts
+can be baked.
+
+The current input pins are:
+
+- V2 reference corpus: `acb6b86f…6646de`
+- V2 canonical masks: `14657b4e…7b5b81`
+- V2 locus database: `aaac6f90…898263`
+- V2 locus coverage report: `34f8cece…f4aaf`
+- V4 acquisition manifest: `67eb11e1…7e30`
+- V4 reference manifest: `9e3deab…944c`
+- V4 reference corpus: `6c540e39…a3133`
+- pristine copied research database: `75867026…e669`
+- reviewed Track-1 pilot: `1d2b2695…0f6d`
+
+Every consuming command verifies its relevant full SHA-256 before reading the
+input. The reference verifier also proves that all readable public-source
+texts reproduce their pickle streams exactly.
+
+## Match and identity contract
+
+The full 667,411-page corpus is matched. An old matched-page allowlist is not a
+valid shortcut: a new reference may match a page absent from the V2 result.
+The run is resumable by a pinned page-batch geometry and writes a staging table
+until every batch is complete.
+
+Promotion preserves the original 381,341-row table as
+`track1_matches_v2_snapshot`, installs the reference-coordinate-aware result,
+and reapplies the frozen `track1-shadow-v1` algorithm. A strict release
+contract records and later recomputes the page, total/live, REF4, duplicate,
+and missing-offset counts plus the matcher fingerprint and input hashes.
+
+Only REF4 references with a live unshadowed match receive a new opaque id. The
+reconciliation step copies the owner-approved author and curated domain from
+the mapped private identity, then creates an approved two-member canonical
+group whose public id is the representative. The existing 16 reviewed merge
+groups and the D-14 decision remain required; V4 cannot be enabled by editing
+the old expected merge count.
+
+## Routing, locus, and excerpts
+
+Existing Track-1 rows retain the fitted gen-2 decisions, including the
+previous split-grain re-graining. REF4 rows did not exist in the fitted router,
+so they are classified separately with its frozen coverage estimand and
+threshold and are recorded as an extrapolated V4 population.
+
+The locus database is extended in the same REF4 coordinate space. Missing
+division tables remain honest whole-work fallbacks. The final public bake
+recomputes claim and identification loci after projection, then loads excerpts
+directly from the hash-verified public source text. A REF4 reference corpus
+without the matching source manifest and normalized source directory is a
+hard excerpt-bake error.
+
+## Release posture
+
+The 2026-08-14 owner ruling in
+`discovery-public-projection-exclusions-v1.json` supersedes the earlier public
+retention posture for both Yalkut Shimoni identities. They remain present in
+the private research bake as routing competitors, but the public projection
+drops their claims and evidence before recomputing works, identifications,
+loci, excerpts, counts, and dependent graph closure.
+
+V4 is first built as a loader-ready ignored candidate. Private verification,
+public projection, public verification, masking scans, SQLite integrity and
+foreign-key checks, excerpt replay, source attribution, and real-loader proof
+must all pass. Its new frame hash is recorded as a candidate fact; it is not
+silently compared with the pre-V4 frame as though the expansion were a
+membership-preserving rebuild.
+
+No upload, manifest swap, or production restart is part of the build. Those
+remain a separate owner-approved deployment step after reviewing the candidate
+counts and representative UI results.

--- a/scripts/bake_discovery_excerpts.py
+++ b/scripts/bake_discovery_excerpts.py
@@ -29,6 +29,9 @@ Non-Tanakh masked works get NO work-side pieces (the UI shows an honest
 (project_discovery_public.run_masking_gate) re-runs over the final artifact.
 
 Work-side sources, by edition class (crosswalk ref-id prefix):
+  REF4:  V4 normalized public-source snapshot, exact offsets. The reference
+         manifest and its acquisition manifest are hash-bound; the recomputed
+         stream must equal the pickle stream.
   REF2:  refs_staging body file, exact offsets. The recomputed stream must
          EQUAL the pickle stream for that ref (prepped_for discipline) or the
          work side is dropped for that work -- never silently approximated.
@@ -45,6 +48,8 @@ stage_cd_preview lesson that a defaulted path silently stages stale data):
   python scripts/bake_discovery_excerpts.py <public.db> --out <baked.db> \
       --crosswalk <crosswalk.json> --refs-staging <dir> --ja-dir <dir> \
       --fullcorpus <fullcorpus_v2.db> --ref-pkl <ref_corpus_v2.pkl> \
+      [--v4-reference-manifest <reference_manifest.json> \
+       --v4-normalized-dir <normalized_dir>] \
       [--ctx 90] [--span-cap 600] [--min-align-score 65] [--limit N]
 
 `--limit` exists for a fast dev smoke ONLY; every gate runs on a full bake.
@@ -64,7 +69,7 @@ import time
 import unicodedata
 from collections import Counter, OrderedDict
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Mapping, Optional, Tuple
 
 _REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO))
@@ -98,22 +103,84 @@ CREATE TABLE discovery_excerpt (
 )
 """
 
-# The best-row rule, frozen: highest matched_letters, ties broken by
-# evidence_id ascending. Deterministic across bakes.
+# The ordinary best-row rule remains highest matched_letters, ties broken by
+# evidence_id ascending.  One excerpt-only exception is admitted: when the
+# public identification's eligible row has no work offsets, a PUBLIC direct
+# witness for that SAME DISPLAY WORK may supply the comparison slice even when
+# its routing decision is review_only.  That row does not create an
+# identification, change a claim, or reach a findings query; it is read only by
+# this post-projection text bake.  Eligible offset-bearing evidence always wins
+# over the fallback.
 _BEST_ROWS_SQL = """
+WITH eligible_ids AS MATERIALIZED (
+    SELECT DISTINCT di.identification_id
+      FROM discovery_identification di
+      JOIN discovery_evidence de ON de.sys_id = di.sys_id
+      JOIN discovery_claim dc ON dc.claim_id = de.claim_id
+      JOIN works canonical_work
+        ON canonical_work.work_id = dc.work_id
+       AND canonical_work.canonical_work_id = di.canonical_work_id
+     WHERE de.evidence_kind = 'witness'
+       AND (de.routing_status = 'shipped'
+            OR de.adjudication_status = 'human_confirmed')
+)
 SELECT di.identification_id, de.evidence_id, de.a_page_id,
        de.matched_letters, de.n_spans, de.text_layer,
        de.span_start, de.span_end, de.w_start, de.w_end,
-       de.aligned_page_start, de.aligned_page_end, dc.work_id
+       de.aligned_page_start, de.aligned_page_end, dc.work_id,
+       de.evidence_source, de.routing_status, de.adjudication_status,
+       de.assertion_visibility
   FROM discovery_identification di
   JOIN discovery_evidence de ON de.sys_id = di.sys_id
   JOIN discovery_claim dc ON dc.claim_id = de.claim_id
-       AND dc.work_id IN (SELECT work_id FROM works
-                           WHERE canonical_work_id = di.canonical_work_id)
+  JOIN works canonical_work
+    ON canonical_work.work_id = dc.work_id
+   AND canonical_work.canonical_work_id = di.canonical_work_id
+  LEFT JOIN eligible_ids ON eligible_ids.identification_id = di.identification_id
  WHERE de.evidence_kind = 'witness'
    AND (de.routing_status = 'shipped'
-        OR de.adjudication_status = 'human_confirmed')
+        OR de.adjudication_status = 'human_confirmed'
+        OR (dc.work_id = di.display_work_id
+            AND de.routing_status = 'review_only'
+            AND de.evidence_source = 'track1_direct'
+            AND de.assertion_visibility = 'public'
+            AND de.w_start IS NOT NULL
+            AND de.w_end > de.w_start
+            AND eligible_ids.identification_id IS NOT NULL))
 """
+
+
+def _has_work_span(row: Mapping[str, object]) -> bool:
+    """Whether an evidence candidate has a non-empty work-side interval."""
+    start, end = row["w_start"], row["w_end"]
+    return start is not None and end is not None and int(end) > int(start)
+
+
+def is_excerpt_only_fallback(row: Mapping[str, object]) -> bool:
+    """True only for the narrow public direct-text fallback described above."""
+    return (
+        row["routing_status"] == "review_only"
+        and row["adjudication_status"] != "human_confirmed"
+        and row["evidence_source"] == "track1_direct"
+        and row["assertion_visibility"] == "public"
+        and _has_work_span(row)
+    )
+
+
+def excerpt_candidate_key(row: Mapping[str, object]) -> Tuple[int, int, str]:
+    """Prefer showable eligible evidence, then the excerpt-only fallback.
+
+    The final rank retains the pre-existing deterministic best-row order for
+    candidates of the same class.
+    """
+    eligible = (
+        row["routing_status"] == "shipped"
+        or row["adjudication_status"] == "human_confirmed"
+    )
+    rank = 0 if eligible and _has_work_span(row) else (
+        1 if is_excerpt_only_fallback(row) else 2
+    )
+    return rank, -int(row["matched_letters"] or 0), str(row["evidence_id"])
 
 
 def sha256_file(path: Path) -> str:
@@ -122,6 +189,34 @@ def sha256_file(path: Path) -> str:
         for chunk in iter(lambda: fh.read(1 << 22), b""):
             h.update(chunk)
     return h.hexdigest()
+
+
+def validate_bake_input_hashes(
+    public_db: Path, crosswalk_path: Path, reference_pickle: Path
+) -> Dict[str, str]:
+    """Bind the excerpt inputs to the already-verified public sidecar.
+
+    Excerpts dereference opaque work ids through the crosswalk and interpret
+    work offsets through the reference pickle. Accepting a different file at
+    either path can produce internally well-formed but wrongly labelled text.
+    The sidecar already records both hashes, so omission is not a compatibility
+    posture here: it is a missing provenance edge and fails closed.
+    """
+    with sqlite3.connect(f"file:{public_db.resolve().as_posix()}?mode=ro", uri=True) as conn:
+        meta = dict(conn.execute("SELECT key, value FROM meta").fetchall())
+    for key, path, label in (
+        ("crosswalk_sha256", crosswalk_path, "crosswalk"),
+        ("reference_corpus_sha256", reference_pickle, "reference pickle"),
+    ):
+        expected = meta.get(key)
+        if not expected:
+            raise ValueError(f"public sidecar does not record {key}")
+        actual = sha256_file(path)
+        if actual != expected:
+            raise ValueError(
+                f"{label} SHA-256 differs from the public sidecar's recorded input"
+            )
+    return meta
 
 
 def pieces(nfc: str, offs, lo: int, hi: int, ctx: int,
@@ -145,6 +240,43 @@ def pieces(nfc: str, offs, lo: int, hi: int, ctx: int,
     return before, nfc[a0:z0], after, 0
 
 
+def load_v4_public_sources(
+    reference_manifest_path: Path, normalized_dir: Path
+) -> Tuple[Dict[str, str], Dict[str, str], str]:
+    """Reconstruct readable REF4 texts under their pinned matcher streams."""
+    manifest = json.loads(reference_manifest_path.read_text(encoding="utf-8"))
+    if manifest.get("schema_version") != "discovery-v4-reference-manifest-v1":
+        raise ValueError("unsupported V4 reference manifest")
+    acquisition_path = Path(manifest["acquisition_manifest"])
+    if sha256_file(acquisition_path) != manifest["acquisition_manifest_sha256"]:
+        raise ValueError("V4 acquisition manifest hash differs from the reference manifest")
+    acquisition = json.loads(acquisition_path.read_text(encoding="utf-8"))
+    acquired_by_key = {
+        entry["key"]: entry
+        for entry in acquisition["entries"]
+        if entry.get("status") == "acquired"
+    }
+    texts: Dict[str, str] = {}
+    attributions: Dict[str, str] = {}
+    for entry in manifest["entries"]:
+        raw_id = entry["raw_reference_id"]
+        source_key = entry["source_key"]
+        acquired = acquired_by_key.get(source_key)
+        if acquired is None:
+            raise ValueError("V4 reference entry has no acquired public-source row")
+        path = normalized_dir / acquired["normalized_file"]
+        if sha256_file(path) != acquired["normalized_sha256"]:
+            raise ValueError("V4 normalized public-source hash mismatch")
+        normalized = json.loads(path.read_text(encoding="utf-8"))
+        units = {int(unit["ordinal"]): unit["text"] for unit in normalized["units"]}
+        ordinals = [int(row["source_ordinal"]) for row in entry["unit_offsets"]]
+        if len(ordinals) != len(set(ordinals)) or any(value not in units for value in ordinals):
+            raise ValueError("V4 reference manifest names missing or duplicate source units")
+        texts[raw_id] = "\n".join(units[value] for value in ordinals)
+        attributions[raw_id] = normalized["attribution"]
+    return texts, attributions, manifest["acquisition_manifest_sha256"]
+
+
 class WorkSources:
     """Lazy, cached access to public reference texts (NFC + stream + offsets).
 
@@ -156,16 +288,26 @@ class WorkSources:
 
     def __init__(self, refs_staging: Path, ja_dir: Path,
                  man_by_key: Dict[str, dict], pkl_stream: Dict[str, str],
-                 counters: Counter):
+                 counters: Counter, *, v4_text: Optional[Dict[str, str]] = None,
+                 v4_attribution: Optional[Dict[str, str]] = None):
         self.refs_staging = refs_staging
         self.ja_dir = ja_dir
         self.man_by_key = man_by_key
         self.pkl_stream = pkl_stream
         self.counters = counters
+        self.v4_text = v4_text or {}
+        self.v4_attribution = v4_attribution or {}
         self._cache: Dict[str, Optional[Tuple[str, object]]] = {}
 
     def _load(self, ref_id: str) -> Optional[Tuple[str, object]]:
-        if ref_id.startswith("REF2:"):
+        raw = None
+        if ref_id.startswith("REF4:"):
+            raw = self.v4_text.get(ref_id)
+            if raw is None:
+                self.counters["work_v4_source_missing"] += 1
+                return None
+            path = None
+        elif ref_id.startswith("REF2:"):
             ent = self.man_by_key.get(ref_id[5:])
             if not ent:
                 self.counters["work_no_manifest_entry"] += 1
@@ -175,11 +317,12 @@ class WorkSources:
             path = self.ja_dir / (ref_id[2:] + ".txt")
         else:
             return None
-        try:
-            raw = path.read_text(encoding="utf-8", errors="replace")
-        except OSError:
-            self.counters["work_file_error"] += 1
-            return None
+        if path is not None:
+            try:
+                raw = path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                self.counters["work_file_error"] += 1
+                return None
         nfc = unicodedata.normalize("NFC", raw)
         stream, offs = norm_stream(nfc)
         expected = self.pkl_stream.get(ref_id)
@@ -187,6 +330,9 @@ class WorkSources:
             self.counters["work_stream_mismatch"] += 1
             return None
         return nfc, offs
+
+    def attribution(self, ref_id: str) -> Optional[str]:
+        return self.v4_attribution.get(ref_id)
 
     def get(self, ref_id: str) -> Optional[Tuple[str, object]]:
         if ref_id not in self._cache:
@@ -370,6 +516,8 @@ def main() -> int:
     ap.add_argument("--ja-dir", required=True)
     ap.add_argument("--fullcorpus", required=True)
     ap.add_argument("--ref-pkl", required=True)
+    ap.add_argument("--v4-reference-manifest")
+    ap.add_argument("--v4-normalized-dir")
     ap.add_argument("--ctx", type=int, default=90)
     ap.add_argument("--span-cap", type=int, default=600)
     ap.add_argument("--min-align-score", type=float, default=65.0)
@@ -387,7 +535,14 @@ def main() -> int:
         sys.exit("--out must not be the input (the pre-excerpt artifact is "
                  "the frame-regression BEFORE side)")
 
-    crosswalk = json.load(open(args.crosswalk, encoding="utf-8"))
+    crosswalk_path = Path(args.crosswalk)
+    ref_pickle_path = Path(args.ref_pkl)
+    try:
+        input_meta = validate_bake_input_hashes(src, crosswalk_path, ref_pickle_path)
+    except (OSError, sqlite3.Error, ValueError) as exc:
+        sys.exit(str(exc))
+
+    crosswalk = json.load(open(crosswalk_path, encoding="utf-8"))
     ref_by_work: Dict[str, List[str]] = {}
     for rid, wid in crosswalk.items():
         ref_by_work.setdefault(wid, []).append(rid)
@@ -400,13 +555,45 @@ def main() -> int:
     man_by_key = {e["key"]: e for e in man["entries"]}
 
     print("loading reference pickle (streams only)...", flush=True)
-    works_pkl = pickle.load(open(args.ref_pkl, "rb"))
+    works_pkl = pickle.load(open(ref_pickle_path, "rb"))
     pkl_stream = {w["id"]: w["stream"] for w in works_pkl}
     del works_pkl
 
+    v4_ids = {ref_id for ref_id in pkl_stream if ref_id.startswith("REF4:")}
+    have_v4_args = bool(args.v4_reference_manifest and args.v4_normalized_dir)
+    if bool(args.v4_reference_manifest) != bool(args.v4_normalized_dir):
+        sys.exit("--v4-reference-manifest and --v4-normalized-dir must be supplied together")
+    if v4_ids and not have_v4_args:
+        sys.exit("REF4 references require their pinned V4 public-source inputs")
+    v4_text: Dict[str, str] = {}
+    v4_attribution: Dict[str, str] = {}
+    v4_source_manifest_sha256 = None
+    if have_v4_args:
+        v4_text, v4_attribution, v4_source_manifest_sha256 = load_v4_public_sources(
+            Path(args.v4_reference_manifest), Path(args.v4_normalized_dir)
+        )
+        if set(v4_text) != v4_ids:
+            sys.exit("V4 public-source set does not equal the REF4 pickle set")
+        expected_source_hash = input_meta.get(
+            "canonical_merges_v4_source_manifest_sha256"
+        )
+        if not expected_source_hash or expected_source_hash != v4_source_manifest_sha256:
+            sys.exit(
+                "V4 public-source manifest differs from the canonical-merge input "
+                "recorded by the public sidecar"
+            )
+        unknown_crosswalk_refs = {
+            raw_id for raw_id in crosswalk
+            if raw_id.startswith("REF4:") and raw_id not in v4_ids
+        }
+        if unknown_crosswalk_refs:
+            sys.exit("crosswalk contains REF4 ids absent from the reference pickle")
+
     counters: Counter = Counter()
-    sources = WorkSources(refs_staging, Path(args.ja_dir), man_by_key,
-                          pkl_stream, counters)
+    sources = WorkSources(
+        refs_staging, Path(args.ja_dir), man_by_key, pkl_stream, counters,
+        v4_text=v4_text, v4_attribution=v4_attribution,
+    )
     targets = ReprojectionTargets(refs_staging, man_by_key)
 
     shutil.copyfile(src, out)
@@ -422,10 +609,12 @@ def main() -> int:
     for r in conn.execute(_BEST_ROWS_SQL):
         k = r["identification_id"]
         cur = best.get(k)
-        if cur is None or (-(r["matched_letters"] or 0), str(r["evidence_id"])) \
-                < (-(cur["matched_letters"] or 0), str(cur["evidence_id"])):
+        if cur is None or excerpt_candidate_key(r) < excerpt_candidate_key(cur):
             best[k] = r
     print(f"identifications with an eligible row: {len(best):,}", flush=True)
+    fallback_count = sum(is_excerpt_only_fallback(row) for row in best.values())
+    if fallback_count:
+        counters["work_review_only_text_fallback"] = fallback_count
 
     conn.execute(_DDL)
 
@@ -516,6 +705,8 @@ def main() -> int:
                 wsrc = "direct"
                 if refs[0].startswith("REF2:"):
                     attribution = man_by_key[refs[0][5:]].get("attribution_text")
+                elif refs[0].startswith("REF4:"):
+                    attribution = sources.attribution(refs[0])
                 elif refs[0].startswith("J:"):
                     # Structural markers out of the DISPLAY pieces, before
                     # the highlight pass reads them (owner, 2026-08-13).
@@ -562,6 +753,12 @@ def main() -> int:
         ("excerpt_span_cap", str(args.span_cap)),
         ("excerpt_refs_manifest_sha256", sha256_file(manifest_path)),
     ]
+    if args.v4_reference_manifest:
+        meta_rows.extend([
+            ("excerpt_v4_reference_manifest_sha256",
+             sha256_file(Path(args.v4_reference_manifest))),
+            ("excerpt_v4_source_manifest_sha256", v4_source_manifest_sha256),
+        ])
     conn.executemany("INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)",
                      meta_rows)
     conn.commit()

--- a/scripts/bench_discovery.py
+++ b/scripts/bench_discovery.py
@@ -356,8 +356,9 @@ def _coherent_bucket_pick(conn: sqlite3.Connection, *, main_pool: bool,
     """
     bucket_sql = "di.main_pool = 1" if main_pool else "di.main_pool = 0"
     out: Dict[str, Any] = {"work_id": None, "domain": None, "author": None,
-                           "novelty_status": None, "suppressed": None,
-                           "sys_id": None}
+                           "novelty_status": None, "locus_from": None,
+                           "locus_to": None, "locus_filter_enabled": False,
+                           "suppressed": None, "sys_id": None}
     try:
         row = conn.execute(
             f"""
@@ -392,6 +393,61 @@ def _coherent_bucket_pick(conn: sqlite3.Connection, *, main_pool: bool,
     if row is not None:
         out.update({"work_id": row[0], "domain": row[1] or None,
                     "author": row[2] or None})
+    # Locus range is a reader filter only on assets carrying the complete
+    # piece/unit pair. Pick real bounds for the chosen work so the benchmark
+    # exercises the shipped EXISTS predicate rather than timing an invented
+    # range that selects nothing. If the heaviest work has no locus pieces,
+    # move the whole coherent pick (work, domain and author together) to the
+    # heaviest work in this bucket that does. Old assets simply leave the
+    # capability false and the two range axes become named skips.
+    try:
+        locus = conn.execute(
+            f"""
+            SELECT MIN(lu.citation_pos), MAX(lu.citation_pos)
+            FROM discovery_identification di
+            JOIN discovery_locus_piece p
+              ON p.identification_id = di.identification_id
+             AND p.locus_work_id = di.display_work_id
+            JOIN locus_unit lu
+              ON lu.work_id = p.locus_work_id
+             AND lu.unit_ord BETWEEN p.start_unit_ord AND p.end_unit_ord
+            WHERE {bucket_sql} AND di.display_work_id = ?
+              AND lu.citation_pos IS NOT NULL
+            """,
+            (out.get("work_id"),),
+        ).fetchone()
+        if locus is None or locus[0] is None or locus[1] is None:
+            locus_work = conn.execute(
+                f"""
+                SELECT di.display_work_id, w.genre, w.author, COUNT(*) AS n,
+                       MIN(lu.citation_pos), MAX(lu.citation_pos)
+                FROM discovery_identification di
+                JOIN works w ON w.work_id = di.display_work_id
+                JOIN discovery_locus_piece p
+                  ON p.identification_id = di.identification_id
+                 AND p.locus_work_id = di.display_work_id
+                JOIN locus_unit lu
+                  ON lu.work_id = p.locus_work_id
+                 AND lu.unit_ord BETWEEN p.start_unit_ord AND p.end_unit_ord
+                WHERE {bucket_sql} AND lu.citation_pos IS NOT NULL
+                GROUP BY di.display_work_id
+                ORDER BY n DESC
+                LIMIT 1
+                """
+            ).fetchone()
+            if locus_work is not None:
+                out.update({"work_id": locus_work[0],
+                            "domain": locus_work[1] or None,
+                            "author": locus_work[2] or None})
+                locus = (locus_work[4], locus_work[5])
+        if locus is not None and locus[0] is not None and locus[1] is not None:
+            out["locus_from"] = int(locus[0])
+            out["locus_to"] = int(locus[1])
+            out["locus_filter_enabled"] = True
+    except sqlite3.Error:
+        # Pre-locus assets are still valid benchmark inputs. The missing
+        # capability is recorded in the picks rather than inferred later.
+        pass
     # ONE REAL SUPPRESSED ID from this bucket. Taken from the bucket rather than
     # invented, so the `NOT IN` clause excludes a row that is really there --
     # a made-up id would build the same SQL shape but exclude nothing, and the
@@ -762,6 +818,12 @@ _FINDINGS_OUT_OF_SCOPE: Tuple[Tuple[str, str], ...] = (
 #: `author`, `work`, every AND-composition and every filtered SECOND-BUCKET
 #: combination unmeasured, while the report said "the FULL combination space"
 #: (code review round 13, finding 4).
+#: `locus_from` / `locus_to` are the two independently settable ends of the
+#: selected work's chapter range. `locus_enabled` is deliberately NOT an axis:
+#: it is an internal schema capability discovered by the service, not page
+#: state a reader can switch. The benchmark passes the equivalent
+#: `locus_filter_enabled` capability for every state when the asset supports it.
+#:
 #: `suppressed` (2026-08-06) is the admin hide list -- a `NOT IN` over
 #: identification ids. It is measured for the same reason every other axis is: it
 #: composes as AND with all of them, it lands in the SAME predicate the count and
@@ -771,7 +833,8 @@ _FINDINGS_OUT_OF_SCOPE: Tuple[Tuple[str, str], ...] = (
 #: shipped_predicate_builder` reads `_build_findings_filter`'s own signature and
 #: fails if this tuple falls behind it -- which is how this entry got added.
 _FINDINGS_FILTER_AXES: Tuple[str, ...] = (
-    "novelty", "divergence", "domain", "author", "work", "suppressed", "sys_id")
+    "novelty", "divergence", "domain", "author", "work", "locus_from",
+    "locus_to", "suppressed", "sys_id")
 
 
 def _findings_filter_states(picks: Dict[str, Dict[str, Any]],
@@ -825,6 +888,15 @@ def _findings_filter_states(picks: Dict[str, Dict[str, Any]],
                 kwargs["author"] = pick.get("author")
             if "work" in on:
                 kwargs["work_id"] = pick.get("work_id")
+            if "locus_from" in on:
+                kwargs["locus_from"] = pick.get("locus_from")
+            if "locus_to" in on:
+                kwargs["locus_to"] = pick.get("locus_to")
+            if pick.get("locus_filter_enabled"):
+                # This is a capability of the loaded asset, not an optional
+                # reader axis. It stays on across the whole state space just as
+                # it does in DiscoveryService after `_has_locus_filter()`.
+                kwargs["locus_filter_enabled"] = True
             if "suppressed" in on:
                 # A REAL id from THIS bucket, so the `NOT IN` is a predicate that
                 # excludes something rather than one the optimiser can discard.
@@ -948,13 +1020,18 @@ def _findings_combination_specs(conn, *, page_size: int, deep_page: int,
         # that pairs it with a domain or an author really can be empty in this
         # asset, and that is a genuine asset fact rather than a probe bug.
         keys = {"novelty": "novelty", "domain": "domain",
-                "author": "author", "work": "work_id"}
+                "author": "author", "work": "work_id",
+                "locus_from": "locus_from", "locus_to": "locus_to"}
         missing = [axis for axis in on
-                   if axis in keys and not kwargs.get(keys[axis])]
+                   if axis in keys and (
+                       kwargs.get(keys[axis]) is None
+                       if axis in {"locus_from", "locus_to"}
+                       else not kwargs.get(keys[axis])
+                   )]
         if missing:
             return (f"this asset offers no value for the {', '.join(missing)} "
-                    f"filter in the {stem} bucket, so that combination cannot be "
-                    "issued against it")
+                    f"filter in the {stem} bucket, so that combination has no "
+                    "non-empty population to measure in this asset")
         # A SINGLE VALUE AXIS never reaches the probe below: every value comes
         # from `_coherent_bucket_pick`, drawn from THIS bucket, so an empty
         # single-axis state means the probe picked something the asset does not
@@ -971,8 +1048,11 @@ def _findings_combination_specs(conn, *, page_size: int, deep_page: int,
         # every unit (the units differ only in grouping, and grouping >=1 row
         # never yields zero groups), and `novelty` is rejected outright on the
         # per-work unit by the builder.
+        predicate_kwargs = dict(kwargs)
+        predicate_kwargs["locus_enabled"] = bool(
+            predicate_kwargs.pop("locus_filter_enabled", False))
         where_sql, params = _build_findings_filter(
-            unit=FINDINGS_UNIT_IDENTIFICATION, **kwargs)
+            unit=FINDINGS_UNIT_IDENTIFICATION, **predicate_kwargs)
         try:
             found = conn.execute(
                 f"SELECT 1 {_FINDINGS_FROM} {where_sql} LIMIT 1", params).fetchone()

--- a/scripts/build_discovery_sidecar.py
+++ b/scripts/build_discovery_sidecar.py
@@ -8059,6 +8059,15 @@ def finalize_build(
         seftja_dates_path=seftja_dates_path,
         seftja_dates_sha256=seftja_dates_sha256,
     )
+    if (
+        release
+        and track1_release_contract_path is not None
+        and track1_release_contract_sha256 is None
+    ):
+        raise ReleaseInputsIncompleteError(
+            "release Track-1 contract requires "
+            "--track1-release-contract-sha256"
+        )
     if track1_release_contract_sha256 is not None and track1_release_contract_path is None:
         raise ReleaseInputsIncompleteError(
             "Track-1 release-contract SHA-256 was supplied without its path"

--- a/scripts/build_discovery_sidecar.py
+++ b/scripts/build_discovery_sidecar.py
@@ -158,6 +158,19 @@ LOCUS_FILTER_VERSION = "locus-filter-v1"
 LOCUS_DIVISIONS_SHA256 = (
     "aaac6f90d9ee2b4c3e0b83c0220e9215dc2cdee0c9995cd2ed6672b951898263"
 )
+REFERENCE_CORPUS_V2_SHA256 = (
+    "acb6b86f61680e5b459fc8274aa3bce8b69d6bec13512c83a56167c7fd6646de"
+)
+REFERENCE_CORPUS_V4_SHA256 = (
+    "6c540e3987752f1e0ead36f881e8d2f41f903b6e1aa9121b2b109ecfbc8a3133"
+)
+LOCUS_DIVISIONS_V4_SHA256 = (
+    "c6cf55d2388585dd2fb8dcf2cb565bbbb386f7def8a32b710516886c18f0fc40"
+)
+LOCUS_DIVISIONS_BY_REFERENCE_SHA256 = {
+    REFERENCE_CORPUS_V2_SHA256: LOCUS_DIVISIONS_SHA256,
+    REFERENCE_CORPUS_V4_SHA256: LOCUS_DIVISIONS_V4_SHA256,
+}
 LOCUS_FAMILIES = frozenset({"sefaria", "ja", "msource_header", "msource_daf"})
 LOCUS_STATUSES = ("resolved", "whole_work", "unavailable")
 
@@ -850,6 +863,8 @@ _CANONICAL_MERGES_TOP_KEYS = frozenset({
     "merges", "dropped_by_135", "source", "canonical_priority", "owner_ratified",
     "ratified_at", "relations_policy", "chronological_rule_examples", "contested",
     "provisional_relations_measurement_only", "residual_direct", "notes",
+    "release_contract_version", "v4_public_reference_canonical_ids",
+    "v4_source_manifest_sha256",
 })
 _MERGE_ENTRY_KEYS = frozenset({"members_w", "canonical_w", "owner_verdict"})
 _W_ID_RE = re.compile(r"^w\d{6}$")
@@ -860,6 +875,8 @@ _D14_MEMBERS = frozenset({"w000452", "w001239"})
 _D14_CANONICAL = "w000452"
 _D14_DROPPED = "w001239"
 _EXPECTED_APPROVE_MERGES = 16
+_V3_MERGE_CONTRACT = "discovery-v3-canonical-merges-v1"
+_V4_MERGE_CONTRACT = "discovery-v4-public-reference-merges-v1"
 
 
 def _is_w_id(x) -> bool:
@@ -908,6 +925,36 @@ def load_canonical_merges(
         raise CanonicalMergesError("--canonical-merges 'merges' must be a list")
     if not isinstance(dropped_raw, list):
         raise CanonicalMergesError("--canonical-merges 'dropped_by_135' must be a list")
+    contract_version = doc.get("release_contract_version") or _V3_MERGE_CONTRACT
+    if contract_version not in {_V3_MERGE_CONTRACT, _V4_MERGE_CONTRACT}:
+        raise CanonicalMergesError("--canonical-merges has an unsupported release contract version")
+    v4_canonical_raw = doc.get("v4_public_reference_canonical_ids", [])
+    v4_source_manifest_sha256 = doc.get("v4_source_manifest_sha256")
+    if contract_version == _V3_MERGE_CONTRACT:
+        if v4_canonical_raw or v4_source_manifest_sha256 is not None:
+            raise CanonicalMergesError(
+                "V3 canonical-merge contract cannot carry V4 public-reference fields"
+            )
+        v4_canonical_ids = set()
+    else:
+        if not (
+            isinstance(v4_canonical_raw, list)
+            and v4_canonical_raw
+            and all(_is_w_id(value) for value in v4_canonical_raw)
+            and len(v4_canonical_raw) == len(set(v4_canonical_raw))
+        ):
+            raise CanonicalMergesError(
+                "V4 canonical-merge contract requires distinct w000xxx-shaped "
+                "v4_public_reference_canonical_ids"
+            )
+        if not (
+            isinstance(v4_source_manifest_sha256, str)
+            and re.fullmatch(r"[0-9a-f]{64}", v4_source_manifest_sha256)
+        ):
+            raise CanonicalMergesError(
+                "V4 canonical-merge contract requires a lowercase SHA-256 source-manifest pin"
+            )
+        v4_canonical_ids = set(v4_canonical_raw)
 
     dropped = set()
     for d in dropped_raw:
@@ -919,6 +966,7 @@ def load_canonical_merges(
     seen_ids: set = set()
     approve_count = 0
     d14_ok = False
+    approved_groups: List[Tuple[set, str]] = []
     for i, m in enumerate(merges):
         if not isinstance(m, dict):
             raise CanonicalMergesError(f"merges[{i}] must be a JSON object")
@@ -950,6 +998,7 @@ def load_canonical_merges(
             )
         seen_ids |= group_ids
         approve_count += 1
+        approved_groups.append((distinct, canon))
         for member in members:
             cross_corpus_map[member] = canon
         if distinct == _D14_MEMBERS and canon == _D14_CANONICAL:
@@ -957,12 +1006,24 @@ def load_canonical_merges(
 
     if require_release_semantics:
         problems = []
-        if approve_count != _EXPECTED_APPROVE_MERGES:
-            problems.append(f"expected {_EXPECTED_APPROVE_MERGES} approve merges, got {approve_count}")
+        expected_approve = _EXPECTED_APPROVE_MERGES + len(v4_canonical_ids)
+        if approve_count != expected_approve:
+            problems.append(f"expected {expected_approve} approve merges, got {approve_count}")
         if dropped != {_D14_DROPPED}:
             problems.append(f"dropped_by_135 must equal {{{_D14_DROPPED!r}}}")
         if not d14_ok:
             problems.append("D-14 flip absent (the w000452/w001239 group must have canonical_w=w000452)")
+        if v4_canonical_ids:
+            v4_groups = {
+                canon
+                for members, canon in approved_groups
+                if canon in v4_canonical_ids and len(members) == 2
+            }
+            missing_v4 = v4_canonical_ids - v4_groups
+            if missing_v4:
+                problems.append(
+                    f"{len(missing_v4)} V4 public canonical id(s) lack an approved two-member merge"
+                )
         if problems:
             raise CanonicalMergesError(
                 "--canonical-merges semantic-ratification assertion failed: " + "; ".join(problems)
@@ -973,6 +1034,9 @@ def load_canonical_merges(
         "dropped": dropped,
         "sha256": actual_sha,
         "approve_count": approve_count,
+        "release_contract_version": contract_version,
+        "v4_public_reference_merges": len(v4_canonical_ids),
+        "v4_source_manifest_sha256": v4_source_manifest_sha256,
     }
 
 
@@ -1972,7 +2036,7 @@ def ingest_locus_divisions(
     crosswalk: Dict[str, str],
     reference_corpus_sha256: Optional[str],
     *,
-    expected_sha256: str = LOCUS_DIVISIONS_SHA256,
+    expected_sha256: Optional[str] = None,
 ) -> List[Tuple[str, str]]:
     """Validate, re-key, and import the pinned division artifact.
 
@@ -1981,11 +2045,20 @@ def ingest_locus_divisions(
     crosswalk; references absent from that crosswalk, and mapped works absent
     from this asset, are counted and omitted rather than guessed.
     """
+    if not reference_corpus_sha256:
+        raise ValueError("--locus-divisions requires --reference-corpus-sha256")
+    reference_corpus_sha256 = reference_corpus_sha256.lower()
+    if expected_sha256 is None:
+        expected_sha256 = LOCUS_DIVISIONS_BY_REFERENCE_SHA256.get(
+            reference_corpus_sha256
+        )
+        if expected_sha256 is None:
+            raise ValueError(
+                "reference corpus has no approved locus-division input pair"
+            )
     source_path = Path(path)
     if _hash_file(source_path).lower() != expected_sha256.lower():
         raise ValueError("locus division database SHA-256 does not match the pinned input")
-    if not reference_corpus_sha256:
-        raise ValueError("--locus-divisions requires --reference-corpus-sha256")
 
     coverage_path = source_path.with_name("coverage.json")
     if not coverage_path.is_file():
@@ -7177,6 +7250,18 @@ _EXPECTED_E1_R3_FRAME_ROWS = 9996
 _EXPECTED_Q2_WITNESS_COLLECTION_ROWS = 4367
 _EXPECTED_Q2_SHARED_TEXT_ROWS = 60156
 _EXPECTED_TIER_A_ROWS = 275894  # track1_matches WHERE shadowed_by IS NULL
+_TRACK1_V4_CONTRACT_VERSION = "discovery-v4-track1-release-contract-v1"
+_TRACK1_V4_CONTRACT_KEYS = frozenset({
+    "schema_version", "reference_corpus_sha256", "canonical_masks_sha256",
+    "source_db_seed_sha256", "matcher_fingerprint", "page_count", "total_rows", "live_rows",
+    "ref4_total_rows", "ref4_live_rows", "v2_snapshot_rows",
+    "missing_ref_offsets", "duplicate_pairs", "shadow_algorithm", "promoted_columns",
+})
+_TRACK1_V4_PROMOTED_COLUMNS = [
+    "page_id", "sys_id", "work_id", "cat", "genre", "author", "title",
+    "matched_letters", "best_density", "n_spans", "spans_json", "generation",
+    "ref_spans_json", "shadowed_by",
+]
 # PROVENANCE (Codex round 2, HIGH -- and the finding was right).
 #
 # The v3 slim DB's own tier-A count is 275,894: EXACTLY this frozen value. The
@@ -7246,6 +7331,116 @@ class BandVocabPreflightError(RuntimeError):
     rename cascade's root cause was that v2 was inferred, never asserted)."""
 
 
+def load_track1_release_contract(path, *, sha256: Optional[str] = None) -> Dict:
+    """Load the hash-pinned V4 matcher population contract."""
+    contract_path = Path(path)
+    if not contract_path.is_file():
+        raise ReleaseInputsIncompleteError("Track-1 release contract file is missing")
+    actual_sha = _hash_file(contract_path)
+    if sha256 is not None and actual_sha != sha256:
+        raise ReleaseInputsIncompleteError("Track-1 release contract SHA-256 mismatch")
+    try:
+        contract = _json_loads_strict(contract_path.read_text(encoding="utf-8"))
+    except ValueError as exc:
+        raise ReleaseInputsIncompleteError(
+            "Track-1 release contract is not strict JSON"
+        ) from exc
+    if not isinstance(contract, dict) or set(contract) != _TRACK1_V4_CONTRACT_KEYS:
+        raise ReleaseInputsIncompleteError(
+            "Track-1 release contract does not have the frozen V4 field set"
+        )
+    if contract["schema_version"] != _TRACK1_V4_CONTRACT_VERSION:
+        raise ReleaseInputsIncompleteError("unsupported Track-1 release contract version")
+    for key in (
+        "reference_corpus_sha256", "canonical_masks_sha256", "source_db_seed_sha256"
+    ):
+        if not isinstance(contract[key], str) or not re.fullmatch(
+            r"[0-9a-f]{64}", contract[key]
+        ):
+            raise ReleaseInputsIncompleteError(
+                f"Track-1 release contract {key} is not a lowercase SHA-256"
+            )
+    if not isinstance(contract["matcher_fingerprint"], str) or not re.fullmatch(
+        r"[0-9a-f]{40}", contract["matcher_fingerprint"]
+    ):
+        raise ReleaseInputsIncompleteError(
+            "Track-1 release contract matcher fingerprint is malformed"
+        )
+    count_keys = (
+        "page_count", "total_rows", "live_rows", "ref4_total_rows",
+        "ref4_live_rows", "v2_snapshot_rows", "missing_ref_offsets",
+        "duplicate_pairs",
+    )
+    if any(not isinstance(contract[key], int) or contract[key] < 0 for key in count_keys):
+        raise ReleaseInputsIncompleteError(
+            "Track-1 release contract contains a non-integer or negative count"
+        )
+    if not (
+        contract["live_rows"] <= contract["total_rows"]
+        and contract["ref4_live_rows"] <= contract["ref4_total_rows"]
+        and contract["ref4_total_rows"] <= contract["total_rows"]
+    ):
+        raise ReleaseInputsIncompleteError("Track-1 release contract counts are inconsistent")
+    if contract["v2_snapshot_rows"] != 381_341:
+        raise ReleaseInputsIncompleteError("Track-1 V2 snapshot row count drift")
+    if contract["page_count"] != 667_411:
+        raise ReleaseInputsIncompleteError("Track-1 page-frame count drift")
+    if contract["missing_ref_offsets"] or contract["duplicate_pairs"]:
+        raise ReleaseInputsIncompleteError(
+            "Track-1 release contract reports missing offsets or duplicate pairs"
+        )
+    if contract["shadow_algorithm"] != "track1-shadow-v1":
+        raise ReleaseInputsIncompleteError("Track-1 shadow algorithm drift")
+    if contract["promoted_columns"] != _TRACK1_V4_PROMOTED_COLUMNS:
+        raise ReleaseInputsIncompleteError("Track-1 promoted schema drift")
+    return {**contract, "sha256": actual_sha}
+
+
+def assert_track1_release_contract(conn: sqlite3.Connection, contract: Dict) -> None:
+    """Recompute the V4 matcher contract against the supplied research DB."""
+    columns = [row[1] for row in conn.execute("PRAGMA table_info(track1_matches)")]
+    if columns != contract["promoted_columns"]:
+        raise ReleaseInputsIncompleteError(
+            "research Track-1 table differs from the exact promoted schema"
+        )
+    tables = {
+        row[0]
+        for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    }
+    if "track1_matches_v2_snapshot" not in tables:
+        raise ReleaseInputsIncompleteError("research DB lacks the preserved V2 snapshot")
+    actual = {
+        "page_count": conn.execute("SELECT COUNT(*) FROM pages").fetchone()[0],
+        "total_rows": conn.execute("SELECT COUNT(*) FROM track1_matches").fetchone()[0],
+        "live_rows": conn.execute(
+            "SELECT COUNT(*) FROM track1_matches WHERE shadowed_by IS NULL"
+        ).fetchone()[0],
+        "ref4_total_rows": conn.execute(
+            "SELECT COUNT(*) FROM track1_matches WHERE work_id LIKE 'REF4:%'"
+        ).fetchone()[0],
+        "ref4_live_rows": conn.execute(
+            "SELECT COUNT(*) FROM track1_matches "
+            "WHERE work_id LIKE 'REF4:%' AND shadowed_by IS NULL"
+        ).fetchone()[0],
+        "v2_snapshot_rows": conn.execute(
+            "SELECT COUNT(*) FROM track1_matches_v2_snapshot"
+        ).fetchone()[0],
+        "missing_ref_offsets": conn.execute(
+            "SELECT COUNT(*) FROM track1_matches WHERE ref_spans_json IS NULL "
+            "OR ref_spans_json='' OR ref_spans_json='[]'"
+        ).fetchone()[0],
+        "duplicate_pairs": conn.execute(
+            "SELECT COUNT(*) FROM (SELECT page_id, work_id, generation, COUNT(*) n "
+            "FROM track1_matches GROUP BY page_id, work_id, generation HAVING n != 1)"
+        ).fetchone()[0],
+    }
+    drift = [key for key, value in actual.items() if value != contract[key]]
+    if drift:
+        raise ReleaseInputsIncompleteError(
+            f"research Track-1 table differs from its release contract in {len(drift)} count(s)"
+        )
+
+
 def _count_tier_a_rows(conn: sqlite3.Connection) -> int:
     (n,) = conn.execute(
         "SELECT COUNT(*) FROM track1_matches WHERE shadowed_by IS NULL"
@@ -7266,6 +7461,7 @@ def _assert_release_inputs_complete(
     q2_collection_tafsir_targum: List[Dict],
     q2_collection_with_arabic: List[Dict],
     tier_a_row_count: Optional[int],
+    expected_tier_a_rows: int = _EXPECTED_TIER_A_ROWS,
 ) -> None:
     """H2: in release mode, REQUIRE every frozen release input present at
     its EXACT expected count -- abort (raise) on any absent/short/long
@@ -7294,7 +7490,7 @@ def _assert_release_inputs_complete(
         (
             "tier_a (track1_matches WHERE shadowed_by IS NULL)",
             tier_a_row_count if tier_a_row_count is not None else 0,
-            _EXPECTED_TIER_A_ROWS,
+            expected_tier_a_rows,
         ),
     ]
     problems = [
@@ -7715,6 +7911,8 @@ def finalize_build(
     allow_partial_sources: bool = False,
     canonical_merges_path=None,
     canonical_merges_sha256: Optional[str] = None,
+    track1_release_contract_path=None,
+    track1_release_contract_sha256: Optional[str] = None,
     composition_dates_path=None,
     composition_dates_sha256: Optional[str] = None,
     seftja_dates_path=None,
@@ -7861,6 +8059,24 @@ def finalize_build(
         seftja_dates_path=seftja_dates_path,
         seftja_dates_sha256=seftja_dates_sha256,
     )
+    if track1_release_contract_sha256 is not None and track1_release_contract_path is None:
+        raise ReleaseInputsIncompleteError(
+            "Track-1 release-contract SHA-256 was supplied without its path"
+        )
+    track1_release_contract = None
+    if track1_release_contract_path is not None:
+        track1_release_contract = load_track1_release_contract(
+            track1_release_contract_path, sha256=track1_release_contract_sha256
+        )
+        track1_release_contract_sha256 = track1_release_contract["sha256"]
+        if (
+            reference_corpus_sha256 is not None
+            and track1_release_contract["reference_corpus_sha256"]
+            != reference_corpus_sha256
+        ):
+            raise ReleaseInputsIncompleteError(
+                "Track-1 release contract and bake reference-corpus hashes differ"
+            )
 
     # v2 STEP 0 (135-06, bake plan §6): resolve the optional --precision-spec
     # FAIL-branch reband BEFORE any DB write. A `measured_fail` tier_a outcome
@@ -7901,6 +8117,9 @@ def finalize_build(
     # the body (v2 STEP -1) so it could thread the band_precision rename; its
     # verified SHA is recorded in meta (`canonical_merges_sha256`) below,
     # giving the shipped asset a clean v2 marker alongside band_vocab_version.
+    canonical_merge_contract_version = None
+    canonical_merge_v4_count = 0
+    canonical_merge_v4_source_manifest_sha256 = None
     if v2_build:
         merges_loaded = load_canonical_merges(
             canonical_merges_path, sha256=canonical_merges_sha256,
@@ -7909,6 +8128,11 @@ def finalize_build(
         cross_corpus_map = merges_loaded["cross_corpus_map"]
         dropped_work_ids = merges_loaded["dropped"]
         canonical_merges_sha256 = merges_loaded["sha256"]
+        canonical_merge_contract_version = merges_loaded["release_contract_version"]
+        canonical_merge_v4_count = merges_loaded["v4_public_reference_merges"]
+        canonical_merge_v4_source_manifest_sha256 = merges_loaded[
+            "v4_source_manifest_sha256"
+        ]
     else:
         cross_corpus_map = {}
         dropped_work_ids = set()
@@ -7930,6 +8154,8 @@ def finalize_build(
     gen2_router = None
     regrain_report = None
     e1_route_report = None
+    v4_route_report = None
+    fullscan_legacy_route_report = None
     if gen2_router_evidence_db is not None:
         from v3_routing_ingest import load_router as _load_gen2_router
         gen2_router = _load_gen2_router(str(gen2_router_evidence_db))
@@ -8043,6 +8269,8 @@ def finalize_build(
         # must never silently ingest as empty and produce a tier-A-only
         # sidecar that still passes every other gate, and a failed release
         # build must never have already deleted/overwritten prior artifacts.
+        if track1_release_contract is not None:
+            assert_track1_release_contract(conn_research, track1_release_contract)
         tier_a_row_count = _count_tier_a_rows(conn_research) if release else None
         _assert_release_inputs_complete(
             release=release,
@@ -8053,6 +8281,11 @@ def finalize_build(
             q2_collection_tafsir_targum=q2_collection_tafsir_targum,
             q2_collection_with_arabic=q2_collection_with_arabic,
             tier_a_row_count=tier_a_row_count,
+            expected_tier_a_rows=(
+                track1_release_contract["live_rows"]
+                if track1_release_contract is not None
+                else _EXPECTED_TIER_A_ROWS
+            ),
         )
 
         # SPLIT-GRAIN RE-GRAINING (option 4, owner-approved 2026-08-07). Runs
@@ -8078,6 +8311,9 @@ def finalize_build(
             from v3_routing_ingest import (
                 load_split_grain_coverage as _load_split_cov,
                 regrain_router_to_split as _regrain,
+                resolve_routing as _resolve_route,
+                route_fullscan_legacy_by_coverage as _route_fullscan_legacy,
+                route_v4_references_by_coverage as _route_v4,
             )
             _split_max = _load_split_cov(str(gen2_router_evidence_db))
             # `pages.n_chars` is the RAW character length, and that is
@@ -8094,19 +8330,62 @@ def finalize_build(
                 p: n for p, n in conn_research.execute(
                     "SELECT page_id, n_chars FROM pages")
             }
-            _tier_a_keys = conn_research.execute(
-                "SELECT page_id, work_id FROM track1_matches "
+            _tier_a_rows = conn_research.execute(
+                "SELECT page_id, work_id, matched_letters FROM track1_matches "
                 "WHERE shadowed_by IS NULL"
             ).fetchall()
+            _v4_rows = [row for row in _tier_a_rows if row[1].startswith("REF4:")]
+            _tier_a_keys = [
+                (page_id, work_id)
+                for page_id, work_id, _matched_letters in _tier_a_rows
+                if not work_id.startswith("REF4:")
+            ]
             regrain_report = _regrain(
                 gen2_router, _split_max, _page_chars, _tier_a_keys)
             if regrain_report["undecided"]:
-                raise RoutingConflictError(
-                    f"split-grain re-graining left {regrain_report['undecided']} "
-                    f"tier-A row(s) with no routing decision -- they would keep the "
-                    f"ingest default and silently bypass coverage routing. Halting "
-                    f"rather than defaulting."
+                if track1_release_contract is None:
+                    raise RoutingConflictError(
+                        f"split-grain re-graining left {regrain_report['undecided']} "
+                        f"tier-A row(s) with no routing decision -- they would keep "
+                        f"the ingest default and silently bypass coverage routing. "
+                        f"Halting rather than defaulting."
+                    )
+                _legacy_unresolved = [
+                    row for row in _tier_a_rows
+                    if not row[1].startswith("REF4:")
+                    and _resolve_route(row[0], row[1], gen2_router)[0] is None
+                ]
+                if len(_legacy_unresolved) != regrain_report["undecided"]:
+                    raise RoutingConflictError(
+                        "split-grain undecided count differs from the exact unresolved "
+                        "legacy row set"
+                    )
+                _historical_keys = set(conn_research.execute(
+                    "SELECT page_id, work_id FROM track1_matches_v2_snapshot"
+                ))
+                fullscan_legacy_route_report = _route_fullscan_legacy(
+                    gen2_router,
+                    _legacy_unresolved,
+                    _page_chars,
+                    _historical_keys,
                 )
+                if fullscan_legacy_route_report["undecided"]:
+                    raise RoutingConflictError(
+                        f"full-scan legacy routing left "
+                        f"{fullscan_legacy_route_report['undecided']} row(s) with no "
+                        f"decision -- halting rather than defaulting"
+                    )
+            if _v4_rows:
+                v4_route_report = _route_v4(
+                    gen2_router, _v4_rows, _page_chars, raw_prefix="REF4:"
+                )
+                if v4_route_report["undecided"]:
+                    raise RoutingConflictError(
+                        f"V4 public-reference routing left "
+                        f"{v4_route_report['undecided']} row(s) with no decision "
+                        f"-- they would keep the ingest default and silently "
+                        f"bypass coverage routing. Halting rather than defaulting."
+                    )
 
             # E1 witness routing (2026-08-08, owner-authorized). The four E1
             # collections are drawn ENTIRELY from the matcher's tier B, which
@@ -8418,7 +8697,14 @@ def finalize_build(
             # one it contains. `gen2_router` (not the flag) drives it: intent is not
             # evidence.
             ("coverage_routing", (
-                "gen2_router_split_regrained" if regrain_report is not None
+                "gen2_router_split_regrained_fullscan_legacy_v4_extrapolated"
+                if (v4_route_report is not None
+                    and fullscan_legacy_route_report is not None)
+                else "gen2_router_split_regrained_fullscan_legacy_extrapolated"
+                if fullscan_legacy_route_report is not None
+                else "gen2_router_split_regrained_v4_extrapolated"
+                if v4_route_report is not None
+                else "gen2_router_split_regrained" if regrain_report is not None
                 else ("gen2_router" if gen2_router is not None
                       else ("lever1_cliff" if run_d17 else "none")))),
         ]
@@ -8464,10 +8750,55 @@ def finalize_build(
                 ("coverage_e1_same_work", str(e1_route_report["same_work"])),
                 ("coverage_e1_parallel", str(e1_route_report["parallel"])),
             ])
+        if v4_route_report is not None:
+            meta_rows.extend([
+                ("coverage_v4_reference_routing", "threshold_extrapolated_new_works"),
+                ("coverage_v4_reference_prefix", v4_route_report["raw_prefix"]),
+                ("coverage_v4_reference_considered", str(v4_route_report["considered"])),
+                ("coverage_v4_reference_routed", str(v4_route_report["added"])),
+                ("coverage_v4_reference_same_work", str(v4_route_report["same_work"])),
+                ("coverage_v4_reference_parallel", str(v4_route_report["parallel"])),
+            ])
+        if fullscan_legacy_route_report is not None:
+            meta_rows.extend([
+                ("coverage_fullscan_legacy_routing",
+                 "threshold_extrapolated_allowlist_removal"),
+                ("coverage_fullscan_legacy_considered",
+                 str(fullscan_legacy_route_report["considered"])),
+                ("coverage_fullscan_legacy_routed",
+                 str(fullscan_legacy_route_report["added"])),
+                ("coverage_fullscan_legacy_same_work",
+                 str(fullscan_legacy_route_report["same_work"])),
+                ("coverage_fullscan_legacy_parallel",
+                 str(fullscan_legacy_route_report["parallel"])),
+                ("coverage_fullscan_historical_key_count",
+                 str(fullscan_legacy_route_report["historical_key_count"])),
+            ])
         # v2 provenance (bake plan §7 gate 11, Codex #B2/#5): record the
         # verified SHA-256 of every supplied hash-pinned input in meta.
         if canonical_merges_sha256 is not None:
             meta_rows.append(("canonical_merges_sha256", canonical_merges_sha256))
+        if canonical_merge_contract_version is not None:
+            meta_rows.extend([
+                ("canonical_merges_release_contract", canonical_merge_contract_version),
+                ("canonical_merges_v4_public_references", str(canonical_merge_v4_count)),
+            ])
+        if canonical_merge_v4_source_manifest_sha256 is not None:
+            meta_rows.append((
+                "canonical_merges_v4_source_manifest_sha256",
+                canonical_merge_v4_source_manifest_sha256,
+            ))
+        if track1_release_contract is not None:
+            meta_rows.extend([
+                ("track1_release_contract_version", track1_release_contract["schema_version"]),
+                ("track1_release_contract_sha256", track1_release_contract_sha256),
+                ("track1_reference_masks_sha256", track1_release_contract["canonical_masks_sha256"]),
+                ("track1_source_db_seed_sha256", track1_release_contract["source_db_seed_sha256"]),
+                ("track1_matcher_fingerprint", track1_release_contract["matcher_fingerprint"]),
+                ("track1_input_total_rows", str(track1_release_contract["total_rows"])),
+                ("track1_input_live_rows", str(track1_release_contract["live_rows"])),
+                ("track1_input_ref4_live_rows", str(track1_release_contract["ref4_live_rows"])),
+            ])
         if composition_dates_sha256 is not None:
             meta_rows.append(("composition_dates_sha256", composition_dates_sha256))
         if seftja_dates_sha256 is not None:
@@ -8627,6 +8958,8 @@ def finalize_build(
         # population was independently verified.
         "router_parity": result.get("router_parity"),
         "coverage_regrain": regrain_report,
+        "coverage_v4_references": v4_route_report,
+        "coverage_fullscan_legacy": fullscan_legacy_route_report,
         "manifest_path": str(manifest_path),
         "db_path": str(out_path),
     }
@@ -8774,6 +9107,12 @@ def build_parser() -> argparse.ArgumentParser:
                              "(REQUIRED for --release; Codex #B2).")
     v2_group.add_argument("--canonical-merges-sha256", metavar="HEX", default=None,
                         help="SHA-256 pin verified before --canonical-merges is used.")
+    v2_group.add_argument("--track1-release-contract", metavar="PATH", default=None,
+                        help="Hash-pinned V4 matcher population contract. Its counts, "
+                             "reference offsets, preserved V2 snapshot, and page frame are "
+                             "recomputed against --db-path before a release build.")
+    v2_group.add_argument("--track1-release-contract-sha256", metavar="HEX", default=None,
+                        help="SHA-256 pin verified before --track1-release-contract is used.")
     v2_group.add_argument("--composition-dates", metavar="PATH", default=None,
                         help="Hash-pinned M-source composition dates (REQUIRED for --release "
                              "D-17; Codex #5). Frozen schema; normalized to a numeric year.")
@@ -9014,6 +9353,8 @@ def main(argv=None) -> int:
         allow_partial_sources=args.allow_partial_sources,
         canonical_merges_path=args.canonical_merges,
         canonical_merges_sha256=args.canonical_merges_sha256,
+        track1_release_contract_path=args.track1_release_contract,
+        track1_release_contract_sha256=args.track1_release_contract_sha256,
         composition_dates_path=args.composition_dates,
         composition_dates_sha256=args.composition_dates_sha256,
         seftja_dates_path=args.seftja_dates,

--- a/scripts/build_work_divisions.py
+++ b/scripts/build_work_divisions.py
@@ -1706,6 +1706,80 @@ def build_sefaria(
     return None
 
 
+# The staged Guide is the original Judeo-Arabic text, not the translated
+# Sefaria edition.  Its body carries its own exact chapter boundaries as
+# ``פצל # <numeral>`` lines, but no versemap sidecar.  The numbering resets in
+# the canonical three parts (76 / 48 / 54 chapters).  Keep this deliberately
+# narrow: none of the other staged JA additions uses this marker grammar, and a
+# reset count that changes fails the whole work closed rather than guessing.
+_STAGED_GUIDE_KEY = "ja2_rambam_moreh"
+_STAGED_GUIDE_PART_CHAPTERS = (76, 48, 54)
+_STAGED_JA_CHAPTER_RE = re.compile(r"^פצל\s*#\s*(\S+)\s*$", re.MULTILINE)
+
+
+def build_staged_ja_chapters(
+    key: str, staging_dir: str, body_file: str, ref_id: str,
+    shipped: Dict[str, str],
+) -> Optional[WorkUnits]:
+    """Build the Guide's three-part chapter table from its own JA markers."""
+    if key != _STAGED_GUIDE_KEY:
+        return None
+    body_path = os.path.join(staging_dir, body_file)
+    if not os.path.exists(body_path):
+        return None
+    raw = _read(body_path)
+    stream, offsets = norm_stream(raw)
+    if shipped.get(ref_id) != stream:
+        return None
+
+    markers = list(_STAGED_JA_CHAPTER_RE.finditer(raw))
+    if len(markers) != sum(_STAGED_GUIDE_PART_CHAPTERS):
+        return None
+
+    marks: List[Tuple[Optional[LocusAddress], int]] = []
+    cursor = 0
+    for part, chapter_count in enumerate(_STAGED_GUIDE_PART_CHAPTERS, 1):
+        for chapter in range(1, chapter_count + 1):
+            marker = markers[cursor]
+            stated = parse_unit_numeral(marker.group(1))
+            # The source twice uses the historically common יו for sixteen;
+            # render the canonical citation טז, but accept no other mismatch.
+            if stated is None and marker.group(1) == "יו":
+                stated = 16
+            if stated != chapter:
+                return None
+            marks.append((
+                LocusAddress(
+                    division=f"חלק {heb_numeral(part)}",
+                    chapter=heb_numeral(chapter),
+                    chapter_kind="פרק",
+                    sub="",
+                    sub_kind="",
+                ),
+                stream_offset_for_raw(offsets, marker.start()),
+            ))
+            cursor += 1
+
+    chapters = _chapter_units(marks)
+    if len(chapters) != len(markers):
+        return None
+    # Text before Part I chapter 1 is a real introduction.  Give each numbered
+    # part its own thousand-wide citation block and keep the introduction at 1.
+    # That makes every part boundary (including introduction -> Part I) a real
+    # break: a span crossing it renders two honest pieces, never the strange
+    # synthetic range ``הקדמה–חלק א, פרק א``.
+    units = [Unit(0, 0, "intro", "הקדמה", 1, ("הקדמה",))]
+    units.extend(
+        unit._replace(
+            unit_ord=index,
+            citation_pos=(unit.citation_pos + 1000
+                          if unit.citation_pos is not None else None),
+        )
+        for index, unit in enumerate(chapters, 1)
+    )
+    return WorkUnits(ref_id, "ja", "chapter", units, len(stream))
+
+
 def _sefaria_verse_units(
     ref_id: str, kind: str, records: Sequence[dict], offsets: Sequence[int],
     stream_len: int, key: str = "", raw: str = "",
@@ -2194,6 +2268,18 @@ corpora are restricted:
         print(f"  SKIPPED: {ENV_JA_DIR} is not set or not a directory")
 
     staging = os.environ.get(ENV_STAGING_DIR)
+    if "ja" in families and staging and os.path.isdir(staging):
+        manifest_path = os.path.join(staging, "manifest.json")
+        entries = (json.load(open(manifest_path, encoding="utf-8")).get("entries", [])
+                   if os.path.exists(manifest_path) else [])
+        for entry in entries:
+            built = build_staged_ja_chapters(
+                entry["key"], staging, entry.get("body_file", f"{entry['key']}.txt"),
+                f"REF2:{entry['key']}", shipped,
+            )
+            if built:
+                works.append(built)
+
     if "sefaria" in families and staging and os.path.isdir(staging):
         manifest_path = os.path.join(staging, "manifest.json")
         entries = (json.load(open(manifest_path, encoding="utf-8")).get("entries", [])
@@ -2202,6 +2288,8 @@ corpora are restricted:
             if entry.get("guard_only"):
                 continue
             key = entry["key"]
+            if key == _STAGED_GUIDE_KEY:
+                continue
             versemap = entry.get("versemap_file") or (
                 f"{key}.versemap.json"
                 if os.path.exists(os.path.join(staging, f"{key}.versemap.json")) else None)

--- a/scripts/discovery_v4_build_reference.py
+++ b/scripts/discovery_v4_build_reference.py
@@ -1,0 +1,526 @@
+#!/usr/bin/env python3
+"""Append acquired V4 texts to the frozen V2 reference corpus.
+
+The append is intentionally narrow: existing reference objects are copied byte
+for semantic byte after deserialization, and only acquired/allowlisted V4
+sources are added.  The same run extends the pinned locus-division database so
+new matcher offsets and locus offsets share one exact coordinate system.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import pickle
+import shutil
+import sqlite3
+import sys
+from collections import Counter
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from shared.discovery_locus import daf_label_he, heb_numeral, sefaria_daf
+from scripts.build_work_divisions import WorkUnits, build_staged_ja_chapters
+
+try:
+    from scripts.discovery_v4_common import (
+        compact_stream,
+        load_source_config,
+        normalize_title,
+        require_hash,
+        sha256_file,
+        stable_json_dump,
+    )
+except ModuleNotFoundError:  # direct ``python scripts/...py`` invocation
+    from discovery_v4_common import (
+        compact_stream,
+        load_source_config,
+        normalize_title,
+        require_hash,
+        sha256_file,
+        stable_json_dump,
+    )
+
+
+def raw_reference_id(source_key: str, mapping: dict, mapping_count: int) -> str:
+    if mapping_count == 1:
+        return f"REF4:{source_key}"
+    chapter_range = mapping.get("chapter_range")
+    if chapter_range:
+        suffix = f"{chapter_range[0]}_{chapter_range[1]}"
+    else:
+        suffix = mapping["target_work_id"]
+    return f"REF4:{source_key}:{suffix}"
+
+
+def select_units(units: list[dict], mapping: dict) -> list[dict]:
+    selected = units
+    if mapping.get("chapter_range"):
+        lower, upper = (int(value) for value in mapping["chapter_range"])
+        if lower < 1 or upper < lower:
+            raise ValueError("invalid source chapter_range")
+        selected = [
+            unit for unit in units if lower <= int(unit["ordinal"]) <= upper
+        ]
+        observed = {int(unit["ordinal"]) for unit in selected}
+        expected = set(range(lower, upper + 1))
+        if observed != expected:
+            missing = sorted(expected - observed)
+            raise ValueError(f"chapter_range has missing source units: {missing[:8]}")
+    if not selected:
+        raise ValueError("source mapping selected no units")
+    return selected
+
+
+def _load_private_works(path: Path) -> dict[str, dict]:
+    conn = sqlite3.connect(f"file:{path.resolve().as_posix()}?mode=ro", uri=True)
+    try:
+        return {
+            row[0]: {
+                "title": row[1],
+                "author": row[2] or "",
+                "genre": row[3] or "",
+                "identity_visibility": row[4],
+            }
+            for row in conn.execute(
+                "SELECT work_id, neutral_title, author, genre, identity_visibility FROM works"
+            )
+        }
+    finally:
+        conn.close()
+
+
+def _unit_offsets(units: list[dict]) -> tuple[str, list[tuple[dict, int]]]:
+    chunks = []
+    rows = []
+    offset = 0
+    for unit in units:
+        chunk = compact_stream(unit["text"])
+        if not chunk:
+            continue
+        rows.append((unit, offset))
+        chunks.append(chunk)
+        offset += len(chunk)
+    stream = "".join(chunks)
+    if not stream:
+        raise ValueError("selected source units normalize to an empty stream")
+    return stream, rows
+
+
+def _legacy_reference_metadata_key(corpus: list[dict]) -> str:
+    """Return the research-only field between ``genre`` and ``stream``.
+
+    The frozen matcher indexes that field directly on every reference row, but
+    its name is restricted vocabulary and must not be copied into this public
+    expansion's source code. Deriving it from the pinned base corpus preserves
+    the matcher-compatible mapping shape without introducing a new literal.
+    """
+    if not corpus:
+        raise ValueError("base reference corpus is empty")
+    keys = list(corpus[0])
+    try:
+        genre_pos = keys.index("genre")
+        stream_pos = keys.index("stream")
+    except ValueError as exc:
+        raise ValueError("base reference corpus lacks its frozen mapping shape") from exc
+    if stream_pos != genre_pos + 2:
+        raise ValueError("base reference corpus metadata-field position drift")
+    key = keys[genre_pos + 1]
+    if not isinstance(key, str) or not key:
+        raise ValueError("base reference corpus metadata key is invalid")
+    if any(key not in work for work in corpus):
+        raise ValueError("base reference corpus metadata key is not universal")
+    # The former reviewed builder used one module-literal key object for all
+    # appended mappings. Reusing the unpickled base key changes pickle memo
+    # opcodes despite producing equal Python objects, so make one fresh object
+    # and reuse it to preserve byte-for-byte reference-corpus reproducibility.
+    return key.encode("utf-8").decode("utf-8")
+
+
+def _locus_label(
+    source: dict, mapping: dict, work: dict, unit: dict, grain: str
+) -> tuple[str, int]:
+    ordinal = int(unit["ordinal"])
+    if grain == "daf_bavli":
+        daf, amud = sefaria_daf(ordinal)
+        return daf_label_he(daf, amud), daf * 2 + amud - 1
+    locus_title = source.get("locus_title_he") or work["title"]
+    if grain == "section":
+        unit_label = str(unit.get("label") or "").strip()
+        if normalize_title(unit_label).startswith(normalize_title(locus_title)):
+            return unit_label, ordinal
+        return f"{locus_title}, {unit_label}", ordinal
+    numeral = heb_numeral(ordinal) if 1 <= ordinal <= 999 else str(ordinal)
+    return f"{locus_title} {numeral}", ordinal
+
+
+def _extend_locus(
+    *,
+    base_db: Path,
+    base_coverage: Path,
+    output_db: Path,
+    output_coverage: Path,
+    new_reference_hash: str,
+    reference_entries: list[dict],
+    supplemental_works: list[WorkUnits] | None = None,
+) -> dict:
+    coverage = json.loads(base_coverage.read_text(encoding="utf-8"))
+    if coverage.get("invariant_problems") != []:
+        raise ValueError("base locus coverage reports invariant problems")
+    output_db.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(base_db, output_db)
+    conn = sqlite3.connect(output_db)
+    added_works = 0
+    added_units = 0
+    grain_counts: Counter[str] = Counter()
+    whole_work_refs = 0
+    supplemental_added_works = 0
+    supplemental_added_units = 0
+    supplemental_works = list(supplemental_works or [])
+    try:
+        conn.execute("PRAGMA foreign_keys = ON")
+        for work in supplemental_works:
+            exists = conn.execute(
+                "SELECT 1 FROM locus_work WHERE locus_ref_id=?", (work.ref_id,)
+            ).fetchone()
+            if exists:
+                continue
+            conn.execute(
+                "INSERT INTO locus_work VALUES (?,?,?,?,?)",
+                (work.ref_id, work.family, work.grain, work.stream_len, len(work.units)),
+            )
+            conn.executemany(
+                "INSERT INTO locus_unit VALUES (?,?,?,?,?,?)",
+                [
+                    (
+                        work.ref_id,
+                        unit.unit_ord,
+                        unit.start,
+                        unit.part_key,
+                        unit.label_he,
+                        unit.citation_pos,
+                    )
+                    for unit in work.units
+                ],
+            )
+            supplemental_added_works += 1
+            supplemental_added_units += len(work.units)
+        for entry in reference_entries:
+            unit_rows = entry["unit_offsets"]
+            if len(unit_rows) <= 1:
+                whole_work_refs += 1
+                continue
+            grain = entry["locus_grain"]
+            raw_id = entry["raw_reference_id"]
+            conn.execute(
+                "INSERT INTO locus_work VALUES (?,?,?,?,?)",
+                (raw_id, "sefaria", grain, entry["stream_len"], len(unit_rows)),
+            )
+            for unit_ord, row in enumerate(unit_rows):
+                conn.execute(
+                    "INSERT INTO locus_unit VALUES (?,?,?,?,?,?)",
+                    (
+                        raw_id,
+                        unit_ord,
+                        row["start_offset"],
+                        f"{grain}:{row['source_ordinal']}",
+                        row["label_he"],
+                        row["citation_pos"],
+                    ),
+                )
+            added_works += 1
+            added_units += len(unit_rows)
+            grain_counts[grain] += 1
+        conn.commit()
+        foreign_key_problems = conn.execute("PRAGMA foreign_key_check").fetchall()
+        integrity = conn.execute("PRAGMA integrity_check").fetchone()[0]
+        work_count = conn.execute("SELECT COUNT(*) FROM locus_work").fetchone()[0]
+        unit_count = conn.execute("SELECT COUNT(*) FROM locus_unit").fetchone()[0]
+        families = dict(
+            conn.execute(
+                "SELECT family, COUNT(*) FROM locus_work GROUP BY family ORDER BY family"
+            ).fetchall()
+        )
+        grains = dict(
+            conn.execute(
+                "SELECT grain, COUNT(*) FROM locus_work GROUP BY grain ORDER BY grain"
+            ).fetchall()
+        )
+    finally:
+        conn.close()
+    problems = []
+    if integrity != "ok":
+        problems.append(f"integrity_check={integrity}")
+    if foreign_key_problems:
+        problems.append(f"foreign_key_check={len(foreign_key_problems)}")
+    if work_count != (
+        int(coverage["works_with_units"]) + added_works + supplemental_added_works
+    ):
+        problems.append("work-count drift")
+    if unit_count != (
+        int(coverage["units_total"]) + added_units + supplemental_added_units
+    ):
+        problems.append("unit-count drift")
+    new_coverage = {
+        **coverage,
+        "reference_corpus_sha256": new_reference_hash,
+        "works_with_units": work_count,
+        "units_total": unit_count,
+        "by_family": families,
+        "by_grain": grains,
+        "invariant_problems": problems,
+        "v4_extension": {
+            "added_works_with_units": added_works,
+            "added_units": added_units,
+            "whole_work_fallback_refs": whole_work_refs,
+            "added_by_grain": dict(sorted(grain_counts.items())),
+        },
+        "supplemental_structures": {
+            "added_works_with_units": supplemental_added_works,
+            "added_units": supplemental_added_units,
+            "reference_ids": [work.ref_id for work in supplemental_works],
+        },
+    }
+    stable_json_dump(new_coverage, output_coverage)
+    if problems:
+        raise ValueError(f"extended locus invariant problems: {problems}")
+    return new_coverage
+
+
+def run(args: argparse.Namespace) -> dict:
+    base_ref = Path(args.base_reference)
+    acquisition_manifest_path = Path(args.acquisition_manifest)
+    normalized_dir = Path(args.normalized_dir)
+    source_map_path = Path(args.source_map)
+    private_db = Path(args.private_db)
+    base_locus_db = Path(args.base_locus_db)
+    base_locus_coverage = Path(args.base_locus_coverage)
+    refs_staging = Path(args.refs_staging)
+    output_ref = Path(args.output_reference)
+    output_manifest = Path(args.output_manifest)
+    output_locus_db = Path(args.output_locus_db)
+    output_locus_coverage = Path(args.output_locus_coverage)
+    require_hash(base_ref, args.base_reference_sha256, "base reference corpus")
+    require_hash(
+        acquisition_manifest_path,
+        args.acquisition_manifest_sha256,
+        "V4 acquisition manifest",
+    )
+    require_hash(base_locus_db, args.base_locus_sha256, "base locus database")
+    require_hash(
+        base_locus_coverage, args.base_locus_coverage_sha256, "base locus coverage"
+    )
+    config = load_source_config(source_map_path)
+    config_by_key = {source["key"]: source for source in config["sources"]}
+    acquisition = json.loads(acquisition_manifest_path.read_text(encoding="utf-8"))
+    if acquisition.get("schema_version") != "discovery-v4-acquisition-manifest-v1":
+        raise ValueError("unsupported acquisition manifest schema")
+    if acquisition.get("source_map_sha256") != sha256_file(source_map_path):
+        raise ValueError("acquisition manifest source-map hash mismatch")
+    base_coverage = json.loads(base_locus_coverage.read_text(encoding="utf-8"))
+    if str(base_coverage.get("reference_corpus_sha256", "")).lower() != (
+        args.base_reference_sha256.lower()
+    ):
+        raise ValueError("base locus coverage does not describe the base reference")
+    private_works = _load_private_works(private_db)
+    with base_ref.open("rb") as stream:
+        corpus = pickle.load(stream)
+    if not isinstance(corpus, list):
+        raise ValueError("base reference corpus must be a list")
+    if not refs_staging.is_dir():
+        raise FileNotFoundError(f"refs staging directory not found: {refs_staging}")
+    staging_manifest_path = refs_staging / "manifest.json"
+    if not staging_manifest_path.is_file():
+        raise FileNotFoundError(f"refs staging manifest not found: {staging_manifest_path}")
+    staging_entries = json.loads(
+        staging_manifest_path.read_text(encoding="utf-8")
+    ).get("entries", [])
+    guide_entry = next(
+        (entry for entry in staging_entries if entry.get("key") == "ja2_rambam_moreh"),
+        None,
+    )
+    if guide_entry is None:
+        raise ValueError("staging manifest lacks the Guide for the Perplexed source")
+    shipped = {
+        work["id"]: work["stream"]
+        for work in corpus
+        if isinstance(work, dict) and work.get("id") and work.get("stream") is not None
+    }
+    guide_units = build_staged_ja_chapters(
+        guide_entry["key"],
+        str(refs_staging),
+        guide_entry.get("body_file", "ja2_rambam_moreh.txt"),
+        "REF2:ja2_rambam_moreh",
+        shipped,
+    )
+    if guide_units is None:
+        raise ValueError("Guide chapter structure does not match its pinned stream")
+    existing_ids = {work.get("id") for work in corpus if isinstance(work, dict)}
+    legacy_metadata_key = _legacy_reference_metadata_key(corpus)
+    reference_entries = []
+    for acquired_entry in acquisition["entries"]:
+        if acquired_entry.get("status") != "acquired":
+            continue
+        key = acquired_entry["key"]
+        source = config_by_key.get(key)
+        if source is None:
+            raise ValueError(f"acquired source missing from source map: {key}")
+        normalized_path = normalized_dir / acquired_entry["normalized_file"]
+        require_hash(
+            normalized_path, acquired_entry["normalized_sha256"], f"normalized {key}"
+        )
+        normalized = json.loads(normalized_path.read_text(encoding="utf-8"))
+        if normalized.get("mappings") != source["mappings"]:
+            raise ValueError(f"normalized source mapping drift: {key}")
+        for mapping in source["mappings"]:
+            target_id = mapping["target_work_id"]
+            work = private_works.get(target_id)
+            if work is None or work["identity_visibility"] != "private":
+                raise ValueError(f"V4 target absent or non-private: {target_id}")
+            units = select_units(normalized["units"], mapping)
+            ref_id = raw_reference_id(key, mapping, len(source["mappings"]))
+            if ref_id in existing_ids:
+                raise ValueError(f"new reference id collides with base corpus: {ref_id}")
+            stream, offsets = _unit_offsets(units)
+            grain = source.get("locus_grain") or (
+                "section" if source.get("mode") == "schema_leaves" else "chapter"
+            )
+            locus_rows = []
+            for unit, start_offset in offsets:
+                label, citation_pos = _locus_label(source, mapping, work, unit, grain)
+                locus_rows.append(
+                    {
+                        "source_ordinal": int(unit["ordinal"]),
+                        "start_offset": start_offset,
+                        "label_he": label,
+                        "citation_pos": citation_pos,
+                    }
+                )
+            reference_work = {
+                "id": ref_id,
+                "cat": "Sefaria",
+                "author": work["author"],
+                "title": work["title"],
+                "date": "",
+                "genre": work["genre"],
+                legacy_metadata_key: "",
+                "stream": stream,
+                "title_en": "",
+                "provenance": normalized["provider"],
+                "source_url": normalized["source_url"],
+                "license": normalized["license"],
+                "ref_kind": "public_reference",
+                "vgroup": None,
+                "split_parent": key if len(source["mappings"]) > 1 else None,
+                "split_division": mapping.get("chapter_range"),
+            }
+            corpus.append(reference_work)
+            existing_ids.add(ref_id)
+            reference_entries.append(
+                {
+                    "raw_reference_id": ref_id,
+                    "source_key": key,
+                    "target_private_work_id": target_id,
+                    "title": work["title"],
+                    "provider": normalized["provider"],
+                    "license": normalized["license"],
+                    "source_url": normalized["source_url"],
+                    "source_coverage_status": normalized.get(
+                        "coverage_status", "complete"
+                    ),
+                    "source_missing_pages": normalized.get("missing_pages", []),
+                    "stream_len": len(stream),
+                    "stream_sha256": hashlib.sha256(stream.encode("utf-8")).hexdigest(),
+                    "locus_grain": grain,
+                    "unit_offsets": locus_rows,
+                }
+            )
+    output_ref.parent.mkdir(parents=True, exist_ok=True)
+    with output_ref.open("wb") as stream:
+        pickle.dump(corpus, stream, protocol=4)
+    output_ref_hash = sha256_file(output_ref)
+    locus_coverage = _extend_locus(
+        base_db=base_locus_db,
+        base_coverage=base_locus_coverage,
+        output_db=output_locus_db,
+        output_coverage=output_locus_coverage,
+        new_reference_hash=output_ref_hash,
+        reference_entries=reference_entries,
+        supplemental_works=[guide_units],
+    )
+    report = {
+        "schema_version": "discovery-v4-reference-manifest-v1",
+        "base_reference": str(base_ref.resolve()),
+        "base_reference_sha256": sha256_file(base_ref),
+        "reference_corpus": str(output_ref.resolve()),
+        "reference_corpus_sha256": output_ref_hash,
+        "base_work_count": len(corpus) - len(reference_entries),
+        "new_reference_count": len(reference_entries),
+        "total_work_count": len(corpus),
+        "acquisition_manifest": str(acquisition_manifest_path.resolve()),
+        "acquisition_manifest_sha256": sha256_file(acquisition_manifest_path),
+        "source_map_sha256": sha256_file(source_map_path),
+        "private_db_sha256": sha256_file(private_db),
+        "locus_divisions": str(output_locus_db.resolve()),
+        "locus_divisions_sha256": sha256_file(output_locus_db),
+        "locus_coverage": str(output_locus_coverage.resolve()),
+        "locus_coverage_sha256": sha256_file(output_locus_coverage),
+        "locus_counts": {
+            "works_with_units": locus_coverage["works_with_units"],
+            "units_total": locus_coverage["units_total"],
+        },
+        "locus_supplemental_sources": {
+            "refs_staging_manifest_sha256": sha256_file(staging_manifest_path),
+            "guide_body_sha256": sha256_file(
+                refs_staging / guide_entry.get("body_file", "ja2_rambam_moreh.txt")
+            ),
+            "guide_units": len(guide_units.units),
+        },
+        "entries": reference_entries,
+    }
+    stable_json_dump(report, output_manifest)
+    print(
+        json.dumps(
+            {
+                "reference_corpus_sha256": output_ref_hash,
+                "new_reference_count": len(reference_entries),
+                "total_work_count": len(corpus),
+                "locus_works": locus_coverage["works_with_units"],
+                "locus_units": locus_coverage["units_total"],
+            },
+            indent=2,
+        )
+    )
+    return report
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-reference", required=True)
+    parser.add_argument("--base-reference-sha256", required=True)
+    parser.add_argument("--acquisition-manifest", required=True)
+    parser.add_argument("--acquisition-manifest-sha256", required=True)
+    parser.add_argument("--normalized-dir", required=True)
+    parser.add_argument("--private-db", required=True)
+    parser.add_argument(
+        "--source-map",
+        default=str(Path(__file__).with_name("discovery_v4_sources.json")),
+    )
+    parser.add_argument("--base-locus-db", required=True)
+    parser.add_argument("--base-locus-sha256", required=True)
+    parser.add_argument("--base-locus-coverage", required=True)
+    parser.add_argument("--base-locus-coverage-sha256", required=True)
+    parser.add_argument("--refs-staging", required=True)
+    parser.add_argument("--output-reference", required=True)
+    parser.add_argument("--output-manifest", required=True)
+    parser.add_argument("--output-locus-db", required=True)
+    parser.add_argument("--output-locus-coverage", required=True)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    run(parse_args())

--- a/scripts/discovery_v4_catalog_audit.py
+++ b/scripts/discovery_v4_catalog_audit.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""Audit private discovery works against pinned public catalogue snapshots.
+
+This is the first V4 gate.  It distinguishes an external title hit from an
+actual missing public identity and applies a small curated hierarchy map for
+containers that do not have the same grain as the internal work catalogue.
+The output contains titles because it is a local review artifact; no output of
+this script is shipped in the public discovery database.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import gzip
+import json
+import sqlite3
+from collections import Counter, defaultdict
+from pathlib import Path
+
+try:
+    from scripts.discovery_v4_common import (
+        iter_sefaria_titles,
+        load_source_config,
+        normalize_title,
+        require_hash,
+        sha256_file,
+        source_target_ids,
+        stable_json_dump,
+    )
+except ModuleNotFoundError:  # direct ``python scripts/...py`` invocation
+    from discovery_v4_common import (
+        iter_sefaria_titles,
+        load_source_config,
+        normalize_title,
+        require_hash,
+        sha256_file,
+        source_target_ids,
+        stable_json_dump,
+    )
+
+
+def _load_sefaria(path: Path) -> tuple[list[dict], dict[str, list[dict]]]:
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    rows = list(iter_sefaria_titles(doc))
+    by_title: dict[str, list[dict]] = defaultdict(list)
+    for row in rows:
+        for title in (row.get("title"), row.get("he_title")):
+            if title:
+                by_title[normalize_title(title)].append(row)
+    return rows, dict(by_title)
+
+
+def _load_wikisource(path: Path) -> tuple[int, dict[str, list[str]]]:
+    by_title: dict[str, list[str]] = defaultdict(list)
+    count = 0
+    with gzip.open(path, "rt", encoding="utf-8") as stream:
+        header = next(stream, "").strip()
+        if header != "page_title":
+            raise ValueError("unexpected Wikisource title-dump header")
+        for line in stream:
+            title = line.rstrip("\n").replace("_", " ")
+            if not title:
+                continue
+            count += 1
+            by_title[normalize_title(title)].append(title)
+    return count, dict(by_title)
+
+
+def _work_rows(conn: sqlite3.Connection) -> list[dict]:
+    stats = {
+        row[0]: {
+            "identification_count": int(row[1]),
+            "main_pool_count": int(row[2]),
+            "fragment_count": int(row[3]),
+        }
+        for row in conn.execute(
+            """
+            SELECT canonical_work_id, COUNT(*), SUM(main_pool), COUNT(DISTINCT sys_id)
+            FROM discovery_identification
+            GROUP BY canonical_work_id
+            """
+        )
+    }
+    rows = []
+    for row in conn.execute(
+        """
+        SELECT work_id, canonical_work_id, neutral_title, author, genre,
+               source_corpus, identity_visibility
+        FROM works
+        ORDER BY work_id
+        """
+    ):
+        work_id, canonical_work_id, title, author, genre, corpus, visibility = row
+        rows.append(
+            {
+                "work_id": work_id,
+                "canonical_work_id": canonical_work_id,
+                "title": title,
+                "author": author,
+                "genre": genre,
+                "source_corpus": corpus,
+                "identity_visibility": visibility,
+                **stats.get(
+                    canonical_work_id,
+                    {
+                        "identification_count": 0,
+                        "main_pool_count": 0,
+                        "fragment_count": 0,
+                    },
+                ),
+            }
+        )
+    return rows
+
+
+def run(args: argparse.Namespace) -> dict:
+    private_db = Path(args.private_db)
+    sefaria_path = Path(args.sefaria_index)
+    wiki_path = Path(args.wikisource_titles)
+    source_map_path = Path(args.source_map)
+    for path, label in (
+        (private_db, "private discovery database"),
+        (sefaria_path, "Sefaria index"),
+        (wiki_path, "Wikisource title dump"),
+        (source_map_path, "V4 source map"),
+    ):
+        if not path.is_file():
+            raise FileNotFoundError(f"{label} not found: {path}")
+    require_hash(sefaria_path, args.sefaria_sha256, "Sefaria index")
+    require_hash(wiki_path, args.wikisource_sha256, "Wikisource title dump")
+
+    config = load_source_config(source_map_path)
+    sefaria_rows, sefaria_by_title = _load_sefaria(sefaria_path)
+    wiki_count, wiki_by_title = _load_wikisource(wiki_path)
+
+    conn = sqlite3.connect(f"file:{private_db.as_posix()}?mode=ro", uri=True)
+    try:
+        works = _work_rows(conn)
+    finally:
+        conn.close()
+    works_by_id = {row["work_id"]: row for row in works}
+    public_by_title: dict[str, list[dict]] = defaultdict(list)
+    for row in works:
+        if row["identity_visibility"] == "public":
+            public_by_title[normalize_title(row["title"])].append(row)
+
+    planned = source_target_ids(config)
+    aggregate = {
+        item["work_id"]: item for item in config.get("aggregate_already_covered", [])
+    }
+    false_hits = {
+        item["work_id"]: item for item in config.get("false_title_collisions", [])
+    }
+    overlap = (planned & set(aggregate)) | (planned & set(false_hits)) | (
+        set(aggregate) & set(false_hits)
+    )
+    if overlap:
+        raise ValueError(f"V4 source-map dispositions overlap: {sorted(overlap)}")
+    for work_id in planned | set(aggregate) | set(false_hits):
+        row = works_by_id.get(work_id)
+        if row is None:
+            raise ValueError(f"curated work is absent from private DB: {work_id}")
+        if row["identity_visibility"] != "private":
+            raise ValueError(f"curated target is not private: {work_id}")
+    for item in aggregate.values():
+        for covered_id in item["covered_by"]:
+            covered = works_by_id.get(covered_id)
+            if covered is None or covered["identity_visibility"] != "public":
+                raise ValueError(
+                    f"aggregate coverage member is absent/non-public: {covered_id}"
+                )
+
+    source_by_work: dict[str, dict] = {}
+    source_checks = []
+    for source in config["sources"]:
+        catalogue = sefaria_by_title if source["provider"] == "sefaria" else wiki_by_title
+        present = bool(catalogue.get(normalize_title(source["source_ref"])))
+        if not present:
+            raise ValueError(
+                f"curated {source['provider']} source is absent from pinned catalogue: "
+                f"{source['source_ref']}"
+            )
+        source_checks.append(
+            {
+                "key": source["key"],
+                "provider": source["provider"],
+                "source_ref": source["source_ref"],
+                "catalogue_present": present,
+                "target_count": len(source["mappings"]),
+            }
+        )
+        for mapping in source["mappings"]:
+            source_by_work[mapping["target_work_id"]] = {
+                "source_key": source["key"],
+                "source_provider": source["provider"],
+                "source_ref": source["source_ref"],
+                "chapter_range": mapping.get("chapter_range"),
+            }
+
+    audit_rows = []
+    for work in works:
+        if work["identity_visibility"] != "private":
+            continue
+        key = normalize_title(work["title"])
+        sefaria_matches = sefaria_by_title.get(key, [])
+        wiki_matches = wiki_by_title.get(key, [])
+        public_matches = public_by_title.get(key, [])
+        work_id = work["work_id"]
+        if work_id in source_by_work:
+            disposition = "planned_public_source"
+            note = "Curated high-confidence public source target."
+        elif work_id in aggregate:
+            disposition = "aggregate_already_covered"
+            note = aggregate[work_id]["note"]
+        elif work_id in false_hits:
+            disposition = "false_title_collision"
+            note = false_hits[work_id]["note"]
+        elif public_matches:
+            disposition = "already_public_same_title"
+            note = "A public internal work already has the same normalized title."
+        elif sefaria_matches or wiki_matches:
+            disposition = "unreviewed_exact_external_hit"
+            note = "Exact title hit requires identity and license review."
+        else:
+            disposition = "no_exact_external_hit"
+            note = "No exact normalized title in either pinned catalogue."
+        audit_rows.append(
+            {
+                **work,
+                "normalized_title": key,
+                "sefaria_exact_titles": sorted(
+                    {row.get("title") or "" for row in sefaria_matches if row.get("title")}
+                ),
+                "wikisource_exact_titles": sorted(set(wiki_matches)),
+                "public_same_title_work_ids": sorted(
+                    row["work_id"] for row in public_matches
+                ),
+                "disposition": disposition,
+                "note": note,
+                **source_by_work.get(work_id, {}),
+            }
+        )
+
+    audit_rows.sort(
+        key=lambda row: (
+            row["disposition"] != "planned_public_source",
+            -row["main_pool_count"],
+            -row["identification_count"],
+            row["work_id"],
+        )
+    )
+    disposition_counts = Counter(row["disposition"] for row in audit_rows)
+    planned_rows = [
+        row for row in audit_rows if row["disposition"] == "planned_public_source"
+    ]
+    report = {
+        "schema_version": "discovery-v4-catalog-audit-v1",
+        "inputs": {
+            "private_db": str(private_db.resolve()),
+            "private_db_sha256": sha256_file(private_db),
+            "sefaria_index": str(sefaria_path.resolve()),
+            "sefaria_index_sha256": sha256_file(sefaria_path),
+            "wikisource_titles": str(wiki_path.resolve()),
+            "wikisource_titles_sha256": sha256_file(wiki_path),
+            "source_map": str(source_map_path.resolve()),
+            "source_map_sha256": sha256_file(source_map_path),
+        },
+        "catalogues": {
+            "sefaria_title_nodes": len(sefaria_rows),
+            "wikisource_namespace0_titles": wiki_count,
+        },
+        "summary": {
+            "private_works": len(audit_rows),
+            "planned_target_work_ids": len(planned),
+            "planned_external_sources": len(config["sources"]),
+            "planned_identifications": sum(
+                row["identification_count"] for row in planned_rows
+            ),
+            "planned_main_pool_identifications": sum(
+                row["main_pool_count"] for row in planned_rows
+            ),
+            "planned_fragments": sum(row["fragment_count"] for row in planned_rows),
+            "dispositions": dict(sorted(disposition_counts.items())),
+        },
+        "source_checks": source_checks,
+        "works": audit_rows,
+    }
+    output_json = Path(args.output_json)
+    output_csv = Path(args.output_csv)
+    output_md = Path(args.output_md)
+    for output in (output_json, output_csv, output_md):
+        output.parent.mkdir(parents=True, exist_ok=True)
+    stable_json_dump(report, output_json)
+    columns = [
+        "work_id",
+        "title",
+        "author",
+        "genre",
+        "identification_count",
+        "main_pool_count",
+        "fragment_count",
+        "disposition",
+        "source_key",
+        "source_provider",
+        "source_ref",
+        "chapter_range",
+        "note",
+    ]
+    with output_csv.open("w", encoding="utf-8-sig", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=columns, extrasaction="ignore")
+        writer.writeheader()
+        for row in audit_rows:
+            csv_row = dict(row)
+            if csv_row.get("chapter_range"):
+                csv_row["chapter_range"] = "-".join(
+                    str(value) for value in csv_row["chapter_range"]
+                )
+            writer.writerow(csv_row)
+    summary = report["summary"]
+    lines = [
+        "# Discovery V4 public-catalogue audit",
+        "",
+        f"- Private works audited: {summary['private_works']:,}",
+        f"- Planned target identities: {summary['planned_target_work_ids']:,}",
+        f"- External source containers: {summary['planned_external_sources']:,}",
+        f"- Current identifications on those targets: {summary['planned_identifications']:,}",
+        f"- Current main-pool identifications: {summary['planned_main_pool_identifications']:,}",
+        "",
+        "## Dispositions",
+        "",
+    ]
+    lines.extend(
+        f"- `{name}`: {count:,}"
+        for name, count in sorted(summary["dispositions"].items())
+    )
+    lines.extend(["", "## Planned targets", "", "| Work | Title | Provider | Source | IDs | Main |", "|---|---|---|---|---:|---:|"])
+    for row in planned_rows:
+        title = str(row["title"]).replace("|", "\\|")
+        source_ref = str(row["source_ref"]).replace("|", "\\|")
+        lines.append(
+            f"| {row['work_id']} | {title} | {row['source_provider']} | "
+            f"{source_ref} | {row['identification_count']:,} | {row['main_pool_count']:,} |"
+        )
+    output_md.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return report
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--private-db", required=True)
+    parser.add_argument("--sefaria-index", required=True)
+    parser.add_argument("--sefaria-sha256", required=True)
+    parser.add_argument("--wikisource-titles", required=True)
+    parser.add_argument("--wikisource-sha256", required=True)
+    parser.add_argument(
+        "--source-map",
+        default=str(Path(__file__).with_name("discovery_v4_sources.json")),
+    )
+    parser.add_argument("--output-json", required=True)
+    parser.add_argument("--output-csv", required=True)
+    parser.add_argument("--output-md", required=True)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    result = run(parse_args())
+    print(json.dumps(result["summary"], ensure_ascii=False, indent=2))

--- a/scripts/discovery_v4_common.py
+++ b/scripts/discovery_v4_common.py
@@ -1,0 +1,178 @@
+"""Shared helpers for the Discovery V4 public-reference expansion.
+
+The V4 pipeline deliberately keeps acquired text and generated artifacts out of
+the repository.  Only the deterministic transformations and the curated source
+map are tracked.  This module contains the small, dependency-free primitives
+shared by the audit, acquisition, and reference-build stages.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import unicodedata
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+
+HEBREW_LETTER_RE = re.compile(r"[\u05d0-\u05ea]")
+FINAL_LETTER_FOLD = str.maketrans({"ך": "כ", "ם": "מ", "ן": "נ", "ף": "פ", "ץ": "צ"})
+_TITLE_PUNCT_RE = re.compile(r"[\"'׳״“”„‘’`´]+")
+_TITLE_OTHER_RE = re.compile(r"[^\u05d0-\u05eaA-Za-z0-9]+")
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def sha256_file(path: str | Path) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def stable_json_dump(value: Any, path: str | Path) -> None:
+    Path(path).write_text(
+        json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def normalize_title(value: str | None) -> str:
+    """Return a deliberately conservative Hebrew/Latin title comparison key."""
+    text = unicodedata.normalize("NFKC", value or "").replace("_", " ")
+    text = "".join(
+        char
+        for char in text
+        if unicodedata.category(char) not in {"Mn", "Cf"}
+    )
+    text = _TITLE_PUNCT_RE.sub("", text)
+    text = _TITLE_OTHER_RE.sub(" ", text)
+    return " ".join(text.split()).casefold()
+
+
+def clean_hebrew(value: str | None) -> str:
+    """Normalize acquired text to the matcher stream alphabet.
+
+    This mirrors the established REF-2 convention: Hebrew letters survive,
+    maqaf becomes a boundary, and every other character is a boundary.  Final
+    letters are intentionally preserved; the downstream matcher owns any
+    folding it performs.
+    """
+    text = unicodedata.normalize("NFKD", value or "")
+    chars: list[str] = []
+    pending_space = False
+    for char in text:
+        if unicodedata.category(char) in {"Mn", "Cf"}:
+            continue
+        if HEBREW_LETTER_RE.fullmatch(char):
+            if pending_space and chars:
+                chars.append(" ")
+            chars.append(char)
+            pending_space = False
+        else:
+            pending_space = True
+    return "".join(chars).strip()
+
+
+def compact_stream(value: str) -> str:
+    """Return the established matcher stream: space-free, finals folded."""
+    return value.replace(" ", "").translate(FINAL_LETTER_FOLD)
+
+
+def count_hebrew_letters(value: str) -> int:
+    return len(HEBREW_LETTER_RE.findall(value))
+
+
+def flatten_text_node(value: Any) -> Iterator[str]:
+    """Yield textual leaves from an arbitrarily nested Sefaria text node."""
+    if isinstance(value, str):
+        if value.strip():
+            yield value
+        return
+    if isinstance(value, list):
+        for child in value:
+            yield from flatten_text_node(child)
+
+
+def iter_sefaria_titles(value: Any, path: tuple[str, ...] = ()) -> Iterator[dict]:
+    """Flatten a Sefaria table-of-contents response into title-bearing nodes."""
+    if isinstance(value, list):
+        for child in value:
+            yield from iter_sefaria_titles(child, path)
+        return
+    if not isinstance(value, dict):
+        return
+    category = value.get("category") or value.get("heCategory")
+    child_path = path + ((str(category),) if category else ())
+    if value.get("title") or value.get("heTitle"):
+        yield {
+            "title": value.get("title"),
+            "he_title": value.get("heTitle"),
+            "categories": list(value.get("categories") or []),
+            "toc_path": list(child_path),
+        }
+    for child in value.get("contents") or []:
+        yield from iter_sefaria_titles(child, child_path)
+
+
+def load_source_config(path: str | Path) -> dict:
+    doc = json.loads(Path(path).read_text(encoding="utf-8"))
+    if doc.get("schema_version") != "discovery-v4-sources-v1":
+        raise ValueError("unsupported or missing V4 source-map schema_version")
+    sources = doc.get("sources")
+    if not isinstance(sources, list) or not sources:
+        raise ValueError("V4 source map must contain a non-empty sources list")
+    seen_keys: set[str] = set()
+    seen_work_ids: set[str] = set()
+    for source in sources:
+        key = source.get("key")
+        if not isinstance(key, str) or not re.fullmatch(r"[a-z0-9_]+", key):
+            raise ValueError(f"invalid source key: {key!r}")
+        if key in seen_keys:
+            raise ValueError(f"duplicate source key: {key}")
+        seen_keys.add(key)
+        if source.get("provider") not in {"sefaria", "hewikisource"}:
+            raise ValueError(f"invalid provider for {key}")
+        mappings = source.get("mappings")
+        if not isinstance(mappings, list) or not mappings:
+            raise ValueError(f"source {key} must have mappings")
+        for mapping in mappings:
+            work_id = mapping.get("target_work_id")
+            if not isinstance(work_id, str) or not re.fullmatch(r"w[0-9]{6}", work_id):
+                raise ValueError(f"source {key} has invalid target_work_id")
+            if work_id in seen_work_ids:
+                raise ValueError(f"target work appears more than once: {work_id}")
+            seen_work_ids.add(work_id)
+    return doc
+
+
+def source_target_ids(config: dict) -> set[str]:
+    return {
+        mapping["target_work_id"]
+        for source in config["sources"]
+        for mapping in source["mappings"]
+    }
+
+
+def require_hash(path: str | Path, expected: str, label: str) -> None:
+    actual = sha256_file(path)
+    if actual != expected:
+        raise ValueError(
+            f"{label} SHA-256 mismatch: expected {expected}, got {actual}"
+        )
+
+
+def strip_html_tags(value: str) -> str:
+    return _HTML_TAG_RE.sub(" ", value)
+
+
+def merge_ranges(ranges: Iterable[tuple[int, int]]) -> list[tuple[int, int]]:
+    ordered = sorted((start, end) for start, end in ranges if end > start)
+    merged: list[tuple[int, int]] = []
+    for start, end in ordered:
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+    return merged

--- a/scripts/discovery_v4_extend_masks.py
+++ b/scripts/discovery_v4_extend_masks.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Compute canonical-text masks only for the references appended by V4."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pickle
+import sys
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+try:
+    from scripts.discovery_v4_common import require_hash, sha256_file, stable_json_dump
+except ModuleNotFoundError:  # direct invocation
+    from discovery_v4_common import require_hash, sha256_file, stable_json_dump
+
+
+CANONICAL_CATEGORIES = {"Bible", "Mishnah", "Tosefta", "Bavli", "Yerushalmi"}
+
+
+def run(args: argparse.Namespace) -> dict:
+    probe_root = Path(args.probe_root).resolve()
+    scripts_dir = probe_root / "scripts"
+    if not scripts_dir.is_dir():
+        raise FileNotFoundError(f"research scripts directory not found: {scripts_dir}")
+    sys.path.insert(0, str(scripts_dir))
+    from mask_ref_canon import mask_edited_works, mask_one_work  # noqa: PLC0415
+    from track1_match import build_ref_index  # noqa: PLC0415
+
+    base_reference = Path(args.base_reference)
+    v4_reference = Path(args.v4_reference)
+    base_masks_path = Path(args.base_masks)
+    output_path = Path(args.output)
+    require_hash(base_reference, args.base_reference_sha256, "base reference")
+    require_hash(v4_reference, args.v4_reference_sha256, "V4 reference")
+    require_hash(base_masks_path, args.base_masks_sha256, "base canonical masks")
+    with base_reference.open("rb") as stream:
+        base = pickle.load(stream)
+    with v4_reference.open("rb") as stream:
+        v4 = pickle.load(stream)
+    if v4[: len(base)] != base:
+        raise ValueError("V4 reference does not preserve the complete base-corpus prefix")
+    appended = v4[len(base) :]
+    if not appended or any(not work.get("id", "").startswith("REF4:") for work in appended):
+        raise ValueError("V4 reference append set is missing or contains a non-REF4 id")
+    canonical = [work for work in v4 if work.get("cat") in CANONICAL_CATEGORIES]
+    index = build_ref_index(canonical)
+    stats: Counter[str] = Counter()
+    if args.workers == 1:
+        new_masks = mask_edited_works(appended, *index[:-1], stats)
+    else:
+        seg_streams, _seg_work, _seg_off, codes_f, seg_f, pos_f = index[:-1]
+
+        def mask_one(work):
+            local: Counter[str] = Counter()
+            merged = mask_one_work(
+                work["stream"], seg_streams, codes_f, seg_f, pos_f, local
+            )
+            return work["id"], merged, local
+
+        new_masks = {}
+        completed = 0
+        with ThreadPoolExecutor(max_workers=args.workers) as executor:
+            futures = [executor.submit(mask_one, work) for work in appended]
+            for future in as_completed(futures):
+                raw_id, merged, local = future.result()
+                stats.update(local)
+                if merged:
+                    new_masks[raw_id] = merged
+                completed += 1
+                print(
+                    f"canonical masks: {completed}/{len(appended)} references complete",
+                    flush=True,
+                )
+    base_masks = json.loads(base_masks_path.read_text(encoding="utf-8"))
+    overlap = set(base_masks) & set(new_masks)
+    if overlap:
+        raise ValueError("V4 mask ids collide with the base mask set")
+    merged = {**base_masks, **new_masks}
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    stable_json_dump(merged, output_path)
+    report = {
+        "schema_version": "discovery-v4-canonical-masks-v1",
+        "base_reference_sha256": sha256_file(base_reference),
+        "v4_reference_sha256": sha256_file(v4_reference),
+        "base_masks_sha256": sha256_file(base_masks_path),
+        "output_masks_sha256": sha256_file(output_path),
+        "appended_reference_count": len(appended),
+        "new_masked_reference_count": len(new_masks),
+        "new_masked_letters": sum(
+            end - start for ranges in new_masks.values() for start, end in ranges
+        ),
+        "total_masked_reference_count": len(merged),
+        "workers": args.workers,
+        "stats": dict(stats),
+    }
+    stable_json_dump(report, output_path.with_suffix(".report.json"))
+    print(json.dumps(report, indent=2))
+    return report
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--probe-root", required=True)
+    parser.add_argument("--base-reference", required=True)
+    parser.add_argument("--base-reference-sha256", required=True)
+    parser.add_argument("--v4-reference", required=True)
+    parser.add_argument("--v4-reference-sha256", required=True)
+    parser.add_argument("--base-masks", required=True)
+    parser.add_argument("--base-masks-sha256", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--workers", type=int, default=1)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    parsed = parse_args()
+    if parsed.workers <= 0:
+        raise ValueError("--workers must be positive")
+    run(parsed)

--- a/scripts/discovery_v4_fetch_sources.py
+++ b/scripts/discovery_v4_fetch_sources.py
@@ -1,0 +1,619 @@
+#!/usr/bin/env python3
+"""Acquire and normalize the curated Discovery V4 public source set.
+
+Every network response is persisted under the ignored output directory and is
+covered by the acquisition manifest.  Licenses fail closed: only the allowlist
+in ``discovery_v4_sources.json`` can produce an acquired source.  Unknown,
+non-commercial, and no-derivatives versions are quarantined.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import html
+import json
+import re
+import time
+import urllib.parse
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Any
+
+import requests
+
+try:
+    from scripts.discovery_v4_common import (
+        clean_hebrew,
+        count_hebrew_letters,
+        flatten_text_node,
+        load_source_config,
+        sha256_file,
+        stable_json_dump,
+    )
+except ModuleNotFoundError:  # direct ``python scripts/...py`` invocation
+    from discovery_v4_common import (
+        clean_hebrew,
+        count_hebrew_letters,
+        flatten_text_node,
+        load_source_config,
+        sha256_file,
+        stable_json_dump,
+    )
+
+
+SEFARIA_BASE = "https://www.sefaria.org"
+WIKISOURCE_API = "https://he.wikisource.org/w/api.php"
+WIKISOURCE_LICENSE = "CC-BY-SA"
+WIKISOURCE_LICENSE_URL = "https://creativecommons.org/licenses/by-sa/4.0/"
+USER_AGENT = (
+    "GenizahSearchDiscoveryV4/1.0 "
+    "(https://genizahsearch.com; public-text research corpus)"
+)
+_LICENSE_RANK = {
+    "public domain": 0,
+    "cc0": 1,
+    "cc-by": 2,
+    "cc by": 2,
+    "cc-by-sa": 3,
+    "cc by-sa": 3,
+}
+_LICENSE_URL = {
+    "public domain": None,
+    "cc0": "https://creativecommons.org/publicdomain/zero/1.0/",
+    "cc-by": "https://creativecommons.org/licenses/by/4.0/",
+    "cc by": "https://creativecommons.org/licenses/by/4.0/",
+    "cc-by-sa": WIKISOURCE_LICENSE_URL,
+    "cc by-sa": WIKISOURCE_LICENSE_URL,
+}
+_HEBREW_NUMERAL_VALUES = {
+    "א": 1,
+    "ב": 2,
+    "ג": 3,
+    "ד": 4,
+    "ה": 5,
+    "ו": 6,
+    "ז": 7,
+    "ח": 8,
+    "ט": 9,
+    "י": 10,
+    "כ": 20,
+    "ך": 20,
+    "ל": 30,
+    "מ": 40,
+    "ם": 40,
+    "נ": 50,
+    "ן": 50,
+    "ס": 60,
+    "ע": 70,
+    "פ": 80,
+    "ף": 80,
+    "צ": 90,
+    "ץ": 90,
+    "ק": 100,
+    "ר": 200,
+    "ש": 300,
+    "ת": 400,
+}
+
+
+class _VisibleTextParser(HTMLParser):
+    _SKIP_TAGS = {"script", "style"}
+    _SKIP_CLASSES = {
+        "mw-editsection",
+        "reference",
+        "references",
+        "navbox",
+        "metadata",
+        "noprint",
+    }
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._skip_depth = 0
+        self._parts: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        classes = set(dict(attrs).get("class", "").split())
+        if self._skip_depth or tag in self._SKIP_TAGS or classes & self._SKIP_CLASSES:
+            self._skip_depth += 1
+        elif tag in {"p", "div", "br", "li", "h1", "h2", "h3", "h4", "td"}:
+            self._parts.append(" ")
+
+    def handle_endtag(self, tag: str) -> None:
+        if self._skip_depth:
+            self._skip_depth -= 1
+        elif tag in {"p", "div", "li", "h1", "h2", "h3", "h4", "td"}:
+            self._parts.append(" ")
+
+    def handle_data(self, data: str) -> None:
+        if not self._skip_depth:
+            self._parts.append(data)
+
+    def text(self) -> str:
+        return " ".join(html.unescape("".join(self._parts)).split())
+
+
+def visible_text(value: str) -> str:
+    parser = _VisibleTextParser()
+    parser.feed(value)
+    parser.close()
+    return parser.text()
+
+
+def hebrew_numeral(value: str) -> int | None:
+    if any(char.isspace() for char in value.strip()):
+        return None
+    letters = [char for char in value if char in _HEBREW_NUMERAL_VALUES]
+    residue = re.sub(r"[\u05d0-\u05ea׳״'\"]", "", value).strip()
+    if not letters or residue:
+        return None
+    return sum(_HEBREW_NUMERAL_VALUES[char] for char in letters)
+
+
+def select_chapter_links(links: list[dict], prefix: str) -> list[tuple[int, str]]:
+    selected = []
+    for link in links:
+        if link.get("ns") != 0 or link.get("missing"):
+            continue
+        title = link.get("title") or ""
+        if not title.startswith(prefix):
+            continue
+        ordinal = hebrew_numeral(title[len(prefix) :])
+        if ordinal is not None:
+            selected.append((ordinal, title))
+    selected.sort(key=lambda item: (item[0], item[1]))
+    ordinals = [item[0] for item in selected]
+    if len(ordinals) != len(set(ordinals)):
+        raise ValueError(f"chapter link prefix produces duplicate ordinals: {prefix}")
+    return selected
+
+
+def _primary_title(node: dict, lang: str) -> str | None:
+    for title in node.get("titles") or []:
+        if title.get("lang") == lang and title.get("primary"):
+            return title.get("text")
+    key = "title" if lang == "en" else "heTitle"
+    return node.get(key)
+
+
+def _schema_leaf_refs(source_ref: str, schema: dict) -> list[tuple[str, str, str]]:
+    leaves: list[tuple[str, str, str]] = []
+
+    def walk(
+        node: dict,
+        path_en: tuple[str, ...],
+        path_he: tuple[str, ...],
+        *,
+        include_title: bool = True,
+    ) -> None:
+        title_en = _primary_title(node, "en")
+        title_he = _primary_title(node, "he")
+        default = bool(node.get("default"))
+        next_en = path_en + (
+            (title_en,) if include_title and title_en and not default else ()
+        )
+        next_he = path_he + (
+            (title_he,) if include_title and title_he and not default else ()
+        )
+        children = node.get("nodes") or []
+        if children:
+            for child in children:
+                walk(child, next_en, next_he)
+            return
+        leaf_ref = ", ".join((source_ref, *next_en)) if next_en else source_ref
+        leaves.append(
+            (
+                leaf_ref,
+                " / ".join(next_en) or source_ref,
+                " / ".join(next_he),
+            )
+        )
+
+    # The root schema title is the index title already present in ``source_ref``.
+    # Including it would fabricate refs such as ``Index, Index, Leaf``.
+    walk(schema, (), (), include_title=False)
+    unique = []
+    seen = set()
+    for leaf in leaves:
+        if leaf[0] not in seen:
+            seen.add(leaf[0])
+            unique.append(leaf)
+    return unique
+
+
+class Fetcher:
+    def __init__(self, output_dir: Path, *, timeout: int = 60) -> None:
+        self.output_dir = output_dir
+        self.raw_dir = output_dir / "raw"
+        self.normalized_dir = output_dir / "normalized"
+        self.raw_dir.mkdir(parents=True, exist_ok=True)
+        self.normalized_dir.mkdir(parents=True, exist_ok=True)
+        self.timeout = timeout
+        self.session = requests.Session()
+        self.session.headers.update({"User-Agent": USER_AGENT})
+
+    def get_json(self, url: str, *, params: dict | None, raw_path: Path) -> dict:
+        error: Exception | None = None
+        for attempt in range(4):
+            try:
+                response = self.session.get(
+                    url, params=params, timeout=self.timeout, allow_redirects=True
+                )
+                response.raise_for_status()
+                raw_path.parent.mkdir(parents=True, exist_ok=True)
+                raw_path.write_bytes(response.content)
+                return response.json()
+            except (requests.RequestException, ValueError) as exc:
+                error = exc
+                if attempt < 3:
+                    time.sleep(1.5 * (attempt + 1))
+        raise RuntimeError(f"request failed after retries: {url}: {error}")
+
+    def sefaria_text(self, ref: str, version: str, raw_path: Path) -> dict:
+        url = f"{SEFARIA_BASE}/api/v3/texts/{urllib.parse.quote(ref, safe='')}"
+        return self.get_json(url, params={"version": version}, raw_path=raw_path)
+
+    def sefaria_index(self, ref: str, raw_path: Path) -> dict:
+        url = f"{SEFARIA_BASE}/api/index/{urllib.parse.quote(ref, safe='')}"
+        return self.get_json(url, params=None, raw_path=raw_path)
+
+    def wikisource_parse(self, page: str, raw_path: Path) -> dict:
+        return self.get_json(
+            WIKISOURCE_API,
+            params={
+                "action": "parse",
+                "page": page,
+                "prop": "text|links|revid|displaytitle",
+                "format": "json",
+                "formatversion": "2",
+                "redirects": "1",
+            },
+            raw_path=raw_path,
+        )
+
+
+def _license_key(value: str | None) -> str:
+    return str(value or "").strip().casefold()
+
+
+def _pick_open_hebrew_version(available: list[dict], allowlist: set[str]) -> dict:
+    candidates = [
+        version
+        for version in available
+        if version.get("language") == "he"
+        and _license_key(version.get("license")) in allowlist
+    ]
+    if not candidates:
+        seen = sorted(
+            {
+                str(version.get("license") or "unknown")
+                for version in available
+                if version.get("language") == "he"
+            }
+        )
+        raise ValueError(f"no allowlisted Hebrew version; observed licenses={seen}")
+    candidates.sort(
+        key=lambda version: (
+            _LICENSE_RANK.get(_license_key(version.get("license")), 99),
+            not bool(version.get("isPrimary")),
+            str(version.get("versionTitle") or ""),
+        )
+    )
+    return candidates[0]
+
+
+def _units_from_nested_text(text: Any, ref: str) -> list[dict]:
+    if not isinstance(text, list):
+        text = [text]
+    units = []
+    for ordinal, node in enumerate(text, start=1):
+        cleaned = clean_hebrew(" ".join(flatten_text_node(node)))
+        if cleaned:
+            units.append(
+                {
+                    "ordinal": ordinal,
+                    "label": f"{ref} {ordinal}",
+                    "provider_ref": f"{ref} {ordinal}",
+                    "text": cleaned,
+                    "hebrew_letters": count_hebrew_letters(cleaned),
+                }
+            )
+    return units
+
+
+def _acquire_sefaria(
+    fetcher: Fetcher, source: dict, allowlist: set[str]
+) -> tuple[dict, list[Path]]:
+    key = source["key"]
+    ref = source["source_ref"]
+    raw_paths: list[Path] = []
+    if source.get("mode") == "schema_leaves":
+        index_path = fetcher.raw_dir / key / "index.json"
+        index = fetcher.sefaria_index(ref, index_path)
+        raw_paths.append(index_path)
+        schema = index.get("schema")
+        if not isinstance(schema, dict):
+            raise ValueError("Sefaria index response has no schema")
+        leaves = _schema_leaf_refs(ref, schema)
+        if not leaves:
+            raise ValueError("Sefaria schema contains no text leaves")
+        probe_path = fetcher.raw_dir / key / "leaf-0000-all.json"
+        probe = fetcher.sefaria_text(leaves[0][0], "all", probe_path)
+        raw_paths.append(probe_path)
+        if probe.get("error"):
+            raise ValueError(f"Sefaria leaf metadata error: {probe['error']}")
+        best = _pick_open_hebrew_version(probe.get("available_versions") or [], allowlist)
+        version_title = best.get("versionTitle")
+        units = []
+        for ordinal, (leaf_ref, label_en, label_he) in enumerate(leaves, start=1):
+            leaf_path = fetcher.raw_dir / key / f"leaf-{ordinal:04d}.json"
+            doc = fetcher.sefaria_text(
+                leaf_ref, f"hebrew|{version_title}", leaf_path
+            )
+            raw_paths.append(leaf_path)
+            if doc.get("error"):
+                raise ValueError(f"Sefaria leaf fetch failed for {leaf_ref}: {doc['error']}")
+            versions = doc.get("versions") or []
+            text = versions[0].get("text") if versions else None
+            cleaned = clean_hebrew(" ".join(flatten_text_node(text)))
+            if cleaned:
+                units.append(
+                    {
+                        "ordinal": ordinal,
+                        "label": label_he or label_en,
+                        "provider_ref": leaf_ref,
+                        "text": cleaned,
+                        "hebrew_letters": count_hebrew_letters(cleaned),
+                    }
+                )
+    else:
+        all_path = fetcher.raw_dir / key / "all.json"
+        metadata = fetcher.sefaria_text(ref, "all", all_path)
+        raw_paths.append(all_path)
+        if metadata.get("error"):
+            raise ValueError(f"Sefaria text metadata error: {metadata['error']}")
+        best = _pick_open_hebrew_version(
+            metadata.get("available_versions") or [], allowlist
+        )
+        version_title = best.get("versionTitle")
+        text_path = fetcher.raw_dir / key / "selected.json"
+        selected = fetcher.sefaria_text(
+            ref, f"hebrew|{version_title}", text_path
+        )
+        raw_paths.append(text_path)
+        if selected.get("error"):
+            raise ValueError(f"Sefaria selected-version error: {selected['error']}")
+        versions = selected.get("versions") or []
+        if not versions:
+            raise ValueError("Sefaria selected version response has no versions")
+        units = _units_from_nested_text(versions[0].get("text"), ref)
+    license_name = str(best.get("license") or "")
+    license_key = _license_key(license_name)
+    return (
+        {
+            "provider": "sefaria",
+            "source_ref": ref,
+            "source_url": f"{SEFARIA_BASE}/{urllib.parse.quote(ref.replace(' ', '_'))}",
+            "version_title": version_title,
+            "version_source": best.get("versionSource"),
+            "license": license_name,
+            "license_url": _LICENSE_URL.get(license_key),
+            "attribution": (
+                f'"{ref}", version "{version_title}", via Sefaria.org.'
+            ),
+            "units": units,
+        },
+        raw_paths,
+    )
+
+
+def _acquire_wikisource(fetcher: Fetcher, source: dict) -> tuple[dict, list[Path]]:
+    key = source["key"]
+    ref = source["source_ref"]
+    main_path = fetcher.raw_dir / key / "page-0000.json"
+    main = fetcher.wikisource_parse(ref, main_path)
+    raw_paths = [main_path]
+    if main.get("error"):
+        raise ValueError(f"Wikisource parse error: {main['error']}")
+    parsed = main.get("parse") or {}
+    selected: list[tuple[int, str]]
+    if source.get("link_prefix"):
+        selected = select_chapter_links(
+            parsed.get("links") or [], source["link_prefix"]
+        )
+        if not selected:
+            raise ValueError("Wikisource table of contents yielded no chapter links")
+    else:
+        selected = [(1, parsed.get("title") or ref)]
+    units = []
+    revisions = []
+    missing_pages = []
+    for position, (ordinal, page) in enumerate(selected, start=1):
+        if position == 1 and page == (parsed.get("title") or ref) and len(selected) == 1:
+            doc = main
+        else:
+            page_path = fetcher.raw_dir / key / f"page-{position:04d}.json"
+            doc = fetcher.wikisource_parse(page, page_path)
+            raw_paths.append(page_path)
+        if doc.get("error"):
+            missing_pages.append({"page": page, "error": doc["error"].get("code")})
+            continue
+        item = doc.get("parse") or {}
+        cleaned = clean_hebrew(visible_text(item.get("text") or ""))
+        if cleaned:
+            units.append(
+                {
+                    "ordinal": ordinal,
+                    "label": item.get("title") or page,
+                    "provider_ref": item.get("title") or page,
+                    "revision_id": item.get("revid"),
+                    "text": cleaned,
+                    "hebrew_letters": count_hebrew_letters(cleaned),
+                }
+            )
+        revisions.append(
+            {"page": item.get("title") or page, "revision_id": item.get("revid")}
+        )
+    canonical_title = parsed.get("title") or ref
+    return (
+        {
+            "provider": "hewikisource",
+            "source_ref": ref,
+            "source_url": "https://he.wikisource.org/wiki/"
+            + urllib.parse.quote(canonical_title.replace(" ", "_")),
+            "version_title": "Hebrew Wikisource revision snapshot",
+            "license": WIKISOURCE_LICENSE,
+            "license_url": WIKISOURCE_LICENSE_URL,
+            "attribution": f'"{canonical_title}", Hebrew Wikisource contributors.',
+            "revisions": revisions,
+            "coverage_status": "partial" if missing_pages else "complete",
+            "missing_pages": missing_pages,
+            "units": units,
+        },
+        raw_paths,
+    )
+
+
+def _combined_raw_hash(paths: list[Path]) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(paths, key=lambda item: str(item)):
+        digest.update(path.name.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(bytes.fromhex(sha256_file(path)))
+    return digest.hexdigest()
+
+
+def run(args: argparse.Namespace) -> dict:
+    config_path = Path(args.source_map)
+    config = load_source_config(config_path)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    allowlist = {_license_key(value) for value in config["license_allowlist"]}
+    minimum = int(config["minimum_hebrew_letters"])
+    fetcher = Fetcher(output_dir, timeout=args.timeout)
+    entries = []
+    for source in config["sources"]:
+        print(f"[{source['provider']}] {source['key']}: {source['source_ref']}", flush=True)
+        normalized_path = output_dir / "normalized" / f"{source['key']}.json"
+        try:
+            if args.reuse_existing and normalized_path.is_file():
+                acquired = json.loads(normalized_path.read_text(encoding="utf-8"))
+                if acquired.get("mappings") != source["mappings"]:
+                    raise ValueError("existing normalized source mapping drift")
+                if acquired.get("provider") != source["provider"]:
+                    raise ValueError("existing normalized source provider drift")
+                if _license_key(acquired.get("license")) not in allowlist:
+                    raise ValueError("existing normalized source license is not allowlisted")
+                raw_paths = sorted((output_dir / "raw" / source["key"]).glob("*.json"))
+                if not raw_paths:
+                    raise ValueError("existing normalized source has no raw responses")
+            elif source["provider"] == "sefaria":
+                acquired, raw_paths = _acquire_sefaria(fetcher, source, allowlist)
+            else:
+                acquired, raw_paths = _acquire_wikisource(fetcher, source)
+            total_letters = sum(unit["hebrew_letters"] for unit in acquired["units"])
+            if total_letters < minimum:
+                raise ValueError(
+                    f"usable Hebrew text below minimum: {total_letters} < {minimum}"
+                )
+            normalized = {
+                "schema_version": "discovery-v4-acquired-source-v1",
+                "key": source["key"],
+                **acquired,
+                "mappings": source["mappings"],
+                "transformation": (
+                    "HTML markup and non-content UI removed; Unicode decomposed; "
+                    "combining marks, punctuation, digits, and non-Hebrew characters "
+                    "removed; word boundaries retained; final-letter forms preserved."
+                ),
+            }
+            stable_json_dump(normalized, normalized_path)
+            entries.append(
+                {
+                    "key": source["key"],
+                    "provider": source["provider"],
+                    "status": "acquired",
+                    "source_ref": source["source_ref"],
+                    "license": acquired["license"],
+                    "license_url": acquired["license_url"],
+                    "unit_count": len(acquired["units"]),
+                    "hebrew_letters": total_letters,
+                    "target_work_ids": [
+                        mapping["target_work_id"] for mapping in source["mappings"]
+                    ],
+                    "raw_response_count": len(raw_paths),
+                    "raw_responses_sha256": _combined_raw_hash(raw_paths),
+                    "normalized_file": normalized_path.name,
+                    "normalized_sha256": sha256_file(normalized_path),
+                }
+            )
+            print(
+                f"  acquired {len(acquired['units'])} units / {total_letters:,} letters",
+                flush=True,
+            )
+        except Exception as exc:  # fail closed per source; manifest remains complete
+            if normalized_path.exists():
+                normalized_path.unlink()
+            entries.append(
+                {
+                    "key": source["key"],
+                    "provider": source["provider"],
+                    "status": "quarantined",
+                    "source_ref": source["source_ref"],
+                    "target_work_ids": [
+                        mapping["target_work_id"] for mapping in source["mappings"]
+                    ],
+                    "reason": str(exc),
+                }
+            )
+            print(f"  quarantined: {exc}", flush=True)
+    manifest = {
+        "schema_version": "discovery-v4-acquisition-manifest-v1",
+        "source_map": str(config_path.resolve()),
+        "source_map_sha256": sha256_file(config_path),
+        "license_allowlist": config["license_allowlist"],
+        "minimum_hebrew_letters": minimum,
+        "entries": entries,
+        "summary": {
+            "configured_sources": len(entries),
+            "acquired_sources": sum(entry["status"] == "acquired" for entry in entries),
+            "quarantined_sources": sum(
+                entry["status"] == "quarantined" for entry in entries
+            ),
+            "acquired_target_work_ids": sum(
+                len(entry["target_work_ids"])
+                for entry in entries
+                if entry["status"] == "acquired"
+            ),
+            "acquired_hebrew_letters": sum(
+                entry.get("hebrew_letters", 0)
+                for entry in entries
+                if entry["status"] == "acquired"
+            ),
+        },
+    }
+    manifest_path = output_dir / "manifest.json"
+    stable_json_dump(manifest, manifest_path)
+    print(json.dumps(manifest["summary"], ensure_ascii=False, indent=2))
+    return manifest
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--source-map",
+        default=str(Path(__file__).with_name("discovery_v4_sources.json")),
+    )
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--timeout", type=int, default=60)
+    parser.add_argument(
+        "--reuse-existing",
+        action="store_true",
+        help="Reuse hash-checked normalized/raw files and fetch only absent sources.",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    run(parse_args())

--- a/scripts/discovery_v4_match.py
+++ b/scripts/discovery_v4_match.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+"""Run and promote the Discovery V4 full-corpus Track-1 frame.
+
+The expensive matcher remains the reviewed, reference-coordinate-aware research
+runner.  This wrapper pins that runner and its calibration input, guarantees that
+no page allowlist is active, keeps output in a staged table, and promotes the
+result only after every page batch is committed.  Promotion happens only inside
+the operator-supplied research DB; the original V2 table is retained there as
+``track1_matches_v2_snapshot``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import pickle
+import re
+import sqlite3
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Iterable
+
+try:
+    from scripts.discovery_v4_common import require_hash, sha256_file, stable_json_dump
+except ModuleNotFoundError:  # direct invocation
+    from discovery_v4_common import require_hash, sha256_file, stable_json_dump
+
+
+PILOT_RELATIVE = Path("rsource/scripts/gen2_track1_pilot.py")
+PILOT_SHA256 = "1d2b2695d87a46e28b143f2567c6743b78a0ee9deda87d8d526dfaf2251f0f6d"
+CALIBRATION_RELATIVE = Path("data/p_calibration_final.json")
+CALIBRATION_SHA256 = "61d47db486af4bd5af64230db615d2e8e2c0b13537bba4631aa4602d024824a3"
+EXPECTED_PAGE_COUNT = 667_411
+GENERATION = "live"
+OVERLAP_FRAC = 0.6
+MIN_DENSITY_GAP = 0.03
+TRACK1_PROMOTED_COLUMNS = (
+    "page_id",
+    "sys_id",
+    "work_id",
+    "cat",
+    "genre",
+    "author",
+    "title",
+    "matched_letters",
+    "best_density",
+    "n_spans",
+    "spans_json",
+    "generation",
+    "ref_spans_json",
+    "shadowed_by",
+)
+
+
+def table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    return conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table,)
+    ).fetchone() is not None
+
+
+def table_columns(conn: sqlite3.Connection, table: str) -> list[str]:
+    return [row[1] for row in conn.execute(f"PRAGMA table_info({table})")]
+
+
+def validate_inputs(args: argparse.Namespace) -> dict:
+    probe_root = Path(args.probe_root).resolve()
+    db = Path(args.db).resolve()
+    reference = Path(args.reference).resolve()
+    masks = Path(args.masks).resolve()
+    pilot = probe_root / PILOT_RELATIVE
+    calibration = probe_root / CALIBRATION_RELATIVE
+    for label, path in (
+        ("research DB", db),
+        ("V4 reference", reference),
+        ("V4 masks", masks),
+        ("Track-1 pilot", pilot),
+        ("calibration model", calibration),
+    ):
+        if not path.is_file():
+            raise FileNotFoundError(f"{label} not found: {path}")
+    require_hash(reference, args.reference_sha256, "V4 reference")
+    require_hash(masks, args.masks_sha256, "V4 masks")
+    require_hash(pilot, PILOT_SHA256, "Track-1 pilot")
+    require_hash(calibration, CALIBRATION_SHA256, "calibration model")
+    if not re.fullmatch(r"[0-9a-f]{64}", args.source_db_sha256):
+        raise ValueError("--source-db-sha256 must be a lowercase SHA-256")
+    with reference.open("rb") as stream:
+        works = pickle.load(stream)
+    raw_ids = [work.get("id") for work in works]
+    if len(raw_ids) != len(set(raw_ids)):
+        raise ValueError("V4 reference contains duplicate raw work ids")
+    if not any(str(raw_id).startswith("REF4:") for raw_id in raw_ids):
+        raise ValueError("V4 reference contains no REF4 works")
+    with sqlite3.connect(db) as conn:
+        if not table_exists(conn, "pages"):
+            raise ValueError("research DB has no pages table")
+        page_count = conn.execute("SELECT COUNT(*) FROM pages").fetchone()[0]
+        if page_count != EXPECTED_PAGE_COUNT:
+            raise ValueError(
+                f"research page frame drift: expected {EXPECTED_PAGE_COUNT}, got {page_count}"
+            )
+        if not table_exists(conn, "stage0_sys_flags"):
+            raise ValueError("research DB has no stage0_sys_flags table")
+    return {
+        "db": str(db),
+        "source_db_seed_sha256": args.source_db_sha256,
+        "reference": str(reference),
+        "reference_sha256": sha256_file(reference),
+        "masks": str(masks),
+        "masks_sha256": sha256_file(masks),
+        "pilot": str(pilot),
+        "pilot_sha256": sha256_file(pilot),
+        "calibration_sha256": sha256_file(calibration),
+        "page_count": page_count,
+        "reference_count": len(works),
+        "ref4_count": sum(str(raw_id).startswith("REF4:") for raw_id in raw_ids),
+    }
+
+
+def staged_table(tag: str) -> str:
+    if not re.fullmatch(r"[A-Za-z0-9_]+", tag):
+        raise ValueError("tag must contain only letters, digits, and underscores")
+    return f"track1_matches_pilot_{tag}_{GENERATION}"
+
+
+def pin_batch_geometry(db: str, tag: str, page_batch: int) -> None:
+    """Prevent the upstream resume key from being reused at a new batch size."""
+    key = f"discovery_v4_page_batch_{tag}_{GENERATION}"
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS gen2_meta (key TEXT PRIMARY KEY, value TEXT)"
+        )
+        row = conn.execute("SELECT value FROM gen2_meta WHERE key=?", (key,)).fetchone()
+        if row is not None and int(row[0]) != page_batch:
+            raise ValueError(
+                f"V4 resume batch-size mismatch: stored {row[0]}, requested {page_batch}"
+            )
+        conn.execute("INSERT OR REPLACE INTO gen2_meta VALUES (?, ?)", (key, page_batch))
+        conn.commit()
+
+
+def pin_source_db_seed(db: str, tag: str, expected_sha256: str) -> None:
+    """Hash the pristine copied DB once, before the first staged write."""
+    key = f"discovery_v4_source_db_seed_sha256_{tag}_{GENERATION}"
+    with sqlite3.connect(db) as conn:
+        have_meta = table_exists(conn, "gen2_meta")
+        row = (
+            conn.execute("SELECT value FROM gen2_meta WHERE key=?", (key,)).fetchone()
+            if have_meta
+            else None
+        )
+    if row is not None:
+        if row[0] != expected_sha256:
+            raise ValueError("stored V4 source-DB seed hash differs from the requested pin")
+        return
+    table = staged_table(tag)
+    with sqlite3.connect(db) as conn:
+        if table_exists(conn, table):
+            raise ValueError("cannot establish a source-DB seed hash after staging began")
+    require_hash(db, expected_sha256, "source research DB seed")
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS gen2_meta (key TEXT PRIMARY KEY, value TEXT)"
+        )
+        conn.execute("INSERT INTO gen2_meta VALUES (?, ?)", (key, expected_sha256))
+        conn.commit()
+
+
+def run_match(args: argparse.Namespace) -> dict:
+    report = validate_inputs(args)
+    pin_source_db_seed(report["db"], args.tag, args.source_db_sha256)
+    pin_batch_geometry(report["db"], args.tag, args.page_batch)
+    pilot = Path(report["pilot"])
+    env = os.environ.copy()
+    env.update(
+        {
+            "GEN2_GEN": GENERATION,
+            "GEN2_TIER": "a",
+            "GEN2_MASKS": report["masks"],
+            "MAPV2_PAGE_BATCH": str(args.page_batch),
+            "PYTHONUTF8": "1",
+        }
+    )
+    # V4 must discover matches on pages that were absent from the old frame.
+    env.pop("MAPV2_SAMPLE_PAGES", None)
+    env.pop("GEN2_PILOT_FORCE", None)
+    command = [
+        sys.executable,
+        "-X",
+        "utf8",
+        "-u",
+        str(pilot),
+        report["db"],
+        args.tag,
+        report["reference"],
+    ]
+    print("Running full-corpus V4 matcher (no page allowlist):", flush=True)
+    print(" ".join(command), flush=True)
+    completed = subprocess.run(command, env=env, check=False)
+    if completed.returncode:
+        raise SystemExit(completed.returncode)
+    status = inspect_stage(args, report=report)
+    if not status["complete"]:
+        raise RuntimeError("matcher exited without committing every page batch")
+    return status
+
+
+def inspect_stage(args: argparse.Namespace, report: dict | None = None) -> dict:
+    report = report or validate_inputs(args)
+    table = staged_table(args.tag)
+    key_done = f"pilot_done_{args.tag}_{GENERATION}"
+    key_fp = f"fp_{args.tag}_{GENERATION}"
+    expected_batches = math.ceil(report["page_count"] / args.page_batch)
+    with sqlite3.connect(report["db"]) as conn:
+        if not table_exists(conn, table):
+            return {
+                **report,
+                "table": table,
+                "complete": False,
+                "reason": "staged table absent",
+                "expected_batches": expected_batches,
+            }
+        done_row = conn.execute(
+            "SELECT value FROM gen2_meta WHERE key=?", (key_done,)
+        ).fetchone()
+        fp_row = conn.execute(
+            "SELECT value FROM gen2_meta WHERE key=?", (key_fp,)
+        ).fetchone()
+        done_batch = int(done_row[0]) if done_row else -1
+        row_count = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+        ref4_rows = conn.execute(
+            f"SELECT COUNT(*) FROM {table} WHERE work_id LIKE 'REF4:%'"
+        ).fetchone()[0]
+        missing_offsets = conn.execute(
+            f"SELECT COUNT(*) FROM {table} "
+            "WHERE ref_spans_json IS NULL OR ref_spans_json='' OR ref_spans_json='[]'"
+        ).fetchone()[0]
+        duplicate_pairs = conn.execute(
+            f"SELECT COUNT(*) FROM (SELECT page_id, work_id, generation, COUNT(*) n "
+            f"FROM {table} GROUP BY page_id, work_id, generation HAVING n != 1)"
+        ).fetchone()[0]
+    complete = done_batch == expected_batches - 1
+    return {
+        **report,
+        "table": table,
+        "expected_batches": expected_batches,
+        "done_batch": done_batch,
+        "complete": complete,
+        "fingerprint": fp_row[0] if fp_row else None,
+        "row_count": row_count,
+        "ref4_rows": ref4_rows,
+        "missing_ref_offsets": missing_offsets,
+        "duplicate_pairs": duplicate_pairs,
+    }
+
+
+def _best_span(spans_json: str) -> tuple[int, int, float]:
+    spans = [
+        (int(span[0]), int(span[1]), float(span[2]))
+        for span in json.loads(spans_json)
+    ]
+    if not spans:
+        raise ValueError("Track-1 row has no page spans")
+    return max(spans, key=lambda span: span[1] - span[0])
+
+
+def shadow_rows(
+    rows: Iterable[tuple[int, str, str, float, str]],
+) -> list[tuple[str, int]]:
+    """Return ``(winner_work_id, shadowed_rowid)`` using the frozen algorithm."""
+    by_page: dict[str, list[tuple[int, str, float, tuple[int, int, float]]]] = (
+        defaultdict(list)
+    )
+    for rowid, page_id, work_id, best_density, spans_json in rows:
+        by_page[page_id].append(
+            (rowid, work_id, float(best_density), _best_span(spans_json))
+        )
+    shadows: list[tuple[str, int]] = []
+    for items in by_page.values():
+        if len(items) < 2:
+            continue
+        items.sort(key=lambda item: item[3][2])
+        live: list[tuple[str, int, int, float]] = []
+        for rowid, work_id, _best_density, span in items:
+            start, end, density = span
+            winner = None
+            for live_work, live_start, live_end, live_density in live:
+                overlap = min(end, live_end) - max(start, live_start)
+                if (
+                    overlap >= OVERLAP_FRAC * (end - start)
+                    and density - live_density >= MIN_DENSITY_GAP
+                ):
+                    winner = live_work
+                    break
+            if winner is None:
+                live.append((work_id, start, end, density))
+            else:
+                shadows.append((winner, rowid))
+    return shadows
+
+
+def promote(args: argparse.Namespace) -> dict:
+    status = inspect_stage(args)
+    if not status["complete"]:
+        raise RuntimeError("cannot promote an incomplete V4 matcher stage")
+    if status["missing_ref_offsets"] or status["duplicate_pairs"]:
+        raise RuntimeError("cannot promote a stage with missing offsets or duplicate pairs")
+    table = status["table"]
+    with sqlite3.connect(status["db"]) as conn:
+        conn.execute("PRAGMA busy_timeout=120000")
+        if not table_exists(conn, "track1_matches_v2_snapshot"):
+            if not table_exists(conn, "track1_matches"):
+                raise ValueError("research DB has no original track1_matches table")
+            if "ref_spans_json" in table_columns(conn, "track1_matches"):
+                raise ValueError("refusing to snapshot an already-promoted Track-1 table")
+            conn.execute(
+                "ALTER TABLE track1_matches RENAME TO track1_matches_v2_snapshot"
+            )
+            conn.commit()
+        if table_exists(conn, "track1_matches"):
+            conn.execute("DROP TABLE track1_matches")
+        conn.execute(
+            """CREATE TABLE track1_matches (
+                page_id TEXT, sys_id TEXT, work_id TEXT, cat TEXT, genre TEXT,
+                author TEXT, title TEXT,
+                matched_letters INTEGER, best_density REAL, n_spans INTEGER,
+                spans_json TEXT, generation TEXT, ref_spans_json TEXT,
+                shadowed_by TEXT
+            )"""
+        )
+        conn.execute(
+            f"""INSERT INTO track1_matches (
+                page_id, sys_id, work_id, cat, genre, author, title,
+                matched_letters, best_density, n_spans, spans_json, generation,
+                ref_spans_json, shadowed_by
+            ) SELECT page_id, sys_id, work_id, cat, genre, author, title,
+                matched_letters, best_density, n_spans, spans_json, generation,
+                ref_spans_json, NULL
+              FROM {table} ORDER BY rowid"""
+        )
+        conn.execute(
+            "CREATE UNIQUE INDEX uq_track1_matches_v4 "
+            "ON track1_matches(page_id, work_id, generation)"
+        )
+        conn.execute("CREATE INDEX ix_track1_matches_page ON track1_matches(page_id)")
+        rows = conn.execute(
+            "SELECT rowid, page_id, work_id, best_density, spans_json "
+            "FROM track1_matches ORDER BY rowid"
+        ).fetchall()
+        shadows = shadow_rows(rows)
+        conn.executemany(
+            "UPDATE track1_matches SET shadowed_by=? WHERE rowid=?", shadows
+        )
+        conn.commit()
+        total = conn.execute("SELECT COUNT(*) FROM track1_matches").fetchone()[0]
+        live = conn.execute(
+            "SELECT COUNT(*) FROM track1_matches WHERE shadowed_by IS NULL"
+        ).fetchone()[0]
+        ref4_total = conn.execute(
+            "SELECT COUNT(*) FROM track1_matches WHERE work_id LIKE 'REF4:%'"
+        ).fetchone()[0]
+        ref4_live = conn.execute(
+            "SELECT COUNT(*) FROM track1_matches "
+            "WHERE work_id LIKE 'REF4:%' AND shadowed_by IS NULL"
+        ).fetchone()[0]
+        snapshot_count = conn.execute(
+            "SELECT COUNT(*) FROM track1_matches_v2_snapshot"
+        ).fetchone()[0]
+        integrity = conn.execute("PRAGMA integrity_check").fetchone()[0]
+    if total != status["row_count"] or snapshot_count != 381_341:
+        raise RuntimeError("promoted or preserved Track-1 row count drift")
+    if integrity != "ok":
+        raise RuntimeError(f"research DB integrity check failed: {integrity}")
+    report = {
+        **status,
+        "schema_version": "discovery-v4-track1-frame-v1",
+        "promoted_rows": total,
+        "live_rows": live,
+        "shadowed_rows": len(shadows),
+        "ref4_promoted_rows": ref4_total,
+        "ref4_live_rows": ref4_live,
+        "v2_snapshot_rows": snapshot_count,
+        "integrity_check": integrity,
+    }
+    contract = {
+        "schema_version": "discovery-v4-track1-release-contract-v1",
+        "reference_corpus_sha256": status["reference_sha256"],
+        "canonical_masks_sha256": status["masks_sha256"],
+        "source_db_seed_sha256": status["source_db_seed_sha256"],
+        "matcher_fingerprint": status["fingerprint"],
+        "page_count": status["page_count"],
+        "total_rows": total,
+        "live_rows": live,
+        "ref4_total_rows": ref4_total,
+        "ref4_live_rows": ref4_live,
+        "v2_snapshot_rows": snapshot_count,
+        "missing_ref_offsets": status["missing_ref_offsets"],
+        "duplicate_pairs": status["duplicate_pairs"],
+        "shadow_algorithm": "track1-shadow-v1",
+        "promoted_columns": list(TRACK1_PROMOTED_COLUMNS),
+    }
+    report["release_contract"] = contract
+    if args.report:
+        stable_json_dump(report, args.report)
+    if args.contract:
+        stable_json_dump(contract, args.contract)
+    print(json.dumps(report, indent=2))
+    return report
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("action", choices=("preflight", "run", "status", "promote"))
+    parser.add_argument("--probe-root", required=True)
+    parser.add_argument("--db", required=True)
+    parser.add_argument("--source-db-sha256", required=True)
+    parser.add_argument("--reference", required=True)
+    parser.add_argument("--reference-sha256", required=True)
+    parser.add_argument("--masks", required=True)
+    parser.add_argument("--masks-sha256", required=True)
+    parser.add_argument("--tag", default="v4full")
+    parser.add_argument("--page-batch", type=int, default=2000)
+    parser.add_argument("--report")
+    parser.add_argument("--contract")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.page_batch <= 0:
+        raise ValueError("--page-batch must be positive")
+    if args.action == "preflight":
+        print(json.dumps(validate_inputs(args), indent=2))
+    elif args.action == "run":
+        print(json.dumps(run_match(args), indent=2))
+    elif args.action == "status":
+        print(json.dumps(inspect_stage(args), indent=2))
+    else:
+        promote(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/discovery_v4_reconcile.py
+++ b/scripts/discovery_v4_reconcile.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Mint and reconcile the public identities that survive the V4 rematch."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import csv
+import hashlib
+import json
+import re
+import sqlite3
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    from scripts.discovery_v4_common import require_hash, sha256_file, stable_json_dump
+except ModuleNotFoundError:  # direct invocation
+    from discovery_v4_common import require_hash, sha256_file, stable_json_dump
+
+
+APPROVED_HEADER = (
+    "work_id",
+    "candidate_title",
+    "author",
+    "genre",
+    "source_label",
+    "confidence_basis",
+    "tier_a_witnesses",
+    "claim_count",
+    "owner_title",
+    "owner_verdict",
+    "owner_note",
+)
+V4_MERGE_CONTRACT = "discovery-v4-public-reference-merges-v1"
+OPAQUE_RE = re.compile(r"w[0-9]{6}")
+
+
+def curated_content_hash(payload: list[dict]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, ensure_ascii=False)
+    return "sha256:" + hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def canonical_map(merges: dict) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for group in merges["merges"]:
+        if group.get("owner_verdict") != "approve":
+            continue
+        for member in group["members_w"]:
+            if member in result:
+                raise ValueError("base canonical merges are not disjoint")
+            result[member] = group["canonical_w"]
+    return result
+
+
+def next_work_ids(crosswalk: dict[str, str], count: int) -> list[str]:
+    values = list(crosswalk.values())
+    if any(not OPAQUE_RE.fullmatch(value) for value in values):
+        raise ValueError("base crosswalk contains a malformed opaque work id")
+    if len(values) != len(set(values)):
+        raise ValueError("base crosswalk is not injective")
+    next_number = max(int(value[1:]) for value in values) + 1
+    if next_number + count - 1 > 999_999:
+        raise ValueError("opaque work-id namespace exhausted")
+    return [f"w{number:06d}" for number in range(next_number, next_number + count)]
+
+
+def update_domain_counts(document: dict) -> None:
+    rows = document["assignments"]
+    confidence = Counter(row["confidence"] for row in rows)
+    needs = [row for row in rows if row["confidence"] == "needs-ruling"]
+    document["counts"] = {
+        "total": len(rows),
+        "by_confidence": dict(sorted(confidence.items())),
+        "unassigned": sum(
+            row["domain_parent"] == "Unassigned" and row["domain_leaf"] == "Unassigned"
+            for row in rows
+        ),
+        "needs_ruling_held": sum(not row.get("owner_ruling") for row in needs),
+        "needs_ruling_ruled": sum(bool(row.get("owner_ruling")) for row in needs),
+    }
+
+
+def run(args: argparse.Namespace) -> dict:
+    reference_manifest_path = Path(args.reference_manifest).resolve()
+    require_hash(
+        reference_manifest_path,
+        args.reference_manifest_sha256,
+        "V4 reference manifest",
+    )
+    reference_manifest = json.loads(
+        reference_manifest_path.read_text(encoding="utf-8")
+    )
+    if reference_manifest.get("schema_version") != "discovery-v4-reference-manifest-v1":
+        raise ValueError("unsupported V4 reference manifest")
+    entries = {
+        entry["raw_reference_id"]: entry for entry in reference_manifest["entries"]
+    }
+    if len(entries) != len(reference_manifest["entries"]):
+        raise ValueError("reference manifest contains duplicate raw ids")
+
+    base_crosswalk_path = Path(args.base_crosswalk)
+    base_approved_path = Path(args.base_approved)
+    base_merges_path = Path(args.base_merges)
+    base_domains_path = Path(args.base_work_domains)
+    require_hash(base_crosswalk_path, args.base_crosswalk_sha256, "base crosswalk")
+    require_hash(base_approved_path, args.base_approved_sha256, "base approved review")
+    require_hash(base_merges_path, args.base_merges_sha256, "base canonical merges")
+    require_hash(base_domains_path, args.base_work_domains_sha256, "base work domains")
+
+    match_db = Path(args.match_db).resolve()
+    with sqlite3.connect(f"file:{match_db.as_posix()}?mode=ro", uri=True) as conn:
+        columns = {
+            row[1] for row in conn.execute("PRAGMA table_info(track1_matches)")
+        }
+        if not {"shadowed_by", "ref_spans_json"}.issubset(columns):
+            raise ValueError("V4 match DB has not been promoted with reference offsets")
+        match_rows = conn.execute(
+            """SELECT work_id, MIN(title), MIN(author), MIN(genre),
+                      COUNT(*), COUNT(DISTINCT sys_id), COUNT(DISTINCT page_id)
+                 FROM track1_matches
+                WHERE shadowed_by IS NULL AND work_id LIKE 'REF4:%'
+                GROUP BY work_id ORDER BY work_id"""
+        ).fetchall()
+    live_raw_ids = [row[0] for row in match_rows]
+    if not live_raw_ids:
+        raise ValueError("V4 rematch produced no live public-reference rows")
+    unknown = set(live_raw_ids) - set(entries)
+    if unknown:
+        raise ValueError("V4 rematch contains raw ids absent from its reference manifest")
+
+    crosswalk = json.loads(base_crosswalk_path.read_text(encoding="utf-8"))
+    collisions = set(live_raw_ids) & set(crosswalk)
+    if collisions:
+        raise ValueError("V4 raw ids already exist in the base crosswalk")
+    minted = dict(zip(live_raw_ids, next_work_ids(crosswalk, len(live_raw_ids))))
+    crosswalk.update(minted)
+    stable_json_dump(crosswalk, args.output_crosswalk)
+
+    with base_approved_path.open(encoding="utf-8-sig", newline="") as stream:
+        reader = csv.DictReader(stream)
+        if tuple(reader.fieldnames or ()) != APPROVED_HEADER:
+            raise ValueError("base approved-review header drift")
+        approved_rows = list(reader)
+    approved_by_id = {row["work_id"]: row for row in approved_rows}
+    if len(approved_by_id) != len(approved_rows):
+        raise ValueError("base approved-review file contains duplicate work ids")
+    for raw_id, _title, _author, genre, row_count, witnesses, claims in match_rows:
+        entry = entries[raw_id]
+        target = entry["target_private_work_id"]
+        target_review = approved_by_id.get(target)
+        if target_review is None or target_review["owner_verdict"] not in {"approve", "edit"}:
+            raise ValueError("V4 target private identity is not owner-approved")
+        approved_rows.append(
+            {
+                "work_id": minted[raw_id],
+                "candidate_title": entry["title"],
+                "author": target_review["author"],
+                "genre": genre or target_review["genre"],
+                "source_label": "sefaria",
+                "confidence_basis": "v4-public-reference-owner-authorized",
+                "tier_a_witnesses": str(witnesses),
+                "claim_count": str(claims),
+                "owner_title": "",
+                "owner_verdict": "approve",
+                "owner_note": (
+                    f"V4 public-source sibling of {target}; matcher rows={row_count}"
+                ),
+            }
+        )
+    output_approved = Path(args.output_approved)
+    output_approved.parent.mkdir(parents=True, exist_ok=True)
+    with output_approved.open("w", encoding="utf-8-sig", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=APPROVED_HEADER)
+        writer.writeheader()
+        writer.writerows(approved_rows)
+
+    base_merges = json.loads(base_merges_path.read_text(encoding="utf-8"))
+    old_canonical = canonical_map(base_merges)
+    used_members = set(old_canonical)
+    new_groups = []
+    for raw_id in live_raw_ids:
+        target = entries[raw_id]["target_private_work_id"]
+        public = minted[raw_id]
+        if target in used_members:
+            raise ValueError("V4 target already participates in a canonical merge")
+        used_members.update((target, public))
+        new_groups.append(
+            {
+                "members_w": [target, public],
+                "canonical_w": public,
+                "owner_verdict": "approve",
+            }
+        )
+    merges = copy.deepcopy(base_merges)
+    merges["release_contract_version"] = V4_MERGE_CONTRACT
+    merges["v4_public_reference_canonical_ids"] = [
+        minted[raw_id] for raw_id in live_raw_ids
+    ]
+    merges["v4_source_manifest_sha256"] = reference_manifest[
+        "acquisition_manifest_sha256"
+    ]
+    merges["source"] = "Discovery V4 public-reference expansion"
+    merges["merges"] = [*base_merges["merges"], *new_groups]
+    stable_json_dump(merges, args.output_merges)
+
+    domains = json.loads(base_domains_path.read_text(encoding="utf-8"))
+    if curated_content_hash(domains["assignments"]) != domains["content_hash"]:
+        raise ValueError("base work-domain artifact has a stale content hash")
+    domain_by_id = {
+        row["canonical_work_id"]: row for row in domains["assignments"]
+    }
+    for raw_id in live_raw_ids:
+        target = entries[raw_id]["target_private_work_id"]
+        target_canonical = old_canonical.get(target, target)
+        source_row = domain_by_id.get(target_canonical)
+        if source_row is None:
+            raise ValueError("V4 target has no curated work-domain assignment")
+        new_row = copy.deepcopy(source_row)
+        new_row["canonical_work_id"] = minted[raw_id]
+        new_row["provenance"] = f"v4-public-reference-inherits:{target_canonical}"
+        domains["assignments"].append(new_row)
+    domains["assignments"].sort(key=lambda row: row["canonical_work_id"])
+    domains["generated_by"] = "scripts/discovery_v4_reconcile.py"
+    domains["generated_utc"] = datetime.now(timezone.utc).isoformat()
+    update_domain_counts(domains)
+    domains["content_hash"] = curated_content_hash(domains["assignments"])
+    stable_json_dump(domains, args.output_work_domains)
+
+    report = {
+        "schema_version": "discovery-v4-reconciliation-v1",
+        "reference_manifest_sha256": sha256_file(reference_manifest_path),
+        "source_manifest_sha256": reference_manifest["acquisition_manifest_sha256"],
+        "live_public_reference_count": len(live_raw_ids),
+        "quarantined_or_unmatched_reference_count": len(entries) - len(live_raw_ids),
+        "live_match_rows": sum(row[4] for row in match_rows),
+        "live_witnesses": sum(row[5] for row in match_rows),
+        "minted_first": min(minted.values()),
+        "minted_last": max(minted.values()),
+        "crosswalk_sha256": sha256_file(args.output_crosswalk),
+        "approved_review_sha256": sha256_file(args.output_approved),
+        "canonical_merges_sha256": sha256_file(args.output_merges),
+        "canonical_merge_count": len(merges["merges"]),
+        "work_domains_file_sha256": sha256_file(args.output_work_domains),
+        "work_domains_content_hash": domains["content_hash"],
+        "work_domain_assignments": len(domains["assignments"]),
+        "raw_to_opaque": minted,
+    }
+    if args.report:
+        stable_json_dump(report, args.report)
+    print(json.dumps(report, indent=2))
+    return report
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--reference-manifest", required=True)
+    parser.add_argument("--reference-manifest-sha256", required=True)
+    parser.add_argument("--match-db", required=True)
+    parser.add_argument("--base-crosswalk", required=True)
+    parser.add_argument("--base-crosswalk-sha256", required=True)
+    parser.add_argument("--base-approved", required=True)
+    parser.add_argument("--base-approved-sha256", required=True)
+    parser.add_argument("--base-merges", required=True)
+    parser.add_argument("--base-merges-sha256", required=True)
+    parser.add_argument("--base-work-domains", required=True)
+    parser.add_argument("--base-work-domains-sha256", required=True)
+    parser.add_argument("--output-crosswalk", required=True)
+    parser.add_argument("--output-approved", required=True)
+    parser.add_argument("--output-merges", required=True)
+    parser.add_argument("--output-work-domains", required=True)
+    parser.add_argument("--report")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    run(parse_args())

--- a/scripts/discovery_v4_sources.json
+++ b/scripts/discovery_v4_sources.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": "discovery-v4-sources-v1",
+  "license_allowlist": [
+    "Public Domain",
+    "CC0",
+    "CC-BY",
+    "CC-BY-SA"
+  ],
+  "minimum_hebrew_letters": 1000,
+  "aggregate_already_covered": [
+    {
+      "work_id": "w000171",
+      "covered_by": ["w001281", "w001278", "w001299", "w001304", "w001275"],
+      "note": "The external Rashi-on-Torah container is already represented by five public book-level works."
+    }
+  ],
+  "false_title_collisions": [
+    {
+      "work_id": "w000509",
+      "note": "The Wikisource title resolves to Megillat Setarim on Esther, not Nissim Gaon's work."
+    },
+    {
+      "work_id": "w000820",
+      "note": "The Wikisource title is the Breslov work, not the local Karaite work."
+    }
+  ],
+  "sources": [
+    {"key":"sifra","provider":"hewikisource","source_ref":"ספרא","link_prefix":"ספרא על ויקרא ","mappings":[{"target_work_id":"w000163"}]},
+    {"key":"seder_olam_rabbah","provider":"sefaria","source_ref":"Seder Olam Rabbah","mappings":[{"target_work_id":"w000164"}]},
+    {"key":"bereshit_rabbah","provider":"sefaria","source_ref":"Bereshit Rabbah","mappings":[{"target_work_id":"w000156"}]},
+    {"key":"pesikta_derav_kahana","provider":"sefaria","source_ref":"Pesikta DeRav Kahana","mappings":[{"target_work_id":"w000904"}]},
+    {"key":"pirkei_derabbi_eliezer","provider":"sefaria","source_ref":"Pirkei DeRabbi Eliezer","mappings":[{"target_work_id":"w000807"}]},
+    {"key":"derekh_eretz_zuta","provider":"sefaria","source_ref":"Tractate Derekh Eretz Zuta","mappings":[{"target_work_id":"w000787"}]},
+    {"key":"tractate_soferim","provider":"sefaria","source_ref":"Tractate Soferim","mappings":[{"target_work_id":"w000774"}]},
+    {"key":"mekhilta_derabbi_yishmael","provider":"hewikisource","source_ref":"מכילתא דרבי ישמעאל","link_prefix":"מכילתא על שמות ","mappings":[{"target_work_id":"w000766"}]},
+    {"key":"sifrei_devarim","provider":"sefaria","source_ref":"Sifrei Devarim","mappings":[{"target_work_id":"w000166"}]},
+    {"key":"shir_hashirim_rabbah","provider":"sefaria","source_ref":"Shir HaShirim Rabbah","mappings":[{"target_work_id":"w000804"}]},
+    {"key":"sefer_yetzirah","provider":"sefaria","source_ref":"Sefer Yetzirah","mappings":[{"target_work_id":"w000522"}]},
+    {"key":"mekhilta_derabbi_shimon","provider":"sefaria","source_ref":"Mekhilta DeRabbi Shimon Ben Yochai","mappings":[{"target_work_id":"w000321"}]},
+    {"key":"midrash_haserot_veyterot","provider":"hewikisource","source_ref":"מדרש חסרות ויתרות","mappings":[{"target_work_id":"w000859"}]},
+    {"key":"yosippon","provider":"hewikisource","source_ref":"יוסיפון","link_prefix":"יוסיפון (ויקיטקסט)/פרק ","mappings":[{"target_work_id":"w000853"}]},
+    {"key":"heikhalot_rabbati","provider":"hewikisource","source_ref":"היכלות רבתי","link_prefix":"פרקי היכלות רבתי פרק ","mappings":[{"target_work_id":"w000170"}]},
+    {"key":"shaarei_teshuvah","provider":"sefaria","source_ref":"Sha'arei Teshuvah","mappings":[{"target_work_id":"w000189"}]},
+    {"key":"midrash_mishlei","provider":"hewikisource","source_ref":"מדרש משלי","link_prefix":"מדרש משלי (בובר) ","mappings":[{"target_work_id":"w000852"}]},
+    {"key":"vayikra_rabbah","provider":"sefaria","source_ref":"Vayikra Rabbah","mappings":[{"target_work_id":"w000169"}]},
+    {"key":"sifrei_bamidbar","provider":"sefaria","source_ref":"Sifrei Bamidbar","mappings":[{"target_work_id":"w000165"}]},
+    {"key":"midrash_tehillim","provider":"sefaria","source_ref":"Midrash Tehillim","mappings":[{"target_work_id":"w001124"}]},
+    {"key":"rashi_bava_kamma","provider":"sefaria","source_ref":"Rashi on Bava Kamma","locus_grain":"daf_bavli","mappings":[{"target_work_id":"w000172"}]},
+    {"key":"eikhah_rabbah","provider":"sefaria","source_ref":"Eikhah Rabbah","mappings":[{"target_work_id":"w001128"}]},
+    {"key":"diqduqe_hateamim","provider":"hewikisource","source_ref":"דקדוקי הטעמים","mappings":[{"target_work_id":"w000910"}]},
+    {"key":"kohelet_rabbah","provider":"sefaria","source_ref":"Kohelet Rabbah","mappings":[{"target_work_id":"w000891"}]},
+    {"key":"devarim_rabbah","provider":"hewikisource","source_ref":"דברים רבה","link_prefix":"דברים רבה ","mappings":[{"target_work_id":"w000794"}]},
+    {"key":"midrash_shmuel","provider":"sefaria","source_ref":"Midrash Shmuel","mappings":[{"target_work_id":"w000896"}]},
+    {"key":"baraita_melekhet_hamishkan","provider":"hewikisource","source_ref":"ברייתא דמלאכת המשכן","link_prefix":"ברייתא דמלאכת המשכן ","mappings":[{"target_work_id":"w000157"}]},
+    {"key":"midrash_tanchuma_buber","provider":"sefaria","source_ref":"Midrash Tanchuma Buber","mode":"schema_leaves","locus_grain":"section","locus_title_he":"תנחומא בובר","mappings":[{"target_work_id":"w000879"}]},
+    {"key":"perek_shirah","provider":"sefaria","source_ref":"Perek Shirah","mappings":[{"target_work_id":"w000991"}]},
+    {"key":"pesikta_rabbati","provider":"sefaria","source_ref":"Pesikta Rabbati","mappings":[{"target_work_id":"w000803"}]},
+    {"key":"kallah_rabbati","provider":"sefaria","source_ref":"Tractate Kallah Rabbati","mappings":[{"target_work_id":"w000809"}]},
+    {"key":"shemot_rabbah","provider":"sefaria","source_ref":"Shemot Rabbah","locus_title_he":"שמות רבה","mappings":[{"target_work_id":"w000929","chapter_range":[1,14]},{"target_work_id":"w000930","chapter_range":[15,52]}]},
+    {"key":"tractate_kallah","provider":"sefaria","source_ref":"Tractate Kallah","mappings":[{"target_work_id":"w000771"}]},
+    {"key":"esther_rabbah","provider":"hewikisource","source_ref":"אסתר רבה","link_prefix":"אסתר רבה ","mappings":[{"target_work_id":"w000841","chapter_range":[1,6]},{"target_work_id":"w000927","chapter_range":[7,10]}]},
+    {"key":"baraita_diyeshua","provider":"hewikisource","source_ref":"ברייתא דישועה","mappings":[{"target_work_id":"w000754"}]},
+    {"key":"tractate_semachot","provider":"sefaria","source_ref":"Tractate Semachot","mappings":[{"target_work_id":"w000780"}]},
+    {"key":"derekh_eretz_rabbah","provider":"sefaria","source_ref":"Tractate Derekh Eretz Rabbah","mappings":[{"target_work_id":"w000786"}]},
+    {"key":"arugat_habosem","provider":"hewikisource","source_ref":"ערוגת הבושם","mappings":[{"target_work_id":"w000160"}]},
+    {"key":"sefer_zerubbabel","provider":"hewikisource","source_ref":"ספר זרובבל","mappings":[{"target_work_id":"w000737"}]},
+    {"key":"midrash_abba_gurion","provider":"hewikisource","source_ref":"בית המדרש/חדר ראשון/מדרש אבא גוריון","mappings":[{"target_work_id":"w000928"}]},
+    {"key":"midrash_hillel","provider":"hewikisource","source_ref":"מדרש הלל","mappings":[{"target_work_id":"w000782"}]},
+    {"key":"ruth_rabbah","provider":"sefaria","source_ref":"Ruth Rabbah","mappings":[{"target_work_id":"w000805"}]},
+    {"key":"aggadat_bereshit","provider":"sefaria","source_ref":"Aggadat Bereshit","mappings":[{"target_work_id":"w000924"}]}
+  ]
+}

--- a/scripts/discovery_v4_verify_reference.py
+++ b/scripts/discovery_v4_verify_reference.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Independently verify the V4 reference corpus and locus extension."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import pickle
+import sqlite3
+from collections import Counter
+from pathlib import Path
+
+try:
+    from scripts.discovery_v4_common import sha256_file, stable_json_dump
+except ModuleNotFoundError:  # direct invocation
+    from discovery_v4_common import sha256_file, stable_json_dump
+
+
+def stream_hash(stream: str) -> str:
+    return hashlib.sha256(stream.encode("utf-8")).hexdigest()
+
+
+def run(args: argparse.Namespace) -> dict:
+    manifest_path = Path(args.manifest).resolve()
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if manifest.get("schema_version") != "discovery-v4-reference-manifest-v1":
+        raise ValueError("unsupported V4 reference manifest")
+    base_path = Path(manifest["base_reference"])
+    reference_path = Path(manifest["reference_corpus"])
+    locus_path = Path(manifest["locus_divisions"])
+    coverage_path = Path(manifest["locus_coverage"])
+    pinned = (
+        (base_path, manifest["base_reference_sha256"], "base reference"),
+        (reference_path, manifest["reference_corpus_sha256"], "V4 reference"),
+        (locus_path, manifest["locus_divisions_sha256"], "V4 locus DB"),
+        (coverage_path, manifest["locus_coverage_sha256"], "V4 locus coverage"),
+    )
+    for path, expected, label in pinned:
+        actual = sha256_file(path)
+        if actual != expected:
+            raise ValueError(f"{label} hash mismatch")
+    with base_path.open("rb") as stream:
+        base = pickle.load(stream)
+    with reference_path.open("rb") as stream:
+        reference = pickle.load(stream)
+    if reference[: len(base)] != base:
+        raise ValueError("V4 reference changed the base-corpus prefix")
+    appended = reference[len(base) :]
+    entries = manifest["entries"]
+    entry_by_id = {entry["raw_reference_id"]: entry for entry in entries}
+    if len(entry_by_id) != len(entries):
+        raise ValueError("manifest contains duplicate V4 raw reference ids")
+    appended_by_id = {work["id"]: work for work in appended}
+    if set(appended_by_id) != set(entry_by_id):
+        raise ValueError("manifest entries do not equal the appended reference set")
+    for raw_id, entry in entry_by_id.items():
+        work = appended_by_id[raw_id]
+        if len(work["stream"]) != entry["stream_len"]:
+            raise ValueError("manifest stream length drift")
+        if stream_hash(work["stream"]) != entry["stream_sha256"]:
+            raise ValueError("manifest stream hash drift")
+        offsets = entry["unit_offsets"]
+        starts = [row["start_offset"] for row in offsets]
+        if not starts or starts[0] != 0 or starts != sorted(set(starts)):
+            raise ValueError("manifest unit offsets are empty, duplicated, or unordered")
+        if starts[-1] >= entry["stream_len"]:
+            raise ValueError("manifest unit offset exceeds its reference stream")
+    coverage = json.loads(coverage_path.read_text(encoding="utf-8"))
+    if coverage.get("reference_corpus_sha256") != sha256_file(reference_path):
+        raise ValueError("locus coverage names a different reference corpus")
+    if coverage.get("invariant_problems") != []:
+        raise ValueError("locus coverage reports invariant problems")
+    with sqlite3.connect(locus_path) as conn:
+        integrity = conn.execute("PRAGMA integrity_check").fetchone()[0]
+        foreign_keys = conn.execute("PRAGMA foreign_key_check").fetchall()
+        work_count = conn.execute("SELECT COUNT(*) FROM locus_work").fetchone()[0]
+        unit_count = conn.execute("SELECT COUNT(*) FROM locus_unit").fetchone()[0]
+        families = dict(
+            conn.execute(
+                "SELECT family, COUNT(*) FROM locus_work GROUP BY family ORDER BY family"
+            )
+        )
+        grains = dict(
+            conn.execute(
+                "SELECT grain, COUNT(*) FROM locus_work GROUP BY grain ORDER BY grain"
+            )
+        )
+        locus_ids = {
+            row[0]
+            for row in conn.execute(
+                "SELECT locus_ref_id FROM locus_work WHERE locus_ref_id LIKE 'REF4:%'"
+            )
+        }
+        expected_locus_ids = {
+            raw_id
+            for raw_id, entry in entry_by_id.items()
+            if len(entry["unit_offsets"]) > 1
+        }
+        if locus_ids != expected_locus_ids:
+            raise ValueError("V4 locus rows disagree with whole-work fallback decisions")
+        for raw_id in sorted(locus_ids):
+            entry = entry_by_id[raw_id]
+            rows = conn.execute(
+                "SELECT unit_ord, start_offset, label_he, citation_pos "
+                "FROM locus_unit WHERE locus_ref_id=? ORDER BY unit_ord",
+                (raw_id,),
+            ).fetchall()
+            expected = [
+                (ordinal, row["start_offset"], row["label_he"], row["citation_pos"])
+                for ordinal, row in enumerate(entry["unit_offsets"])
+            ]
+            if rows != expected:
+                raise ValueError("V4 locus units drifted from the reference manifest")
+    if integrity != "ok" or foreign_keys:
+        raise ValueError("V4 locus database failed SQLite integrity checks")
+    expected_vocab = {"sefaria", "ja", "msource_header", "msource_daf"}
+    if set(families) != expected_vocab:
+        raise ValueError("V4 locus family vocabulary drift")
+    if work_count != coverage["works_with_units"]:
+        raise ValueError("V4 locus work count drift")
+    if unit_count != coverage["units_total"]:
+        raise ValueError("V4 locus unit count drift")
+    if families != coverage["by_family"] or grains != coverage["by_grain"]:
+        raise ValueError("V4 locus coverage summaries drift from the database")
+    report = {
+        "schema_version": "discovery-v4-reference-verification-v1",
+        "manifest_sha256": sha256_file(manifest_path),
+        "base_reference_count": len(base),
+        "reference_count": len(reference),
+        "appended_reference_count": len(appended),
+        "appended_letters": sum(len(work["stream"]) for work in appended),
+        "providers": dict(Counter(entry["provider"] for entry in entries)),
+        "locus_work_count": work_count,
+        "locus_unit_count": unit_count,
+        "v4_locus_work_count": len(locus_ids),
+        "whole_work_fallback_count": len(entries) - len(locus_ids),
+        "integrity_check": integrity,
+        "foreign_key_problems": len(foreign_keys),
+    }
+    if args.report:
+        stable_json_dump(report, args.report)
+    print(json.dumps(report, indent=2))
+    return report
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--report")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    run(parse_args())

--- a/scripts/project_discovery_public.py
+++ b/scripts/project_discovery_public.py
@@ -11,9 +11,11 @@ claim rows alone.
 Usage:
     python scripts/project_discovery_public.py <private_db> <public_db_out>
 
-`is_public` (`shared/discovery_visibility.py`) is the ONE eligibility rule
-this script consumes -- it is never restated here. Every table present in
-the private input MUST have an explicit projection rule in
+`is_public` (`shared/discovery_visibility.py`) remains the row-level
+visibility rule. A separate, versioned owner-curated exclusion policy may
+withhold otherwise-public canonical works while retaining them in the private
+research bake as routing competitors. Every table present in the private input
+MUST have an explicit projection rule in
 `PROJECTION_RULES` below; an unrecognized table is a BUILD ERROR
 (`ProjectionError`), never silently copied whole.
 
@@ -35,6 +37,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sqlite3
 import sys
 from pathlib import Path
@@ -69,12 +72,65 @@ _LATER_SHARED_TEXT = "later_shared_text"
 # graph raises instead of looping forever.
 _MAX_CLOSURE_PASSES = 25
 
+_DEFAULT_PUBLIC_EXCLUSIONS_PATH = os.path.join(
+    _REPO_ROOT, "docs", "specs", "discovery-public-projection-exclusions-v1.json"
+)
+_PUBLIC_EXCLUSIONS_SCHEMA = "discovery-public-projection-exclusions-v1"
+_OPAQUE_WORK_ID_RE = re.compile(r"^w[0-9]{6}$")
+
 # G9: claim types that ASSERT a witness relation and therefore require at least
 # one witness-kind evidence row to survive with them.
 _WITNESS_ASSERTING_CLAIM_TYPES = (
     ids.CLAIM_TYPE_DIRECT_WITNESS,
     ids.CLAIM_TYPE_QUOTES_THIS_WORK,
 )
+
+
+def load_public_projection_exclusions(path: str) -> Tuple[str, Set[str]]:
+    """Load the owner-curated canonical-work exclusion policy.
+
+    The policy is projection-only: excluded works remain in the private asset
+    and continue to participate in routing and competition. The public build
+    drops their evidence first, then closes and recomputes the graph normally.
+    """
+    with open(path, encoding="utf-8") as fh:
+        payload = json.load(fh)
+    expected_top_keys = {
+        "schema_version", "policy_version", "ruled_date", "ruling", "entries"
+    }
+    if not isinstance(payload, dict) or set(payload) != expected_top_keys:
+        raise ProjectionError(
+            "public projection exclusions must use the exact versioned policy shape"
+        )
+    if payload["schema_version"] != _PUBLIC_EXCLUSIONS_SCHEMA:
+        raise ProjectionError("unsupported public projection exclusions schema_version")
+    policy_version = payload["policy_version"]
+    if not isinstance(policy_version, str) or not policy_version:
+        raise ProjectionError("public projection exclusions policy_version must be non-empty")
+    entries = payload["entries"]
+    if not isinstance(entries, list):
+        raise ProjectionError("public projection exclusions entries must be a list")
+    work_ids: Set[str] = set()
+    for entry in entries:
+        if not isinstance(entry, dict) or set(entry) != {
+            "canonical_work_id", "title", "reason"
+        }:
+            raise ProjectionError(
+                "every public projection exclusion must have canonical_work_id, title, reason"
+            )
+        work_id = entry["canonical_work_id"]
+        if not isinstance(work_id, str) or not _OPAQUE_WORK_ID_RE.fullmatch(work_id):
+            raise ProjectionError(
+                "public projection exclusion canonical_work_id must be an opaque work id"
+            )
+        if work_id in work_ids:
+            raise ProjectionError("public projection exclusions contain a duplicate work id")
+        if not isinstance(entry["title"], str) or not entry["title"]:
+            raise ProjectionError("public projection exclusion title must be non-empty")
+        if not isinstance(entry["reason"], str) or not entry["reason"]:
+            raise ProjectionError("public projection exclusion reason must be non-empty")
+        work_ids.add(work_id)
+    return policy_version, work_ids
 
 
 # ---------------------------------------------------------------------------
@@ -146,8 +202,16 @@ class ProjectionContext:
     """Everything the per-table projection rules need, computed ONCE from
     the private asset before any output row is written."""
 
-    def __init__(self, conn: sqlite3.Connection):
+    def __init__(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        exclusion_policy_version: str = "test-no-public-exclusions",
+        excluded_canonical_work_ids: Set[str] = frozenset(),
+    ):
         self.conn = conn
+        self.exclusion_policy_version = exclusion_policy_version
+        self.excluded_canonical_work_ids = frozenset(excluded_canonical_work_ids)
         self.works_by_id: Dict[str, Dict[str, Any]] = {
             w["work_id"]: w for w in _rows_as_dicts(conn, "works")
         }
@@ -160,6 +224,21 @@ class ProjectionContext:
         }
 
         all_evidence = _rows_as_dicts(conn, "discovery_evidence")
+        present_canonical_ids = {
+            work["canonical_work_id"] for work in self.works_by_id.values()
+        }
+        self.present_excluded_canonical_work_ids = (
+            self.excluded_canonical_work_ids & present_canonical_ids
+        )
+        self.policy_excluded_claim_ids = {
+            claim_id for claim_id, claim in self.claims_by_id.items()
+            if self.works_by_id.get(claim["work_id"], {}).get("canonical_work_id")
+            in self.excluded_canonical_work_ids
+        }
+        self.policy_excluded_evidence_ids = {
+            ev["evidence_id"] for ev in all_evidence
+            if ev["claim_id"] in self.policy_excluded_claim_ids
+        }
 
         # --- Evidence survival (the D-22 conjunction, per row) -----------
         surviving_evidence_by_claim: Dict[str, List[Dict[str, Any]]] = {}
@@ -170,6 +249,11 @@ class ProjectionContext:
             if claim is None:
                 continue  # orphan evidence in the PRIVATE asset -- not this script's concern
             work = self.works_by_id.get(claim["work_id"])
+            if (
+                work
+                and work.get("canonical_work_id") in self.excluded_canonical_work_ids
+            ):
+                continue
             identity_vis = work.get("identity_visibility") if work else None
             assertion_vis = ev.get("assertion_visibility")
             if visibility.is_public(assertion_vis, identity_vis):
@@ -310,6 +394,8 @@ class ProjectionContext:
         self.public_work_ids: Set[str] = {
             wid for wid in referenced_work_ids
             if self.works_by_id.get(wid, {}).get("identity_visibility") == visibility.VISIBILITY_PUBLIC
+            and self.works_by_id.get(wid, {}).get("canonical_work_id")
+            not in self.excluded_canonical_work_ids
         }
 
 
@@ -665,6 +751,10 @@ def _project_meta(ctx: ProjectionContext, projected_counts: Dict[str, int]) -> L
     private_meta = {row["key"]: row["value"] for row in _rows_as_dicts(ctx.conn, "meta")}
     out_meta = dict(private_meta)
     out_meta["audience"] = "public"
+    out_meta["public_projection_exclusion_version"] = ctx.exclusion_policy_version
+    out_meta["public_projection_excluded_canonical_work_count"] = str(
+        len(ctx.present_excluded_canonical_work_ids)
+    )
     # Recompute -- never copy -- every release-contract row-count key so a
     # reader can never infer how many private rows were removed from a
     # count that quietly stayed at the private total.
@@ -1048,6 +1138,7 @@ def project(
     public_db_out_path: str,
     *,
     masking_patterns: Optional[List[str]] = None,
+    public_exclusions_path: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Build the public projection at `public_db_out_path` from
     `private_db_path`. Returns the reconciliation report dict (also written
@@ -1070,7 +1161,15 @@ def project(
                 "projection rule is a build error, never a silent whole-table copy"
             )
 
-        ctx = ProjectionContext(private_conn)
+        exclusions_path = public_exclusions_path or _DEFAULT_PUBLIC_EXCLUSIONS_PATH
+        exclusion_policy_version, excluded_canonical_work_ids = (
+            load_public_projection_exclusions(exclusions_path)
+        )
+        ctx = ProjectionContext(
+            private_conn,
+            exclusion_policy_version=exclusion_policy_version,
+            excluded_canonical_work_ids=excluded_canonical_work_ids,
+        )
 
         out_path = Path(public_db_out_path)
         if out_path.exists():
@@ -1183,6 +1282,17 @@ def project(
             # Evidence dropped as a CASCADE of the above: a claim asserting a
             # witness relation that lost its last witness row goes entirely.
             "pruned_g9_cascade_evidence": len(ctx.pruned_g9_cascade_evidence_ids),
+            "public_projection_exclusions": {
+                "policy_version": ctx.exclusion_policy_version,
+                "configured_canonical_work_count": len(
+                    ctx.excluded_canonical_work_ids
+                ),
+                "present_canonical_work_count": len(
+                    ctx.present_excluded_canonical_work_ids
+                ),
+                "excluded_claim_count": len(ctx.policy_excluded_claim_ids),
+                "excluded_evidence_count": len(ctx.policy_excluded_evidence_ids),
+            },
             # A green `project()` is NOT a release decision. The self-gate above
             # is deliberately narrow -- it checks that what was just emitted is
             # internally coherent (closed graph, honest counts, right audience,
@@ -1237,6 +1347,14 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("private_db", help="Path to the PRIVATE discovery.db sidecar (input)")
     parser.add_argument("public_db_out", help="Path to write the PUBLIC projection to (output)")
+    parser.add_argument(
+        "--public-exclusions",
+        default=_DEFAULT_PUBLIC_EXCLUSIONS_PATH,
+        help=(
+            "Versioned public-projection canonical-work exclusion policy "
+            "(default: docs/specs/discovery-public-projection-exclusions-v1.json)"
+        ),
+    )
     return parser
 
 
@@ -1244,7 +1362,11 @@ def main(argv=None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
     try:
-        report = project(args.private_db, args.public_db_out)
+        report = project(
+            args.private_db,
+            args.public_db_out,
+            public_exclusions_path=args.public_exclusions,
+        )
     except ProjectionError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1

--- a/scripts/refresh_discovery_locus.py
+++ b/scripts/refresh_discovery_locus.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Replace only the locus layer of an already-built private discovery asset.
+
+This is the fast path for a division-table correction whose reference corpus,
+claims, routing, domains, and frame are unchanged.  It copies the input asset,
+empties the three imported locus tables, re-runs the production importer, and
+re-materializes both claim- and identification-grain labels plus filter pieces.
+The public projection must still be rerun afterwards; it recomputes those
+grains again after masking.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sqlite3
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.build_discovery_sidecar import (
+    LOCUS_SCHEMA_VERSION,
+    ingest_locus_divisions,
+    locus_display_meta_rows,
+    materialize_locus_labels,
+)
+
+
+def refresh_locus(
+    source_db: Path,
+    output_db: Path,
+    locus_db: Path,
+    crosswalk_path: Path,
+    reference_corpus_sha256: str,
+    locus_sha256: str,
+) -> dict:
+    if source_db.resolve() == output_db.resolve():
+        raise ValueError("locus refresh requires a distinct output path")
+    for path in (source_db, locus_db, crosswalk_path):
+        if not path.is_file():
+            raise FileNotFoundError(path)
+    output_db.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source_db, output_db)
+
+    with crosswalk_path.open(encoding="utf-8") as stream:
+        document = json.load(stream)
+    crosswalk = document.get("crosswalk", document)
+    if not isinstance(crosswalk, dict):
+        raise ValueError("crosswalk must be a JSON mapping")
+
+    conn = sqlite3.connect(output_db)
+    try:
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute("DELETE FROM discovery_locus_piece")
+        for table in ("locus_edition", "locus_unit", "locus_work"):
+            conn.execute(f"DELETE FROM {table}")
+        conn.execute(
+            "DELETE FROM meta WHERE key LIKE 'locus_%' "
+            "OR key LIKE 'expected_locus_%' "
+            "OR key IN ('expected_rows_locus_work', 'expected_rows_locus_unit', "
+            "'expected_rows_locus_edition', 'expected_rows_discovery_locus_piece')"
+        )
+        input_meta = ingest_locus_divisions(
+            conn,
+            str(locus_db),
+            crosswalk,
+            reference_corpus_sha256,
+            expected_sha256=locus_sha256,
+        )
+        status_counts = materialize_locus_labels(conn)
+        rows = [("locus_schema_version", LOCUS_SCHEMA_VERSION), *input_meta]
+        for table in ("locus_work", "locus_unit", "locus_edition"):
+            count = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+            rows.append((f"expected_rows_{table}", str(count)))
+        rows.extend(locus_display_meta_rows(conn))
+        conn.executemany(
+            "INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)", rows
+        )
+        integrity = conn.execute("PRAGMA integrity_check").fetchone()[0]
+        foreign_keys = conn.execute("PRAGMA foreign_key_check").fetchall()
+        if integrity != "ok" or foreign_keys:
+            raise ValueError(
+                f"refreshed asset failed SQLite checks: integrity={integrity!r}, "
+                f"foreign_keys={len(foreign_keys)}"
+            )
+        conn.commit()
+        return {
+            "locus_work": conn.execute("SELECT COUNT(*) FROM locus_work").fetchone()[0],
+            "locus_unit": conn.execute("SELECT COUNT(*) FROM locus_unit").fetchone()[0],
+            "locus_edition": conn.execute(
+                "SELECT COUNT(*) FROM locus_edition"
+            ).fetchone()[0],
+            **status_counts,
+        }
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source_db")
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--locus-divisions", required=True)
+    parser.add_argument("--locus-sha256", required=True)
+    parser.add_argument("--crosswalk", required=True)
+    parser.add_argument("--reference-corpus-sha256", required=True)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    result = refresh_locus(
+        Path(args.source_db),
+        Path(args.out),
+        Path(args.locus_divisions),
+        Path(args.crosswalk),
+        args.reference_corpus_sha256,
+        args.locus_sha256,
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2))

--- a/scripts/v3_measure_novelty_reuse.py
+++ b/scripts/v3_measure_novelty_reuse.py
@@ -130,7 +130,13 @@ _SQLITE_SIDECAR_SUFFIXES = ("-journal", "-wal", "-shm")
 # writer's alternatives from `finalize_build`'s own meta expression and fails if
 # that expression and this set disagree.
 _V3_ROUTING_MODES = frozenset({
-    "gen2_router", "gen2_router_split_regrained", "lever1_cliff", "none",
+    "gen2_router",
+    "gen2_router_split_regrained",
+    "gen2_router_split_regrained_fullscan_legacy_extrapolated",
+    "gen2_router_split_regrained_fullscan_legacy_v4_extrapolated",
+    "gen2_router_split_regrained_v4_extrapolated",
+    "lever1_cliff",
+    "none",
 })
 
 

--- a/scripts/v3_routing_ingest.py
+++ b/scripts/v3_routing_ingest.py
@@ -585,6 +585,178 @@ def route_e1_by_coverage(
     return report
 
 
+def route_v4_references_by_coverage(
+    router: Dict,
+    match_rows,
+    page_chars: Dict[str, int],
+    *,
+    raw_prefix: str = "REF4:",
+) -> Dict:
+    """Route newly appended V4 public references with the frozen threshold.
+
+    These references did not exist when gen-2's coverage router ran, so they
+    cannot be treated as independently routed or as split-grain descendants of
+    an old key.  Their matcher ``matched_letters`` and ``pages.n_chars`` are the
+    same numerator/denominator pair used by the calibrated router.  Reusing its
+    threshold is still an extrapolation to new works, and the dedicated
+    ``v4_reference_keys`` population makes that limitation explicit in parity
+    and asset metadata.
+
+    ``match_rows`` contains ``(page_id, raw_work_id, matched_letters)`` for the
+    unshadowed Track-1 frame.  Any non-V4 row is rejected; callers must split the
+    old and new populations deliberately rather than accidentally routing the
+    entire legacy frame through this path.
+    """
+    threshold = _router_threshold(router)
+    route = router["route"]
+    router.setdefault("v4_reference_keys", set())
+    report = {
+        "considered": 0,
+        "added": 0,
+        "already_present": 0,
+        "same_work": 0,
+        "parallel": 0,
+        "undecided": 0,
+        "undecided_examples": [],
+        "threshold": threshold,
+        "raw_prefix": raw_prefix,
+    }
+    seen = set()
+    for page_id, raw_work, matched_letters in match_rows:
+        if not isinstance(raw_work, str) or not raw_work.startswith(raw_prefix):
+            raise RoutingRegrainError(
+                "V4 reference routing received a row outside its declared raw-id prefix"
+            )
+        key = (page_id, raw_work)
+        if key in seen:
+            raise RoutingRegrainError(
+                "V4 reference routing received a duplicate (page, work) key"
+            )
+        seen.add(key)
+        report["considered"] += 1
+        if key in route:
+            raise RoutingRegrainError(
+                "V4 reference key already exists in the fitted router; the "
+                "new-reference population is no longer disjoint"
+            )
+        n_chars = page_chars.get(page_id)
+        if not n_chars or matched_letters is None:
+            report["undecided"] += 1
+            if len(report["undecided_examples"]) < 5:
+                report["undecided_examples"].append(
+                    {"page_id": page_id, "work_id": raw_work}
+                )
+            continue
+        if n_chars < 0 or matched_letters < 0:
+            raise RoutingRegrainError(
+                "V4 reference coverage received a negative numerator or denominator"
+            )
+        coverage = matched_letters / n_chars
+        if coverage > 1.0:
+            raise RoutingRegrainError(
+                f"V4 reference coverage exceeds 1.0 ({coverage:.4f}) -- the numerator "
+                f"and denominator are not the pair the threshold was calibrated on. "
+                f"Refusing to route on an impossible coverage. "
+                f"(counts only, D-25: matched={matched_letters}, denominator={n_chars})"
+            )
+        surface = SURFACE_SAME_WORK if coverage >= threshold else SURFACE_PARALLEL
+        route[key] = (surface, coverage, 1)
+        router["v4_reference_keys"].add(key)
+        report["added"] += 1
+        if surface == SURFACE_SAME_WORK:
+            report["same_work"] += 1
+        else:
+            report["parallel"] += 1
+    return report
+
+
+def route_fullscan_legacy_by_coverage(
+    router: Dict,
+    match_rows,
+    page_chars: Dict[str, int],
+    historical_keys,
+    *,
+    excluded_prefix: str = "REF4:",
+) -> Dict:
+    """Route legacy-reference pairs newly exposed by V4's full-page scan.
+
+    The historical Track-1 run did not scan every page. V4 must do so because a
+    new public reference can match a page outside that old allowlist; the same
+    scan can consequently expose a legacy-reference pair that the fitted router
+    never saw. These rows are neither fitted decisions nor new REF4 works, so
+    they get a distinct provenance population and reuse the frozen coverage
+    threshold as an explicit extrapolation.
+
+    ``historical_keys`` is the preserved V2 Track-1 snapshot. Any overlap is a
+    hard error: an old pair with no fitted/re-grained decision is regression,
+    not permission to extrapolate it.
+    """
+    threshold = _router_threshold(router)
+    route = router["route"]
+    historical_keys = set(historical_keys)
+    router.setdefault("fullscan_legacy_keys", set())
+    report = {
+        "considered": 0,
+        "added": 0,
+        "same_work": 0,
+        "parallel": 0,
+        "undecided": 0,
+        "undecided_examples": [],
+        "threshold": threshold,
+        "historical_key_count": len(historical_keys),
+    }
+    seen = set()
+    for page_id, raw_work, matched_letters in match_rows:
+        if not isinstance(raw_work, str) or raw_work.startswith(excluded_prefix):
+            raise RoutingRegrainError(
+                "full-scan legacy routing received a row outside its population"
+            )
+        key = (page_id, raw_work)
+        if key in seen:
+            raise RoutingRegrainError(
+                "full-scan legacy routing received a duplicate (page, work) key"
+            )
+        seen.add(key)
+        report["considered"] += 1
+        if key in historical_keys:
+            raise RoutingRegrainError(
+                "an unresolved full-scan key exists in the historical Track-1 frame"
+            )
+        if resolve_routing(page_id, raw_work, router)[0] is not None:
+            raise RoutingRegrainError(
+                "full-scan legacy routing received a key that already has a decision"
+            )
+        n_chars = page_chars.get(page_id)
+        if not n_chars or matched_letters is None:
+            report["undecided"] += 1
+            if len(report["undecided_examples"]) < 5:
+                report["undecided_examples"].append(
+                    {"page_id": page_id, "work_id": raw_work}
+                )
+            continue
+        if n_chars < 0 or matched_letters < 0:
+            raise RoutingRegrainError(
+                "full-scan legacy coverage received a negative numerator or denominator"
+            )
+        coverage = matched_letters / n_chars
+        if coverage > 1.0:
+            raise RoutingRegrainError(
+                f"full-scan legacy coverage exceeds 1.0 ({coverage:.4f}) -- the "
+                f"numerator and denominator are not the calibrated pair. "
+                f"(counts only, D-25: matched={matched_letters}, "
+                f"denominator={n_chars})"
+            )
+        surface = SURFACE_SAME_WORK if coverage >= threshold else SURFACE_PARALLEL
+        route[key] = (surface, coverage, 1)
+        router["fullscan_legacy_keys"].add(key)
+        report["added"] += 1
+        if surface == SURFACE_SAME_WORK:
+            report["same_work"] += 1
+        else:
+            report["parallel"] += 1
+    return report
+
+
 def resolve_routing(
     page_id: str, work_id: str, router: Dict
 ) -> Tuple[Optional[str], Optional[str], Optional[float]]:
@@ -756,6 +928,8 @@ def assert_assembled_parity(
     checked_independent = 0
     checked_regrained = 0
     checked_e1 = 0
+    checked_v4_references = 0
+    checked_fullscan_legacy = 0
     for row in evidence_rows:
         if row[evidence_source_idx] != track1_source:
             continue
@@ -800,6 +974,17 @@ def assert_assembled_parity(
             # extrapolation. Reported apart from BOTH the independent rows and
             # the re-grained ones, because they carry a different warrant.
             checked_e1 += 1
+        elif resolved_key in (router.get("v4_reference_keys") or ()):
+            # New public-reference works did not exist in gen-2's router. Their
+            # decision is a threshold extrapolation at the original metric, not
+            # an independently reproduced router result.
+            checked_v4_references += 1
+        elif resolved_key in (router.get("fullscan_legacy_keys") or ()):
+            # Removing the historical page allowlist exposes legacy-reference
+            # pairs the fitted router never saw. Their decision is also a
+            # threshold extrapolation, but it is deliberately counted apart
+            # from genuinely new REF4 work identities.
+            checked_fullscan_legacy += 1
         else:
             checked_independent += 1
         got = row[routing_status_idx]
@@ -859,6 +1044,8 @@ def assert_assembled_parity(
         "checked_independent": checked_independent,
         "checked_regrained": checked_regrained,
         "checked_e1": checked_e1,
+        "checked_v4_references": checked_v4_references,
+        "checked_fullscan_legacy": checked_fullscan_legacy,
     }
 
 

--- a/scripts/verify_discovery_sidecar.py
+++ b/scripts/verify_discovery_sidecar.py
@@ -2040,9 +2040,16 @@ def check_locus_reference_basis(conn: sqlite3.Connection, meta: dict) -> List[st
 
 _LOCUS_DISPLAY_VERSION = "locus-display-v1"
 _LOCUS_DISPLAY_STATUSES = ("resolved", "whole_work", "unavailable")
-_LOCUS_DIVISIONS_SHA256 = (
-    "aaac6f90d9ee2b4c3e0b83c0220e9215dc2cdee0c9995cd2ed6672b951898263"
-)
+_LOCUS_DIVISIONS_BY_REFERENCE_SHA256 = {
+    "acb6b86f61680e5b459fc8274aa3bce8b69d6bec13512c83a56167c7fd6646de": (
+        "aaac6f90d9ee2b4c3e0b83c0220e9215dc2cdee0c9"
+        "995cd2ed6672b951898263"
+    ),
+    "6c540e3987752f1e0ead36f881e8d2f41f903b6e1aa9121b2b109ecfbc8a3133": (
+        "c6cf55d2388585dd2fb8dcf2cb565bbbb386f7def8"
+        "a32b710516886c18f0fc40"
+    ),
+}
 
 
 def check_locus_display_contract(conn: sqlite3.Connection, meta: dict) -> List[str]:
@@ -2134,7 +2141,14 @@ def check_locus_display_contract(conn: sqlite3.Connection, meta: dict) -> List[s
             f"locus display: {bad_whole_work} whole-work row(s) have a populated unit table"
         )
     if conn.execute("SELECT COUNT(*) FROM locus_unit").fetchone()[0]:
-        if meta.get("locus_divisions_sha256") != _LOCUS_DIVISIONS_SHA256:
+        expected_locus_sha = _LOCUS_DIVISIONS_BY_REFERENCE_SHA256.get(
+            meta.get("reference_corpus_sha256")
+        )
+        if expected_locus_sha is None:
+            violations.append(
+                "meta.reference_corpus_sha256 has no approved locus input pair"
+            )
+        elif meta.get("locus_divisions_sha256") != expected_locus_sha:
             violations.append("meta.locus_divisions_sha256 is absent or not the pinned input")
 
     filter_marker = meta.get("locus_filter_version")

--- a/shared/discovery_service.py
+++ b/shared/discovery_service.py
@@ -3133,19 +3133,30 @@ class DiscoveryService:
         if conn is None or not self._has_locus_filter(conn):
             return unavailable_envelope(meta={"reason": "locus_filter_unavailable"})
         try:
+            work = conn.execute(
+                "SELECT family, grain FROM locus_work WHERE work_id=?",
+                (str(work_id),),
+            ).fetchone()
             rows = conn.execute(
                 "SELECT citation_pos, MIN(part_key) AS part_key, "
                 "MIN(label_he) AS label_he FROM locus_unit "
-                "WHERE work_id=? GROUP BY citation_pos ORDER BY citation_pos",
+                "WHERE work_id=? AND citation_pos IS NOT NULL "
+                "GROUP BY citation_pos ORDER BY citation_pos",
                 (str(work_id),),
             ).fetchall()
         except Exception as exc:
             logger.error("DiscoveryService.get_locus_units error: %s", exc)
             return unavailable_envelope(meta={"reason": "query_failed"})
         items = [surface_safe_locus_unit(dict(row)) for row in rows]
+        work_meta = dict(work) if work is not None else {}
         return make_envelope(
             STATUS_OK, items, len(items),
-            meta={"work_id": str(work_id), "locus_filter": True},
+            meta={
+                "work_id": str(work_id),
+                "locus_filter": True,
+                "family": work_meta.get("family"),
+                "grain": work_meta.get("grain"),
+            },
         )
 
     def get_findings_enveloped(
@@ -3497,7 +3508,13 @@ class DiscoveryService:
             for parent, count in parents.items()
         ]
         items.extend(surface_safe_facet(leaf) for leaf in leaves)
-        items.sort(key=lambda it: (it["parent"] or it["value"], it["is_leaf"], it["value"]))
+        from shared.domain_hierarchy import domain_sort_key
+
+        items.sort(key=lambda item: (
+            domain_sort_key(item["value"]),
+            item["is_leaf"],
+            item["value"],
+        ))
         return items
 
     def _findings_timeout(self) -> float:

--- a/shared/domain_hierarchy.py
+++ b/shared/domain_hierarchy.py
@@ -1,0 +1,186 @@
+"""Canonical, database-free FJMS domain hierarchy shared by UI surfaces."""
+
+FJMS_PARENT_ORDER = [
+    "Bible: Texts and Translations",
+    "Biblical Exegesis",
+    "Rabbinic Literature",
+    "Halakhic Literature and Talmudic Commentaries",
+    "Derashot and Later Midrashim",
+    "Philosophy, Theology, Ethical literature",
+    "Kabbalah",
+    "Polemics",
+    "Historiography and geographical descriptions",
+    "Occult Sciences",
+    "Sciences",
+    "Liturgy and Brakhot",
+    "Piyut and its Interpretation",
+    "Secular Poetry",
+    "Stories and Belles Lettres",
+    "Philology",
+    "Documentary",
+    "Ritual Objects",
+    "Other Religions",
+    "Teaching Aids,Pen Trials,Writing Exercises,Scribblings,Jotting",
+    "Ancillaries to the Main Work",
+    "Unspecified (Nature of text unclear after initial inspection)",
+    "Unspecified Domain",
+]
+FJMS_PARENT_IDX = {name: i for i, name in enumerate(FJMS_PARENT_ORDER)}
+
+FJMS_CHILD_ORDER = {
+    "Bible: Texts and Translations": [
+        "Bible: Texts", "Aramaic Targumim", "Arabic Tafsir",
+        "Translations into other Languages", "Apocryphal Literature",
+        "Massorah", "Lists of Parshiyyot and Haftarot", "Haftarot",
+    ],
+    "Biblical Exegesis": [
+        "Biblical Exegesis- Rabbanite", "Biblical Exegesis- Karaite",
+    ],
+    "Rabbinic Literature": [
+        "Mishnah: Texts and Translations", "Tosefta",
+        "Talmud Bavli: Texts and Anthologies", "Minor Tractates",
+        "Talmud Yerushalmi", "Midrash",
+    ],
+    "Halakhic Literature and Talmudic Commentaries": [
+        "Mishnaic Commentaries", "Talmud Bavli Commentaries",
+        "Talmud Yerushalmi Commentaries", "Talmudic Commentaries",
+        "Halakhic", "Sifrei Mitzvot (Rabbinical)",
+        "Responsa and Halakhic Decisions", "Minhagim",
+        "Talmud – Introductions and Rules",
+    ],
+    "Derashot and Later Midrashim": ["Derashot", "Eulogies", "Later Midrashim"],
+    "Philosophy, Theology, Ethical literature": [
+        "Kalam", "Philosophy", "Logic", "Ethical Literature",
+        "Mystical Literature (not Kabbalah)", "Sufi Literature",
+        "Hermetic Literature", "Wisdom Literature",
+        "Apocalyptic Literature", "Theology",
+    ],
+    "Kabbalah": [
+        "Heikhalot", "Zohar literature",
+        "Spanish and Provencal Kabbalah", "Lurianic Kabbalah",
+    ],
+    "Polemics": [
+        "Polemics Karaite-Rabbanite", "Polemics Jewish-Christian",
+        "Polemics Jewish-Muslim", "Polemics Rabbinical",
+    ],
+    "Occult Sciences": [
+        "Theoretical Works", "Astrology", "Alchemy", "Magic Recipes",
+        "Amulets", "Shimmush Tehillim", "Predicting the Future",
+        "Revealing Treasures",
+    ],
+    "Sciences": ["Astronomy", "Mathematics", "Medicine", "Meteorology", "Physics"],
+    "Liturgy and Brakhot": [
+        "Common Prayers", "Brakhot", "Prayer Commentaries",
+        "Karaite Prayers", "Occasional prayer", "Liturgical additions",
+        "Baqqashot and Personal Prayers", "Passover Haggadah",
+    ],
+    "Piyut and its Interpretation": [
+        "Piyyut", "Liturgical commentary", "Piyyut Commentaries",
+    ],
+    "Secular Poetry": ["Dirges"],
+    "Philology": ["Grammar", "Dictionaries", "Glossaries", "Cantillation notes"],
+    "Documentary": [
+        "Letters", "Personal Status Documents and Legal documents",
+        "Business Documents", "Lists", "Communal Documents", "Court Documents",
+        "Governmental Documents", "Notes/Records", "Accounts",
+    ],
+    "Ritual Objects": ["Mezuzot", "Tefillin", "Torah scroll", "Esther Scroll"],
+    "Other Religions": ["Christian", "Muslim"],
+    "Ancillaries to the Main Work": [
+        "Colophons", "Title Pages", "Table of contents", "Indices",
+        "Calendars", "Teaching Aids",
+    ],
+    "Unspecified Domain": [
+        "Blank", "Illegible", "Missing",
+        "Cannot be determined from the catalogue", "Unidentified",
+    ],
+}
+FJMS_CHILD_IDX = {
+    parent: {name: i for i, name in enumerate(children)}
+    for parent, children in FJMS_CHILD_ORDER.items()
+}
+
+FJMS_SUBCHILD_ORDER = {
+    "Massorah": [
+        "Masorah that follows the text order", "Cumulative or Comparative Masorah",
+        "Masorah in Arabic", "Masorah Variants",
+        "Diqduqe ha-Te'amim and Qunterese ha-Masorah", "Lists and Counts",
+    ],
+    "Mishnah: Texts and Translations": ["Mishnah: Texts", "Mishnah: Translations"],
+    "Talmud Bavli: Texts and Anthologies": [
+        "Talmud Bavli", "Talmud Bavli: Anthologies",
+    ],
+    "Midrash": ["Halakhic Midrashim", "Aggadic Midrashim"],
+    "Halakhic": [
+        "Halakhic - Saadia Gaon", "Halakhic - Shmuel ben Hofni Gaon",
+        "Halakhot ha-Rif and its Commentaries", "Halakhic- Gaonim",
+        "Mishneh Torah and its Commentaries", "Halakhic- Rishonim and Aharonim",
+        "Halakhic- Karaite",
+    ],
+    "Responsa and Halakhic Decisions": [
+        "Responsa- Gaonim", "Responsa- Rishonim and Aharonim", "Responsa- Karaite",
+    ],
+    "Kalam": ["Jewish Kalam", "Muslim Kalam"],
+    "Philosophy": ["Aristotelian Philosophy", "Neoplatonic Philosophy"],
+    "Theology": ["Legal theory"],
+    "Predicting the Future": [
+        "Dream interpretation", "Goralot (Lots)", "Goralot (Lots) in Sand",
+        "Predictions by Thunder", "Palmistry", "Predictions by Ticks",
+        "Physiognomy", "Hemorology/Horology",
+    ],
+    "Astronomy": ["Calendar"],
+    "Medicine": ["Medical Works", "Medical Prescriptions", "Pharmacology"],
+    "Glossaries": [
+        "Biblical Glossary", "Mishnaic Glossary", "Talmudic Glossary",
+        "Glossary for Piyyut",
+    ],
+    "Personal Status Documents and Legal documents": [
+        "Get Halitzah", "Ketubbot", "Legal documents",
+    ],
+    "Business Documents": ["Monetary Issues", "Contracts"],
+    "Lists": [
+        "Book lists", "Shopping lists", "Charity Lists", "Genealogical Records",
+        "Property Lists", "Lists of People", "Lists of Debts", "Responsa lists",
+    ],
+    "Communal Documents": [
+        "Communal Registers", "Writs of Appointment", "Bans and Excommunications",
+    ],
+    "Court Documents": ["Court Records", "Court Registers"],
+}
+FJMS_SUBCHILD_IDX = {
+    parent: {name: i for i, name in enumerate(children)}
+    for parent, children in FJMS_SUBCHILD_ORDER.items()
+}
+
+
+def domain_sort_key(value: str) -> tuple:
+    """Return a domain's canonical ``/catalog-browse`` hierarchy position."""
+    text = str(value or "").strip()
+    parts = [part.strip() for part in text.split(" / ") if part.strip()]
+    node = parts[-1] if parts else ""
+    fallback = 9999
+
+    if node in FJMS_PARENT_IDX:
+        return (FJMS_PARENT_IDX[node], -1, -1, text.casefold())
+
+    for parent, children in FJMS_CHILD_IDX.items():
+        if node in children:
+            return (FJMS_PARENT_IDX.get(parent, fallback), children[node], -1, text.casefold())
+
+    for child, subchildren in FJMS_SUBCHILD_IDX.items():
+        if node not in subchildren:
+            continue
+        for parent, children in FJMS_CHILD_IDX.items():
+            if child in children:
+                return (
+                    FJMS_PARENT_IDX.get(parent, fallback),
+                    children[child],
+                    subchildren[node],
+                    text.casefold(),
+                )
+
+    if len(parts) > 1:
+        parent_key = domain_sort_key(parts[0])
+        if parent_key[0] != fallback:
+            return (parent_key[0], parent_key[1], fallback, text.casefold())
+    return (fallback, fallback, fallback, text.casefold())

--- a/shared/fjms_service.py
+++ b/shared/fjms_service.py
@@ -23,6 +23,7 @@ import threading
 from pathlib import Path
 from typing import Optional
 
+from shared import domain_hierarchy as _domain_hierarchy
 from shared.thread_local_db import ThreadLocalConnection
 # Phase 78 (Concern #3): APIError from neutral shared module — NOT from web layer.
 # Plan 03 R2-#3: validate_filter_values uses APIError to fail closed when
@@ -687,6 +688,19 @@ _FJMS_SUBCHILD_IDX = {
 }
 
 
+def fjms_domain_sort_key(value: str) -> tuple:
+    """Compatibility wrapper around the shared, database-free authority."""
+    return _domain_hierarchy.domain_sort_key(value)
+
+
+# Keep the existing public helper and catalogue implementation on the same
+# database-free authority that Discovery imports.  The aliases also preserve
+# compatibility for callers which historically imported the FJMS names here.
+_FJMS_PARENT_IDX = _domain_hierarchy.FJMS_PARENT_IDX
+_FJMS_CHILD_IDX = _domain_hierarchy.FJMS_CHILD_IDX
+_FJMS_SUBCHILD_IDX = _domain_hierarchy.FJMS_SUBCHILD_IDX
+
+
 class FjmsService:
     """Service for accessing FJMS enrichment data from the SQLite sidecar."""
 
@@ -727,18 +741,26 @@ class FjmsService:
 
         # Resolve db_path
         if db_path is None:
-            # Check user-updated sidecar location first (LOCALAPPDATA)
-            import os
-            user_path = os.path.join(
-                os.environ.get('LOCALAPPDATA', ''),
-                'GenizahSearchPro', 'data', _SIDECAR_DIR, _SIDECAR_FILENAME
-            )
-            if os.path.isfile(user_path):
-                db_path = user_path
+            # A worktree does not contain gitignored sidecars. Let a local
+            # preview point explicitly at the main checkout's FJMS database
+            # without copying 1.5 GB or creating a junction. An explicit
+            # constructor argument still has priority over this environment
+            # override, which in turn has priority over auto-detection.
+            configured_path = os.environ.get("GENIZAH_FJMS_DB_PATH", "").strip()
+            if configured_path:
+                db_path = configured_path
             else:
-                root = _find_project_root()
-                if root:
-                    db_path = str(root / _SIDECAR_DIR / _SIDECAR_FILENAME)
+                # Check user-updated sidecar location first (LOCALAPPDATA)
+                user_path = os.path.join(
+                    os.environ.get('LOCALAPPDATA', ''),
+                    'GenizahSearchPro', 'data', _SIDECAR_DIR, _SIDECAR_FILENAME
+                )
+                if os.path.isfile(user_path):
+                    db_path = user_path
+                else:
+                    root = _find_project_root()
+                    if root:
+                        db_path = str(root / _SIDECAR_DIR / _SIDECAR_FILENAME)
 
         if db_path is None:
             logger.warning("FjmsService: No db_path provided and project root not found")

--- a/tests/render_smoke/test_discovery_masking_sweep.py
+++ b/tests/render_smoke/test_discovery_masking_sweep.py
@@ -758,8 +758,14 @@ def _findings_deep_renders(seed: Optional[str] = None) -> Tuple[List[str], List[
     hrefs: List[str] = []
 
     def _take(client) -> None:
-        texts.extend(_client_texts(client))
-        hrefs.extend(_client_hrefs(client))
+        try:
+            texts.extend(_client_texts(client))
+            hrefs.extend(_client_hrefs(client))
+        finally:
+            # These capture clients are synthetic and never connect. Keeping
+            # dozens of them in NiceGUI's global registry lets later tests'
+            # pruning timer reach a client with no request context.
+            client.delete()
 
     # A facet cascade with a PARENT and its LEAF, so the domain tree renders its
     # branch, its chevron and its collapsed child container rather than a flat
@@ -1392,7 +1398,10 @@ def capture_copy_export(hrefs: List[str], seed: Optional[str] = None) -> str:
         # The seeded row's link target, rendered by the shipped renderer.
         client = _render_component(
             lambda: fr.render_finding_row(tf.finding_row(sys_id=seed), "en"))
-        lines.extend(_client_hrefs(client))
+        try:
+            lines.extend(_client_hrefs(client))
+        finally:
+            client.delete()
     return "\n".join(lines)
 
 
@@ -1478,12 +1487,18 @@ def _rendered_error_states(seed: Optional[str] = None) -> List[Tuple[str, str]]:
             client = _render_findings_page(
                 lang=lang, findings=tf.findings_envelope([], status=status),
                 drive=True)
-            out.append((f"rendered-outage/{status}/{lang}",
-                        "\n".join(_client_texts(client))))
+            try:
+                out.append((f"rendered-outage/{status}/{lang}",
+                            "\n".join(_client_texts(client))))
+            finally:
+                client.delete()
         client = _render_component(lambda ln=lang, t=title: fr.render_finding_row(
             tf.finding_row(neutral_title=t, rendered_relation="not_a_relation"), ln))
-        out.append((f"rendered-malformed-row/{lang}",
-                    "\n".join(_client_texts(client))))
+        try:
+            out.append((f"rendered-malformed-row/{lang}",
+                        "\n".join(_client_texts(client))))
+        finally:
+            client.delete()
     return out
 
 

--- a/tests/render_smoke/test_discovery_masking_sweep.py
+++ b/tests/render_smoke/test_discovery_masking_sweep.py
@@ -529,6 +529,24 @@ def _render_findings_page(*, lang: str, findings: Any, facets: Any = None,
     async def _launch(*_a, **_k):
         return dict(launch_envelope)
 
+    async def _locus_units(work_id):
+        return {
+            "status": "ok",
+            "items": [
+                {"citation_pos": 10, "part_key": "page:10",
+                 "label_he": "פרק יז, עמ' 219"},
+                {"citation_pos": 11, "part_key": "page:11",
+                 "label_he": "פרק יח, עמ' 220"},
+            ],
+            "total": 2,
+            "meta": {
+                "work_id": work_id,
+                "locus_filter": True,
+                "family": "ja",
+                "grain": "page",
+            },
+        }
+
     # excerpt-v1 (2026-08-13): availability answered TRUE so `_render_row`
     # builds the `load_excerpt` closure, and the read stubbed so the driven
     # click on the compare-texts toggle EXECUTES that closure -- the
@@ -546,6 +564,7 @@ def _render_findings_page(*, lang: str, findings: Any, facets: Any = None,
     patch.setattr(fp, "get_findings_enveloped", _findings)
     patch.setattr(fp, "get_findings_facets_enveloped", _facets)
     patch.setattr(fp, "get_launch_stats_enveloped", _launch)
+    patch.setattr(fp, "get_locus_units_enveloped", _locus_units)
     patch.setattr(fp, "excerpts_available", _excerpts_on)
     patch.setattr(fp, "get_excerpt_enveloped", _excerpt)
     patch.setattr(fp, "discovery_meta",
@@ -663,7 +682,6 @@ async def _drive_value_change_handlers(client) -> None:
     import inspect as _inspect
 
     for element in list(client.elements.values()):
-        slot = getattr(element, "parent_slot", None)
         handlers = list(getattr(element, "_change_handlers", None) or ())
         # ...plus any NON-click listener the surface registered itself. NiceGUI's
         # own internal bridges are skipped: they read a different event shape and
@@ -680,6 +698,12 @@ async def _drive_value_change_handlers(client) -> None:
         for value in _control_option_values(element):
             for handler in handlers:
                 try:
+                    # A preceding change handler can repaint the whole result
+                    # region and detach controls that were present in this
+                    # snapshot. Resolve the weak parent-slot reference here so
+                    # a detached control is skipped by the same fail-soft path
+                    # as a handler that is no longer driveable.
+                    slot = getattr(element, "parent_slot", None)
                     with slot if slot is not None else client:
                         result = (handler()
                                   if not _inspect.signature(handler).parameters
@@ -777,6 +801,26 @@ def _findings_deep_renders(seed: Optional[str] = None) -> Tuple[List[str], List[
         _take(_render_findings_page(
             lang=lang, findings=tf.findings_envelope(rows_full),
             facets=rich_facets))
+        # 2a. a selected work with addressable units. The initial facet pass
+        # paints the From/To controls and caches their envelope; the generic
+        # change-handler driver then refreshes the page and exercises the cache
+        # hit as well as the controls' own async selection handlers.
+        _take(_render_findings_page(
+            lang=lang, findings=tf.findings_envelope(rows_full),
+            facets=rich_facets,
+            state={"unit": tf.FINDINGS_UNIT_IDENTIFICATION,
+                   "bucket": tf.BUCKET_MAIN, "sort": "band_rank",
+                   "novelty_view": fp.NOVELTY_VIEW_ALL, "domain": None,
+                   "author": None, "work_id": tf.CURATED_WORK_ID,
+                   "work_label": tf.CURATED_RAW_TITLE, "page": 1}))
+        # A populated locus table can still have no public address options.
+        # Exercise the honest fail-closed branch: it paints no empty controls.
+        _take(_render_component(
+            lambda ln=lang: fp._render_locus_range(
+                {"status": "ok", "items": [], "total": 0, "meta": {}},
+                {"locus_from": None, "locus_to": None}, ln,
+                lambda: None,
+            )))
         # 2b. a PERSISTED PAGE PAST THE END. The page clamps its own state and
         #     refetches, and that refetch is a second painted result region no
         #     other case in this capture produces -- reachable only when the
@@ -1274,6 +1318,21 @@ def payload_map(seed: Optional[str] = None) -> Dict[str, List[Tuple[str, Any]]]:
         "get_launch_stats_enveloped": (
             [(n, e) for n, e in findings_envelopes if n.startswith("launch/")]
             + [("launch_shades", panel["launch_shades"])]),
+        "get_locus_units_enveloped": [("locus_units", {
+            "status": "ok",
+            "items": [{
+                "citation_pos": 1,
+                "part_key": "chapter:1",
+                "label_he": _seeded(seed, "פרק א"),
+            }],
+            "total": 1,
+            "meta": {
+                "work_id": tf.CURATED_WORK_ID,
+                "locus_filter": True,
+                "family": "other_staged",
+                "grain": "chapter",
+            },
+        })],
         # excerpt-v1 (2026-08-13): the one payload whose values are CORPUS TEXT.
         # The seed stands in every text piece and the attribution.
         "get_excerpt_enveloped": [("excerpt", {
@@ -1662,6 +1721,15 @@ NON_PAINTING_EXEMPT: Dict[Tuple[str, str, str], str] = {
         "nothing -- and it is taken only when the reader's client disconnected "
         "while a cascade read was in flight, which a synchronous capture cannot "
         "produce without faking the client's own liveness.",
+    ("web/pages/findings.py", "_render_locus_range",
+     "except (TypeError, ValueError):"):
+        "the defensive conversion guard for a malformed select event. It only "
+        "chooses a local fallback and paints nothing; the shipped select emits "
+        "integer option keys or None, neither of which can enter this branch.",
+    ("web/pages/findings.py", "_render_locus_range", "candidate = None"):
+        "the local assignment inside the same malformed-event guard. It paints "
+        "nothing, and producing it would require fabricating an event value the "
+        "range select cannot emit from its integer-keyed option vocabulary.",
     ("web/pages/findings.py", "_render_body", "return"):
         "the page-gone guards inside `refresh`. They RETURN -- they put nothing "
         "on a screen -- and they are taken only when the reader's client has "

--- a/tests/render_smoke/test_findings_render_smoke.py
+++ b/tests/render_smoke/test_findings_render_smoke.py
@@ -2865,8 +2865,11 @@ def capture_rendered_output(destination: str) -> str:
                     finally:
                         patch.undo()
                     chunks.append(f"--- {lang}/{status}/{unit}/{bucket} ---")
-                    for element in client.elements.values():
-                        chunks.extend(_subtree_texts(element))
+                    try:
+                        for element in client.elements.values():
+                            chunks.extend(_subtree_texts(element))
+                    finally:
+                        client.delete()
 
         # TWO STATES THE MATRIX ABOVE CANNOT REACH, each one a branch that
         # PAINTS. A capture that never enters a painting branch is a masking
@@ -2926,8 +2929,11 @@ def capture_rendered_output(destination: str) -> str:
             finally:
                 patch.undo()
             chunks.append(f"--- {lang}/{label} ---")
-            for element in client.elements.values():
-                chunks.extend(_subtree_texts(element))
+            try:
+                for element in client.elements.values():
+                    chunks.extend(_subtree_texts(element))
+            finally:
+                client.delete()
 
     with contextlib.closing(io.open(destination, "w", encoding="utf-8")) as fh:
         fh.write("\n".join(chunks))

--- a/tests/render_smoke/test_panel_render_smoke.py
+++ b/tests/render_smoke/test_panel_render_smoke.py
@@ -2190,8 +2190,12 @@ async def _drive_click_handlers(client, rounds: int = 2) -> None:
         for element, handler in listeners:
             if handler is None:
                 continue
-            slot = getattr(element, 'parent_slot', None)
             try:
+                # An earlier driven handler may clear and repaint this
+                # element's container. NiceGUI then raises while resolving the
+                # old element's weak parent-slot reference; treat that detached
+                # control like any other handler that is no longer driveable.
+                slot = getattr(element, 'parent_slot', None)
                 with slot if slot is not None else client:
                     result = (handler()
                               if not inspect.signature(handler).parameters

--- a/tests/render_smoke/test_panel_render_smoke.py
+++ b/tests/render_smoke/test_panel_render_smoke.py
@@ -2229,8 +2229,12 @@ def _render_capture(paint, *, drive: bool = True) -> str:
 
     asyncio.run(_run())
     parts: List[str] = []
-    for element in holder['client'].elements.values():
-        parts.extend(_own_texts(element))
+    client = holder['client']
+    try:
+        for element in client.elements.values():
+            parts.extend(_own_texts(element))
+    finally:
+        client.delete()
     return '\n'.join(parts)
 
 

--- a/tests/test_bake_excerpt_cleaning.py
+++ b/tests/test_bake_excerpt_cleaning.py
@@ -13,12 +13,78 @@ Grammar licence, measured over all 92 per_doc files: 1,743 distinct tokens,
 and outside the grammar the corpus contains only three stray `+~` pairs --
 `+` and `~` are never content characters.
 """
+import json
+import sqlite3
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 
-from bake_discovery_excerpts import clean_ja_markers  # noqa: E402
+from bake_discovery_excerpts import (  # noqa: E402
+    clean_ja_markers,
+    excerpt_candidate_key,
+    is_excerpt_only_fallback,
+    load_v4_public_sources,
+    sha256_file,
+    validate_bake_input_hashes,
+)
+
+
+def _excerpt_candidate(**updates):
+    row = {
+        "evidence_id": "e1",
+        "matched_letters": 100,
+        "w_start": None,
+        "w_end": None,
+        "evidence_source": "propagated",
+        "routing_status": "shipped",
+        "adjudication_status": "unreviewed",
+        "assertion_visibility": "public",
+    }
+    row.update(updates)
+    return row
+
+
+def test_excerpt_only_direct_fallback_beats_an_unlocated_propagated_row():
+    propagated = _excerpt_candidate(matched_letters=500)
+    direct = _excerpt_candidate(
+        evidence_id="e2",
+        matched_letters=100,
+        w_start=10,
+        w_end=40,
+        evidence_source="track1_direct",
+        routing_status="review_only",
+    )
+    assert is_excerpt_only_fallback(direct)
+    assert excerpt_candidate_key(direct) < excerpt_candidate_key(propagated)
+
+
+def test_eligible_located_evidence_still_beats_the_excerpt_only_fallback():
+    shipped = _excerpt_candidate(w_start=10, w_end=40)
+    fallback = _excerpt_candidate(
+        evidence_id="e2",
+        matched_letters=999,
+        w_start=20,
+        w_end=60,
+        evidence_source="track1_direct",
+        routing_status="review_only",
+    )
+    assert excerpt_candidate_key(shipped) < excerpt_candidate_key(fallback)
+
+
+def test_private_or_unlocated_review_rows_are_never_excerpt_fallbacks():
+    base = {
+        "evidence_source": "track1_direct",
+        "routing_status": "review_only",
+        "w_start": 10,
+        "w_end": 40,
+    }
+    assert not is_excerpt_only_fallback(
+        _excerpt_candidate(**base, assertion_visibility="private")
+    )
+    assert not is_excerpt_only_fallback(
+        _excerpt_candidate(**(base | {"w_end": 10}))
+    )
 
 
 def test_label_and_value_tokens_are_removed_inline_and_on_their_own_line():
@@ -52,3 +118,81 @@ def test_text_without_markers_passes_through_unchanged():
 def test_none_and_empty_are_passed_through():
     assert clean_ja_markers(None) is None
     assert clean_ja_markers("") == ""
+
+
+def test_v4_public_source_loader_replays_pinned_unit_selection(tmp_path):
+    normalized_dir = tmp_path / "normalized"
+    normalized_dir.mkdir()
+    normalized = {
+        "attribution": "Synthetic public attribution",
+        "units": [
+            {"ordinal": 1, "text": "יחידה אחת"},
+            {"ordinal": 2, "text": "יחידה שתים"},
+            {"ordinal": 3, "text": "יחידה שלש"},
+        ],
+    }
+    normalized_path = normalized_dir / "source.json"
+    normalized_path.write_text(json.dumps(normalized), encoding="utf-8")
+    acquisition = {
+        "entries": [
+            {
+                "key": "source",
+                "status": "acquired",
+                "normalized_file": "source.json",
+                "normalized_sha256": sha256_file(normalized_path),
+            }
+        ]
+    }
+    acquisition_path = tmp_path / "acquisition.json"
+    acquisition_path.write_text(json.dumps(acquisition), encoding="utf-8")
+    reference = {
+        "schema_version": "discovery-v4-reference-manifest-v1",
+        "acquisition_manifest": str(acquisition_path),
+        "acquisition_manifest_sha256": sha256_file(acquisition_path),
+        "entries": [
+            {
+                "raw_reference_id": "REF4:source:2_3",
+                "source_key": "source",
+                "unit_offsets": [
+                    {"source_ordinal": 2},
+                    {"source_ordinal": 3},
+                ],
+            }
+        ],
+    }
+    reference_path = tmp_path / "reference.json"
+    reference_path.write_text(json.dumps(reference), encoding="utf-8")
+
+    texts, attributions, source_hash = load_v4_public_sources(
+        reference_path, normalized_dir
+    )
+    assert texts == {"REF4:source:2_3": "יחידה שתים\nיחידה שלש"}
+    assert attributions == {"REF4:source:2_3": "Synthetic public attribution"}
+    assert source_hash == sha256_file(acquisition_path)
+
+
+def test_excerpt_inputs_are_bound_to_the_public_sidecar_hashes(tmp_path):
+    crosswalk = tmp_path / "crosswalk.json"
+    reference = tmp_path / "reference.pkl"
+    crosswalk.write_text("{}", encoding="utf-8")
+    reference.write_bytes(b"reference")
+    db = tmp_path / "public.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute("CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT)")
+        conn.executemany(
+            "INSERT INTO meta VALUES (?, ?)",
+            [
+                ("crosswalk_sha256", sha256_file(crosswalk)),
+                ("reference_corpus_sha256", sha256_file(reference)),
+            ],
+        )
+
+    meta = validate_bake_input_hashes(db, crosswalk, reference)
+    assert meta["crosswalk_sha256"] == sha256_file(crosswalk)
+    reference.write_bytes(b"different")
+    try:
+        validate_bake_input_hashes(db, crosswalk, reference)
+    except ValueError as exc:
+        assert "reference pickle" in str(exc)
+    else:  # pragma: no cover - mutation control
+        raise AssertionError("a changed reference pickle passed its sidecar pin")

--- a/tests/test_build_work_divisions.py
+++ b/tests/test_build_work_divisions.py
@@ -47,6 +47,7 @@ from scripts.build_work_divisions import (
     build_ja,
     build_ja_pages,
     build_sefaria,
+    build_staged_ja_chapters,
     check_invariants,
     ja_edition,
     ja_range_regressions,
@@ -65,6 +66,7 @@ from shared.discovery_locus import (
     RANGE_SEP,
     LocusAddress,
     citation_runs,
+    heb_numeral,
     norm_stream,
     parse_canonical_header,
     stream_offset_for_raw,
@@ -80,6 +82,52 @@ PROVENANCE = "| PROVENANCE-FIELD: SOURCE-MS"
 _STAGING_DIR = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
     "same_work_spike", "probe", "refs_staging")
+
+
+def test_staged_guide_uses_its_three_exact_chapter_resets(tmp_path):
+    parts = (76, 48, 54)
+    lines = ["הקדמת המחבר"]
+    for count in parts:
+        for chapter in range(1, count + 1):
+            # Exercise the source's two non-canonical sixteen markers too.
+            numeral = "יו" if chapter == 16 and count != 54 else heb_numeral(chapter)
+            lines.extend((f"פצל # {numeral}", f"טקסט {chapter}"))
+    raw = "\n".join(lines)
+    (tmp_path / "guide.txt").write_text(raw, encoding="utf-8")
+    stream = norm_stream(raw)[0]
+
+    built = build_staged_ja_chapters(
+        "ja2_rambam_moreh", str(tmp_path), "guide.txt",
+        "REF2:ja2_rambam_moreh", {"REF2:ja2_rambam_moreh": stream},
+    )
+
+    assert built is not None
+    assert (built.family, built.grain, len(built.units)) == ("ja", "chapter", 179)
+    assert built.units[0].label_he == "הקדמה"
+    assert built.units[0].citation_pos == 1
+    assert built.units[1].label_he == "חלק א, פרק א"
+    assert built.units[1].citation_pos == 1001
+    assert built.units[76].label_he == "חלק א, פרק עו"
+    assert built.units[77].label_he == "חלק ב, פרק א"
+    assert built.units[77].citation_pos == 2001
+    assert built.units[-1].label_he == "חלק ג, פרק נד"
+    assert all(a.start < b.start for a, b in zip(built.units, built.units[1:]))
+
+
+def test_staged_guide_fails_closed_on_changed_chapter_sequence(tmp_path):
+    lines = ["פתיחה"]
+    for count in (76, 48, 54):
+        for chapter in range(1, count + 1):
+            numeral = heb_numeral(2 if chapter == 1 and count == 48 else chapter)
+            lines.extend((f"פצל # {numeral}", "טקסט"))
+    raw = "\n".join(lines)
+    (tmp_path / "guide.txt").write_text(raw, encoding="utf-8")
+
+    assert build_staged_ja_chapters(
+        "ja2_rambam_moreh", str(tmp_path), "guide.txt",
+        "REF2:ja2_rambam_moreh",
+        {"REF2:ja2_rambam_moreh": norm_stream(raw)[0]},
+    ) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_discovery_build.py
+++ b/tests/test_discovery_build.py
@@ -3579,14 +3579,17 @@ def test_the_probes_filter_axes_are_PINNED_to_the_shipped_predicate_builder():
     says "the FULL combination space" -- which is round 13's finding 4 verbatim.
 
     `unit` and `bucket` are excluded because neither is optional: `unit` is a
-    grain the probe crosses separately, and `bucket` is the state's stem."""
+    grain the probe crosses separately, and `bucket` is the state's stem.
+    `locus_enabled` is also excluded because it is an internal schema
+    capability selected by DiscoveryService, not page state a reader can set;
+    the reader-settable locus axes are `locus_from` and `locus_to`."""
     import inspect
     from scripts import bench_discovery
     from shared.discovery_service import _build_findings_filter
 
     authority = tuple(
         name for name in inspect.signature(_build_findings_filter).parameters
-        if name not in ("unit", "bucket")
+        if name not in ("unit", "bucket", "locus_enabled")
     )
     probe = tuple(
         "work_id" if axis == "work" else axis

--- a/tests/test_discovery_display_strings.py
+++ b/tests/test_discovery_display_strings.py
@@ -124,6 +124,8 @@ SWEEP_INPUTS = {
     "low_coverage_note": [{}],
     "granularity_subline": [{"other_work_title": WORK_EN},
                             {"other_work_title": WORK_HE}],
+    "locus_subline": [{"locus_label": "Part I, chapter 1"},
+                       {"locus_label": "חלק א, פרק א"}],
     "missing_title": [{}],
     "not_an_identification_note": [{}],
     "section_header": [

--- a/tests/test_discovery_findings_query.py
+++ b/tests/test_discovery_findings_query.py
@@ -311,6 +311,12 @@ def test_locus_range_filters_by_witnessed_interval_and_old_assets_ignore_it(tmp_
     units = service.get_locus_units_enveloped("wA")
     assert units["status"] == STATUS_OK
     assert [item["citation_pos"] for item in units["items"]] == [1, 2, 3]
+    assert units["meta"] == {
+        "work_id": "wA",
+        "locus_filter": True,
+        "family": "sefaria",
+        "grain": "chapter",
+    }
 
 
 def test_per_manuscript_unit_annotates_a_manuscript_carrying_more_than_one_work(service):
@@ -1275,6 +1281,31 @@ def test_a_genre_with_no_separator_is_a_leaf_and_never_also_a_parent(service):
     assert None not in by_value, "a NULL-keyed parent node reached the surface"
     parents = [row["value"] for row in env["items"] if not row["is_leaf"]]
     assert sorted(parents) == [_PARENT_A, _PARENT_B]
+
+
+def test_domain_facets_follow_catalog_browse_order_not_alphabetical():
+    rows = [
+        {"value": "Philosophy, Theology, Ethical literature / Ethical Literature",
+         "label": "", "count": 1},
+        {"value": "Midrash / Aggadic Midrashim", "label": "", "count": 1},
+        {"value": "Biblical Exegesis / Biblical Exegesis- Rabbanite",
+         "label": "", "count": 1},
+        {"value": "Bible: Texts and Translations / Arabic Tafsir",
+         "label": "", "count": 1},
+    ]
+    parent_rows = [
+        {"value": "Philosophy, Theology, Ethical literature", "count": 1},
+        {"value": "Midrash", "count": 1},
+        {"value": "Biblical Exegesis", "count": 1},
+        {"value": "Bible: Texts and Translations", "count": 1},
+    ]
+    items = DiscoveryService._project_facets("domain", rows, parent_rows)
+    assert [item["value"] for item in items if not item["is_leaf"]] == [
+        "Bible: Texts and Translations",
+        "Biblical Exegesis",
+        "Midrash",
+        "Philosophy, Theology, Ethical literature",
+    ]
 
 
 def test_the_facet_count_table_covers_exactly_the_offered_units():

--- a/tests/test_discovery_locus_bake.py
+++ b/tests/test_discovery_locus_bake.py
@@ -92,6 +92,20 @@ def test_locus_import_rejects_a_bad_pin_before_reading_rows(tmp_path):
         )
 
 
+def test_locus_import_selects_pin_by_reference_corpus(tmp_path, monkeypatch):
+    path, digest = _source_fixture(tmp_path)
+    monkeypatch.setitem(builder.LOCUS_DIVISIONS_BY_REFERENCE_SHA256, REF_SHA, digest)
+    meta = dict(builder.ingest_locus_divisions(
+        _asset(), str(path), {"raw:kept": "w000001"}, REF_SHA
+    ))
+    assert meta["locus_divisions_sha256"] == digest
+
+    with pytest.raises(ValueError, match="no approved"):
+        builder.ingest_locus_divisions(
+            _asset(), str(path), {}, "b" * 64
+        )
+
+
 def test_locus_import_rejects_coverage_invariant_problems(tmp_path):
     path, digest = _source_fixture(tmp_path, invariant_problems=["synthetic"])
     with pytest.raises(ValueError, match="invariant problems"):

--- a/tests/test_discovery_v2_bake.py
+++ b/tests/test_discovery_v2_bake.py
@@ -203,6 +203,88 @@ def test_canonical_merges_release_semantics_reject_wrong_drop_set(tmp_path):
         sidecar_build.load_canonical_merges(path, require_release_semantics=True)
 
 
+def _v4_release_merges_doc(*, v4_members=("w030001", "w040001")):
+    base = [
+        _merge([f"w01{i:04d}", f"w02{i:04d}"], f"w02{i:04d}")
+        for i in range(1, 16)
+    ]
+    base.append(_merge(["w000452", "w001239"], "w000452"))
+    return {
+        "release_contract_version": "discovery-v4-public-reference-merges-v1",
+        "v4_public_reference_canonical_ids": ["w040001"],
+        "v4_source_manifest_sha256": "a" * 64,
+        "merges": [*base, _merge(v4_members, "w040001")],
+        "dropped_by_135": ["w001239"],
+    }
+
+
+def test_v4_canonical_merge_contract_extends_instead_of_weakening_v3(tmp_path):
+    path = _write_json(tmp_path / "m.json", _v4_release_merges_doc())
+    out = sidecar_build.load_canonical_merges(
+        path, require_release_semantics=True
+    )
+    assert out["approve_count"] == 17
+    assert out["v4_public_reference_merges"] == 1
+    assert out["release_contract_version"] == (
+        "discovery-v4-public-reference-merges-v1"
+    )
+    assert out["cross_corpus_map"]["w030001"] == "w040001"
+
+
+def test_v4_canonical_merge_contract_requires_two_member_public_pair(tmp_path):
+    doc = _v4_release_merges_doc(
+        v4_members=("w030001", "w035001", "w040001")
+    )
+    path = _write_json(tmp_path / "m.json", doc)
+    with pytest.raises(sidecar_build.CanonicalMergesError, match="two-member"):
+        sidecar_build.load_canonical_merges(
+            path, require_release_semantics=True
+        )
+
+
+def _v4_track1_contract():
+    return {
+        "schema_version": "discovery-v4-track1-release-contract-v1",
+        "reference_corpus_sha256": "a" * 64,
+        "canonical_masks_sha256": "b" * 64,
+        "source_db_seed_sha256": "d" * 64,
+        "matcher_fingerprint": "c" * 40,
+        "page_count": 667411,
+        "total_rows": 400000,
+        "live_rows": 290000,
+        "ref4_total_rows": 20000,
+        "ref4_live_rows": 15000,
+        "v2_snapshot_rows": 381341,
+        "missing_ref_offsets": 0,
+        "duplicate_pairs": 0,
+        "shadow_algorithm": "track1-shadow-v1",
+        "promoted_columns": [
+            "page_id", "sys_id", "work_id", "cat", "genre", "author", "title",
+            "matched_letters", "best_density", "n_spans", "spans_json",
+            "generation", "ref_spans_json", "shadowed_by",
+        ],
+    }
+
+
+def test_v4_track1_release_contract_is_strict_and_versioned(tmp_path):
+    path = _write_json(tmp_path / "track1.json", _v4_track1_contract())
+    loaded = sidecar_build.load_track1_release_contract(path)
+    assert loaded["live_rows"] == 290000
+    assert len(loaded["sha256"]) == 64
+
+    bad = _v4_track1_contract()
+    bad["missing_ref_offsets"] = 1
+    bad_path = _write_json(tmp_path / "track1-bad.json", bad)
+    with pytest.raises(sidecar_build.ReleaseInputsIncompleteError, match="missing offsets"):
+        sidecar_build.load_track1_release_contract(bad_path)
+
+    bad_schema = _v4_track1_contract()
+    bad_schema["promoted_columns"] = bad_schema["promoted_columns"][:-1]
+    bad_schema_path = _write_json(tmp_path / "track1-bad-schema.json", bad_schema)
+    with pytest.raises(sidecar_build.ReleaseInputsIncompleteError, match="schema drift"):
+        sidecar_build.load_track1_release_contract(bad_schema_path)
+
+
 def test_insert_works_real_threads_cross_corpus_map(tmp_path):
     """The cross_corpus_map is threaded into the real-mode works insert:
     both merged members carry the SAME canonical_work_id."""

--- a/tests/test_discovery_v2_bake.py
+++ b/tests/test_discovery_v2_bake.py
@@ -285,6 +285,33 @@ def test_v4_track1_release_contract_is_strict_and_versioned(tmp_path):
         sidecar_build.load_track1_release_contract(bad_schema_path)
 
 
+def test_release_track1_contract_requires_sha_before_loading(tmp_path, monkeypatch):
+    contract_path = _write_json(tmp_path / "track1.json", _v4_track1_contract())
+    loader_called = False
+
+    def _unexpected_load(*_args, **_kwargs):
+        nonlocal loader_called
+        loader_called = True
+        raise AssertionError("unpinned release contract must not be loaded")
+
+    monkeypatch.setattr(sidecar_build, "load_track1_release_contract", _unexpected_load)
+    with pytest.raises(
+        sidecar_build.ReleaseInputsIncompleteError,
+        match="release Track-1 contract requires.*sha256",
+    ):
+        sidecar_build.finalize_build(
+            source_db_path=str(tmp_path / "missing-research.db"),
+            from_approved_path=str(tmp_path / "missing-approved.csv"),
+            crosswalk_path=str(tmp_path / "crosswalk.json"),
+            out_db_path=str(tmp_path / "out.db"),
+            release=True,
+            frozen_precision_defaults=True,
+            track1_release_contract_path=contract_path,
+            masking_patterns=["TOTALLY-UNMATCHED-MARKER-XYZ-123"],
+        )
+    assert loader_called is False
+
+
 def test_insert_works_real_threads_cross_corpus_map(tmp_path):
     """The cross_corpus_map is threaded into the real-mode works insert:
     both merged members carry the SAME canonical_work_id."""

--- a/tests/test_discovery_v4_common.py
+++ b/tests/test_discovery_v4_common.py
@@ -1,0 +1,339 @@
+import argparse
+import csv
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scripts.discovery_v4_common import (
+    clean_hebrew,
+    compact_stream,
+    load_source_config,
+    normalize_title,
+    sha256_file,
+)
+from scripts.discovery_v4_fetch_sources import (
+    _schema_leaf_refs,
+    hebrew_numeral,
+    select_chapter_links,
+    visible_text,
+)
+from scripts.discovery_v4_build_reference import (
+    _legacy_reference_metadata_key,
+    raw_reference_id,
+    select_units,
+)
+from scripts.discovery_v4_match import shadow_rows, staged_table
+from scripts.discovery_v4_reconcile import (
+    canonical_map,
+    curated_content_hash,
+    next_work_ids,
+    run as reconcile_v4,
+)
+
+
+def test_normalize_title_folds_marks_punctuation_and_spacing():
+    assert normalize_title('  רש״י_עַל--התורה ') == normalize_title("רש'י על התורה")
+
+
+def test_clean_hebrew_preserves_final_letters_and_drops_marks():
+    assert clean_hebrew("אָב־גָּד 12, end") == "אב גד"
+
+
+def test_compact_stream_matches_established_final_letter_fold():
+    assert compact_stream("מלך עולם מן") == "מלכעולממנ"
+
+
+def test_source_config_rejects_duplicate_target(tmp_path: Path):
+    path = tmp_path / "sources.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "discovery-v4-sources-v1",
+                "sources": [
+                    {
+                        "key": "one",
+                        "provider": "sefaria",
+                        "source_ref": "One",
+                        "mappings": [{"target_work_id": "w000001"}],
+                    },
+                    {
+                        "key": "two",
+                        "provider": "hewikisource",
+                        "source_ref": "Two",
+                        "mappings": [{"target_work_id": "w000001"}],
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="appears more than once"):
+        load_source_config(path)
+
+
+def test_hebrew_numeral_and_chapter_link_selection_reject_nested_paragraphs():
+    links = [
+        {"ns": 0, "title": "אסתר רבה א"},
+        {"ns": 0, "title": "אסתר רבה א א"},
+        {"ns": 0, "title": "אסתר רבה י"},
+    ]
+    assert hebrew_numeral("טו") == 15
+    assert select_chapter_links(links, "אסתר רבה ") == [
+        (1, "אסתר רבה א"),
+        (10, "אסתר רבה י"),
+    ]
+
+
+def test_visible_text_drops_edit_controls_and_scripts():
+    value = (
+        '<div>גוף <span class="mw-editsection">עריכה</span>'
+        '<script>פסול</script><p>המשך</p></div>'
+    )
+    assert visible_text(value) == "גוף המשך"
+
+
+def test_schema_leaf_refs_does_not_duplicate_root_title():
+    schema = {
+        "title": "Root",
+        "nodes": [
+            {
+                "title": "Leaf",
+                "heTitle": "עלה",
+                "nodeType": "JaggedArrayNode",
+            }
+        ],
+    }
+    assert _schema_leaf_refs("Root", schema) == [("Root, Leaf", "Leaf", "עלה")]
+
+
+def test_reference_id_and_range_slice_are_stable():
+    mapping = {"target_work_id": "w000001", "chapter_range": [2, 3]}
+    units = [{"ordinal": value} for value in range(1, 5)]
+    assert raw_reference_id("parent", mapping, 2) == "REF4:parent:2_3"
+    assert [row["ordinal"] for row in select_units(units, mapping)] == [2, 3]
+
+
+def test_reference_metadata_key_is_derived_from_frozen_mapping_shape():
+    corpus = [
+        {
+            "id": "base",
+            "genre": "g",
+            "legacy_private_field": "",
+            "stream": "abc",
+        }
+    ]
+    original_key = list(corpus[0])[2]
+    derived_key = _legacy_reference_metadata_key(corpus)
+    assert derived_key == "legacy_private_field"
+    assert derived_key is not original_key
+
+    with pytest.raises(ValueError, match="position drift"):
+        _legacy_reference_metadata_key(
+            [{"id": "base", "genre": "g", "stream": "abc"}]
+        )
+
+
+def test_v4_staged_table_rejects_sql_metacharacters():
+    assert staged_table("v4_full") == "track1_matches_pilot_v4_full_live"
+    with pytest.raises(ValueError, match="tag"):
+        staged_table("v4;drop")
+
+
+def test_shadow_rows_preserves_distinct_spans_and_shadows_worse_overlap():
+    rows = [
+        (1, "p1", "better", 0.10, json.dumps([[10, 110, 0.10]])),
+        (2, "p1", "worse", 0.14, json.dumps([[20, 100, 0.14]])),
+        (3, "p1", "distinct", 0.30, json.dumps([[200, 260, 0.30]])),
+    ]
+    assert shadow_rows(rows) == [("better", 2)]
+
+
+def test_shadow_rows_uses_worse_span_as_overlap_denominator():
+    rows = [
+        (1, "p1", "better", 0.10, json.dumps([[0, 50, 0.10]])),
+        (2, "p1", "worse", 0.14, json.dumps([[20, 70, 0.14]])),
+    ]
+    # 30/50 meets the frozen 0.6 threshold exactly.
+    assert shadow_rows(rows) == [("better", 2)]
+
+
+def test_v4_reconciliation_mints_after_the_persisted_namespace():
+    assert next_work_ids({"raw:one": "w000001", "raw:two": "w000003"}, 2) == [
+        "w000004",
+        "w000005",
+    ]
+
+
+def test_v4_reconciliation_rejects_transitive_base_merges():
+    document = {
+        "merges": [
+            {
+                "members_w": ["w000001", "w000002"],
+                "canonical_w": "w000002",
+                "owner_verdict": "approve",
+            },
+            {
+                "members_w": ["w000001", "w000003"],
+                "canonical_w": "w000003",
+                "owner_verdict": "approve",
+            },
+        ]
+    }
+    with pytest.raises(ValueError, match="disjoint"):
+        canonical_map(document)
+
+
+def test_curated_content_hash_depends_only_on_payload():
+    rows = [{"canonical_work_id": "w000001", "domain_leaf": "One"}]
+    assert curated_content_hash(rows) == curated_content_hash(list(rows))
+    assert curated_content_hash(rows).startswith("sha256:")
+
+
+def test_v4_reconciliation_mints_and_merges_only_a_live_public_reference(
+    tmp_path: Path,
+):
+    manifest = tmp_path / "reference-manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": "discovery-v4-reference-manifest-v1",
+                "acquisition_manifest_sha256": "a" * 64,
+                "entries": [
+                    {
+                        "raw_reference_id": "REF4:one",
+                        "target_private_work_id": "w000001",
+                        "title": "Public One",
+                    },
+                    {
+                        "raw_reference_id": "REF4:no_live_match",
+                        "target_private_work_id": "w000002",
+                        "title": "No Match",
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    crosswalk = tmp_path / "crosswalk.json"
+    crosswalk.write_text(
+        json.dumps({"PRIVATE:one": "w000001", "PRIVATE:two": "w000002"}),
+        encoding="utf-8",
+    )
+    approved = tmp_path / "approved.csv"
+    with approved.open("w", encoding="utf-8-sig", newline="") as stream:
+        writer = csv.DictWriter(
+            stream,
+            fieldnames=(
+                "work_id",
+                "candidate_title",
+                "author",
+                "genre",
+                "source_label",
+                "confidence_basis",
+                "tier_a_witnesses",
+                "claim_count",
+                "owner_title",
+                "owner_verdict",
+                "owner_note",
+            ),
+        )
+        writer.writeheader()
+        for work_id, title in (("w000001", "Private One"), ("w000002", "Private Two")):
+            writer.writerow(
+                {
+                    "work_id": work_id,
+                    "candidate_title": title,
+                    "author": "Author",
+                    "genre": "Genre",
+                    "source_label": "msource",
+                    "confidence_basis": "none-owner-supplies",
+                    "tier_a_witnesses": "1",
+                    "claim_count": "1",
+                    "owner_title": "",
+                    "owner_verdict": "approve",
+                    "owner_note": "",
+                }
+            )
+    merges = tmp_path / "merges.json"
+    merges.write_text(json.dumps({"merges": []}), encoding="utf-8")
+    domain_rows = [
+        {
+            "canonical_work_id": work_id,
+            "domain_parent": "Parent",
+            "domain_leaf": "Leaf",
+            "confidence": "high",
+            "provenance": "test",
+        }
+        for work_id in ("w000001", "w000002")
+    ]
+    domains = tmp_path / "domains.json"
+    domains.write_text(
+        json.dumps(
+            {
+                "artifact": "work_domains",
+                "artifact_version": "v1",
+                "assignments": domain_rows,
+                "content_hash": curated_content_hash(domain_rows),
+            }
+        ),
+        encoding="utf-8",
+    )
+    match_db = tmp_path / "matches.db"
+    with sqlite3.connect(match_db) as conn:
+        conn.execute(
+            "CREATE TABLE track1_matches (work_id TEXT, title TEXT, author TEXT, "
+            "genre TEXT, sys_id TEXT, page_id TEXT, shadowed_by TEXT, "
+            "ref_spans_json TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO track1_matches VALUES "
+            "('REF4:one', 'Public One', '', 'Genre', 's1', 'p1', NULL, '[[0,5]]')"
+        )
+
+    out_crosswalk = tmp_path / "out-crosswalk.json"
+    out_approved = tmp_path / "out-approved.csv"
+    out_merges = tmp_path / "out-merges.json"
+    out_domains = tmp_path / "out-domains.json"
+    report = reconcile_v4(
+        argparse.Namespace(
+            reference_manifest=str(manifest),
+            reference_manifest_sha256=sha256_file(manifest),
+            match_db=str(match_db),
+            base_crosswalk=str(crosswalk),
+            base_crosswalk_sha256=sha256_file(crosswalk),
+            base_approved=str(approved),
+            base_approved_sha256=sha256_file(approved),
+            base_merges=str(merges),
+            base_merges_sha256=sha256_file(merges),
+            base_work_domains=str(domains),
+            base_work_domains_sha256=sha256_file(domains),
+            output_crosswalk=str(out_crosswalk),
+            output_approved=str(out_approved),
+            output_merges=str(out_merges),
+            output_work_domains=str(out_domains),
+            report=None,
+        )
+    )
+
+    assert report["live_public_reference_count"] == 1
+    assert report["quarantined_or_unmatched_reference_count"] == 1
+    assert report["raw_to_opaque"] == {"REF4:one": "w000003"}
+    assert json.loads(out_crosswalk.read_text(encoding="utf-8"))["REF4:one"] == "w000003"
+    merged = json.loads(out_merges.read_text(encoding="utf-8"))
+    assert merged["v4_public_reference_canonical_ids"] == ["w000003"]
+    assert merged["merges"] == [
+        {
+            "canonical_w": "w000003",
+            "members_w": ["w000001", "w000003"],
+            "owner_verdict": "approve",
+        }
+    ]
+    domain_doc = json.loads(out_domains.read_text(encoding="utf-8"))
+    copied = next(
+        row for row in domain_doc["assignments"]
+        if row["canonical_work_id"] == "w000003"
+    )
+    assert copied["domain_parent"] == "Parent"
+    assert copied["provenance"] == "v4-public-reference-inherits:w000001"

--- a/tests/test_findings_page.py
+++ b/tests/test_findings_page.py
@@ -2161,8 +2161,9 @@ def _reset_to_main_bucket(page, lang: str) -> None:
         from playwright.sync_api import expect
 
         chip.click(timeout=_CLICK_TIMEOUT_MS)
-        expect(chip).to_have_attribute(
-            "aria-pressed", "true", timeout=_CONTROL_TIMEOUT_MS
+        bucket_line = page.locator(f".{fp.RESULT_BAR_CLASS}-bucket").first
+        expect(bucket_line).to_contain_text(
+            bucket_name(True, lang), timeout=_CONTROL_TIMEOUT_MS
         )
 
 
@@ -2190,7 +2191,11 @@ def _browser_actionability_probe(page, control_name: str, lang=None) -> None:
     if lang is not None:
         from playwright.sync_api import expect
 
-        expect(region).to_contain_text(
+        # The target name also appears in the invitation and on the control,
+        # both before the click. Wait on the result bar's bucket line: it is
+        # the element whose text changes only after the server-side refresh.
+        bucket_line = page.locator(f".{fp.RESULT_BAR_CLASS}-bucket").first
+        expect(bucket_line).to_contain_text(
             bucket_name(False, lang), timeout=_CONTROL_TIMEOUT_MS
         )
     after = region.inner_html()

--- a/tests/test_findings_page.py
+++ b/tests/test_findings_page.py
@@ -1525,6 +1525,13 @@ def test_no_quasar_prop_pins_an_element_to_a_physical_side(module_path):
 # the app lifespan, which is not safe to interleave with the bulk suite.
 # ---------------------------------------------------------------------------
 
+# NiceGUI's simulated ``should_see`` waits only 300 ms by default. A refresh
+# that has already completed by the time its failure dump is built can still
+# lose that race on a busy Windows runner, so post-interaction assertions get a
+# bounded three-second window. The real-browser gate below remains responsible
+# for browser actionability and uses its own larger network/UI timeout.
+_ASYNC_UI_RETRIES = 30
+
 @pytest.mark.render_smoke
 @pytest.mark.parametrize("lang", ["en", "he"])
 def test_more_matches_click_replaces_the_rendered_result_set(lang):
@@ -1601,7 +1608,9 @@ def test_more_matches_click_replaces_the_rendered_result_set(lang):
                         control.click()
 
                         # The RENDERED result region is replaced.
-                        await user.should_see(MORE_ROW_TITLE)
+                        await user.should_see(
+                            MORE_ROW_TITLE, retries=_ASYNC_UI_RETRIES
+                        )
                         await user.should_not_see(MAIN_ROW_TITLE)
             finally:
                 _os.environ.pop("NICEGUI_USER_SIMULATION", None)
@@ -1803,7 +1812,10 @@ def test_turning_candidates_on_then_switching_to_one_row_per_work_does_not_break
                         # or not the popup is showing; then pick the option).
                         user.find(fp.copy_text("novelty_view_label", lang)).click()
                         user.find(words["toggle"]).click()
-                        await user.should_see(_INTERACTION_ROW_TITLES[("identification", True)])
+                        await user.should_see(
+                            _INTERACTION_ROW_TITLES[("identification", True)],
+                            retries=_ASYNC_UI_RETRIES,
+                        )
                         await user.should_not_see(_INTERACTION_ROW_TITLES[("identification", False)])
 
                         # (2) ...and then changes the row unit to one row per
@@ -1815,7 +1827,10 @@ def test_turning_candidates_on_then_switching_to_one_row_per_work_does_not_break
                         # (2a) The new unit is RENDERED, the selection is STILL
                         # APPLIED (a distinct sentinel from the plain work
                         # row), and the old set is gone.
-                        await user.should_see(_INTERACTION_ROW_TITLES[("work", True)])
+                        await user.should_see(
+                            _INTERACTION_ROW_TITLES[("work", True)],
+                            retries=_ASYNC_UI_RETRIES,
+                        )
                         await user.should_not_see(_INTERACTION_ROW_TITLES[("work", False)])
                         await user.should_not_see(
                             _INTERACTION_ROW_TITLES[("identification", True)])
@@ -5047,7 +5062,9 @@ def test_switching_bucket_replaces_the_facet_lists_as_well_as_the_rows():
                         user.find(kind=ui.button,
                                   content=bucket_name(False, lang)).click()
 
-                        await user.should_see(_FACET_MORE_SENTINEL)
+                        await user.should_see(
+                            _FACET_MORE_SENTINEL, retries=_ASYNC_UI_RETRIES
+                        )
                         await user.should_not_see(_FACET_MAIN_SENTINEL)
             finally:
                 _os.environ.pop("NICEGUI_USER_SIMULATION", None)
@@ -5129,7 +5146,9 @@ def test_a_chip_removes_its_own_filter_and_clear_all_removes_every_filter():
 
                         # (1) pick a domain from the facet list.
                         user.find(kind=ui.button, content="Liturgy").click()
-                        await user.should_see(_ROW_FILTERED)
+                        await user.should_see(
+                            _ROW_FILTERED, retries=_ASYNC_UI_RETRIES
+                        )
                         await user.should_not_see(_ROW_UNFILTERED)
 
                         # (2) remove it through the CHIP's own listener.
@@ -5146,14 +5165,20 @@ def test_a_chip_removes_its_own_filter_and_clear_all_removes_every_filter():
                                 in removes[0]._event_listeners.values()
                                 if listener.type == "click")
                             handle_event(listener.handler, None)
-                        await user.should_see(_ROW_UNFILTERED)
+                        await user.should_see(
+                            _ROW_UNFILTERED, retries=_ASYNC_UI_RETRIES
+                        )
                         await user.should_not_see(_ROW_FILTERED)
 
                         # (3) pick it again, then use Clear all.
                         user.find(kind=ui.button, content="Liturgy").click()
-                        await user.should_see(_ROW_FILTERED)
+                        await user.should_see(
+                            _ROW_FILTERED, retries=_ASYNC_UI_RETRIES
+                        )
                         user.find(kind=ui.button, content=tr("Clear All")).click()
-                        await user.should_see(_ROW_UNFILTERED)
+                        await user.should_see(
+                            _ROW_UNFILTERED, retries=_ASYNC_UI_RETRIES
+                        )
                         await user.should_not_see(_ROW_FILTERED)
             finally:
                 _os.environ.pop("NICEGUI_USER_SIMULATION", None)

--- a/tests/test_findings_page.py
+++ b/tests/test_findings_page.py
@@ -2158,8 +2158,12 @@ def _reset_to_main_bucket(page, lang: str) -> None:
     chip = page.get_by_role("button", name=bucket_name(True, lang), exact=True).first
     chip.wait_for(state="visible", timeout=_CONTROL_TIMEOUT_MS)
     if chip.get_attribute("aria-pressed") != "true":
+        from playwright.sync_api import expect
+
         chip.click(timeout=_CLICK_TIMEOUT_MS)
-        page.wait_for_timeout(750)
+        expect(chip).to_have_attribute(
+            "aria-pressed", "true", timeout=_CONTROL_TIMEOUT_MS
+        )
 
 
 def _browser_actionability_probe(page, control_name: str, lang=None) -> None:
@@ -2183,7 +2187,12 @@ def _browser_actionability_probe(page, control_name: str, lang=None) -> None:
     # No preceding disclosure action: click straight away. Playwright's own
     # actionability checks run inside click() and raise on failure.
     locator.click(timeout=_CLICK_TIMEOUT_MS)
-    page.wait_for_timeout(750)
+    if lang is not None:
+        from playwright.sync_api import expect
+
+        expect(region).to_contain_text(
+            bucket_name(False, lang), timeout=_CONTROL_TIMEOUT_MS
+        )
     after = region.inner_html()
     assert after != before, (
         "the results region did not change after a real browser click on "

--- a/tests/test_findings_page.py
+++ b/tests/test_findings_page.py
@@ -6263,6 +6263,38 @@ def test_selected_work_lazily_renders_a_citation_order_range(monkeypatch):
     }
 
 
+def test_ja_page_range_options_hide_pages_without_changing_unit_labels(monkeypatch):
+    items = [
+        {"citation_pos": 10, "part_key": "page:10", "label_he": "פרק יז, עמ' 219"},
+        {"citation_pos": 11, "part_key": "page:11", "label_he": "פרק יח, עמ׳ 220"},
+    ]
+
+    async def _units(work_id):
+        return {
+            "status": "ok",
+            "items": items,
+            "total": 2,
+            "meta": {
+                "work_id": work_id,
+                "locus_filter": True,
+                "family": "ja",
+                "grain": "page",
+            },
+        }
+
+    monkeypatch.setattr(fp, "get_locus_units_enveloped", _units)
+    client = _render_page(
+        monkeypatch,
+        lang="en",
+        state=_state(work_id=_UNCURATED_WORK_ID, work_label=_UNCURATED_RAW_TITLE),
+    )
+    from_control = _elements_with_class(
+        client, f"{fp.FILTER_BAR_CLASS}-locus-from"
+    )[0]
+    assert from_control.options == {10: "פרק יז", 11: "פרק יח"}
+    assert items[0]["label_he"] == "פרק יז, עמ' 219"
+
+
 def test_the_facet_cascade_stops_reading_when_the_token_moves(monkeypatch):
     """The cascade issues THREE reads and each one is a chance for a newer
     refresh to have taken over. A superseded pass that kept filling containers

--- a/tests/test_fjms_service.py
+++ b/tests/test_fjms_service.py
@@ -8,9 +8,16 @@ graceful degradation, and edge cases.
 """
 
 import sqlite3
+from pathlib import Path
 import pytest
 
-from shared.fjms_service import FjmsService, get_fjms_service, get_team_display_name, TEAM_DISPLAY_NAMES
+from shared.fjms_service import (
+    TEAM_DISPLAY_NAMES,
+    FjmsService,
+    fjms_domain_sort_key,
+    get_fjms_service,
+    get_team_display_name,
+)
 
 
 @pytest.fixture
@@ -447,6 +454,37 @@ def test_get_all_domains_piyyut_count(service):
     piyyut = next(d for d in all_domains if d["domain"] == "Piyyut")
     # 990001, 990003, and 990007 all have domain=Piyyut
     assert piyyut["count"] == 3
+
+
+def test_fjms_domain_sort_key_matches_catalog_hierarchy():
+    shuffled = [
+        "Philosophy, Theology, Ethical literature",
+        "Midrash / Aggadic Midrashim",
+        "Unassigned",
+        "Massorah / Lists and Counts",
+        "Biblical Exegesis",
+        "Rabbinic Literature",
+        "Bible: Texts and Translations",
+    ]
+    assert sorted(shuffled, key=fjms_domain_sort_key) == [
+        "Bible: Texts and Translations",
+        "Massorah / Lists and Counts",
+        "Biblical Exegesis",
+        "Rabbinic Literature",
+        "Midrash / Aggadic Midrashim",
+        "Philosophy, Theology, Ethical literature",
+        "Unassigned",
+    ]
+
+
+def test_fjms_path_override_supports_git_worktrees(test_db, monkeypatch):
+    monkeypatch.setenv("GENIZAH_FJMS_DB_PATH", test_db)
+    svc = FjmsService()
+    try:
+        assert svc.is_available() is True
+        assert Path(svc._db_path).resolve() == Path(test_db).resolve()
+    finally:
+        svc.close()
 
 
 # ── Join group tests ─────────────────────────────────────────────

--- a/tests/test_rebuild_preservation.py
+++ b/tests/test_rebuild_preservation.py
@@ -110,10 +110,12 @@ def _populate_base_rows(conn: sqlite3.Connection, *, is_new: bool) -> None:
     _insert_row(conn, "discovery_claim", dict(
         page_id=PAGE1, work_id=WORK1, claim_id=C1_ID, claim_type=ids.CLAIM_TYPE_DIRECT_WITNESS,
         display_evidence_id=EA_ID, source_corpus="sefaria", sidecar_version="fixture-v1",
+        locus_status="unavailable",
     ))
     _insert_row(conn, "discovery_claim", dict(
         page_id=PAGE2, work_id=WORK2, claim_id=C2_ID, claim_type=ids.CLAIM_TYPE_DIRECT_WITNESS,
         display_evidence_id=EC_ID, source_corpus="ja", sidecar_version="fixture-v1",
+        locus_status="unavailable",
     ))
 
     _new_evidence_cols = dict(
@@ -296,7 +298,7 @@ def test_control_3_row_added_to_claim(fixture_pair):
     conn = sqlite3.connect(str(new_path))
     conn.execute(
         "INSERT INTO discovery_claim (page_id, work_id, claim_id, claim_type, display_evidence_id, "
-        "source_corpus, sidecar_version) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        "source_corpus, sidecar_version, locus_status) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
         # EB_ID, not EA_ID: phase 136 added the UNIQUE index
         # `ux_discovery_claim_display_evidence_id` (a real uniqueness invariant,
         # not a performance hint), so reusing EA_ID — already the display pointer
@@ -305,7 +307,7 @@ def test_control_3_row_added_to_claim(fixture_pair):
         # fixture that nothing points at yet, so it satisfies both the FK and the
         # new uniqueness constraint.
         (PAGE3, WORK1, ids.claim_id(PAGE3, WORK1), ids.CLAIM_TYPE_DIRECT_WITNESS, EB_ID,
-         "sefaria", "fixture-v1"),
+         "sefaria", "fixture-v1", "unavailable"),
     )
     conn.commit()
     conn.close()

--- a/tests/test_v3_routing_ingest.py
+++ b/tests/test_v3_routing_ingest.py
@@ -27,6 +27,8 @@ from v3_routing_ingest import (  # noqa: E402
     load_router,
     parity_report,
     resolve_routing,
+    route_fullscan_legacy_by_coverage,
+    route_v4_references_by_coverage,
 )
 
 
@@ -60,6 +62,104 @@ P1, P2 = "990000000000000001_IE1_P1_FL1", "990000000000000002_IE1_P1_FL1"
 # Column positions in the emitted `evidence_rows` tuples.
 _ROUTING_STATUS_IDX = 7
 _ROUTING_REASON_IDX = 8
+
+
+def test_v4_reference_routing_is_separate_threshold_extrapolation():
+    router = {
+        "route": {},
+        "meta": {"threshold": 0.30},
+        "raw_to_can": {},
+        "counts": {},
+    }
+    report = route_v4_references_by_coverage(
+        router,
+        [(P1, "REF4:one", 30), (P2, "REF4:two", 29)],
+        {P1: 100, P2: 100},
+    )
+    assert report["same_work"] == 1
+    assert report["parallel"] == 1
+    assert router["route"][(P1, "REF4:one")][0] == "same_work"
+    assert router["route"][(P2, "REF4:two")][0] == "parallel"
+    assert router["v4_reference_keys"] == {
+        (P1, "REF4:one"),
+        (P2, "REF4:two"),
+    }
+
+
+def test_v4_reference_routing_rejects_legacy_rows_and_impossible_coverage():
+    router = {
+        "route": {},
+        "meta": {"threshold": 0.30},
+        "raw_to_can": {},
+        "counts": {},
+    }
+    with pytest.raises(RoutingRegrainError, match="outside"):
+        route_v4_references_by_coverage(
+            router, [(P1, "M:legacy", 20)], {P1: 100}
+        )
+    with pytest.raises(RoutingRegrainError, match="exceeds 1.0"):
+        route_v4_references_by_coverage(
+            router, [(P1, "REF4:one", 101)], {P1: 100}
+        )
+    with pytest.raises(RoutingRegrainError, match="negative"):
+        route_v4_references_by_coverage(
+            router, [(P1, "REF4:one", -1)], {P1: 100}
+        )
+
+
+def test_v4_reference_routing_rejects_a_key_in_the_fitted_population():
+    router = {
+        "route": {(P1, "REF4:one"): ("same_work", 0.5, 1)},
+        "meta": {"threshold": 0.30},
+        "raw_to_can": {},
+        "counts": {},
+    }
+    with pytest.raises(RoutingRegrainError, match="no longer disjoint"):
+        route_v4_references_by_coverage(
+            router, [(P1, "REF4:one", 50)], {P1: 100}
+        )
+
+
+def test_fullscan_legacy_routing_is_separate_extrapolation():
+    router = {
+        "route": {},
+        "meta": {"threshold": 0.30},
+        "raw_to_can": {},
+        "counts": {},
+    }
+    report = route_fullscan_legacy_by_coverage(
+        router,
+        [(P1, "M:legacy-one", 30), (P2, "J:legacy-two", 29)],
+        {P1: 100, P2: 100},
+        {("old-page", "M:old-work")},
+    )
+    assert report["same_work"] == 1
+    assert report["parallel"] == 1
+    assert report["historical_key_count"] == 1
+    assert router["fullscan_legacy_keys"] == {
+        (P1, "M:legacy-one"),
+        (P2, "J:legacy-two"),
+    }
+
+
+def test_fullscan_legacy_routing_rejects_wrong_or_historical_population():
+    router = {
+        "route": {},
+        "meta": {"threshold": 0.30},
+        "raw_to_can": {},
+        "counts": {},
+    }
+    with pytest.raises(RoutingRegrainError, match="outside"):
+        route_fullscan_legacy_by_coverage(
+            router, [(P1, "REF4:new", 30)], {P1: 100}, set()
+        )
+    with pytest.raises(RoutingRegrainError, match="historical"):
+        route_fullscan_legacy_by_coverage(
+            router,
+            [(P1, "M:legacy", 30)],
+            {P1: 100},
+            {(P1, "M:legacy")},
+        )
 
 
 def test_the_ingested_routing_follows_the_router_and_the_gate_can_fail(tmp_path):

--- a/tests/test_vis01_projection.py
+++ b/tests/test_vis01_projection.py
@@ -10,6 +10,7 @@ run time (never hardcoded into this committed file) and never print it.
 """
 from __future__ import annotations
 
+import json
 import re
 import sqlite3
 from pathlib import Path
@@ -359,6 +360,81 @@ def test_baseline_keeps_exactly_the_fully_open_rows(tmp_path):
     assert claim_ids == {"C1"}
     assert evidence_ids == {"E1"}
     assert work_ids == {"W_OPEN"}
+
+
+def test_owner_public_exclusions_remove_yalkut_but_keep_private_competitors(tmp_path):
+    path, conn = _new_private_conn(tmp_path)
+    _add_work(conn, "W_OPEN", identity_visibility="public")
+    _add_work(conn, "w001383", identity_visibility="public")
+    _add_work(conn, "w001384", identity_visibility="public")
+    _add_claim_with_evidence(
+        conn, claim_id="C_OPEN", page_id="P1", work_id="W_OPEN",
+        evidence_id="E_OPEN", sys_id="SYS_OPEN", assertion_visibility="public",
+    )
+    for suffix, work_id in (("NACH", "w001383"), ("TORAH", "w001384")):
+        _add_claim_with_evidence(
+            conn, claim_id=f"C_{suffix}", page_id=f"P_{suffix}", work_id=work_id,
+            evidence_id=f"E_{suffix}", sys_id=f"SYS_{suffix}",
+            assertion_visibility="public",
+        )
+    _add_meta(conn, audience="private")
+    _finalize(conn)
+
+    out_path, report = _run_projection(tmp_path, path)
+    out_conn = _open_ro(out_path)
+
+    assert out_conn.execute(
+        "SELECT COUNT(*) FROM works WHERE work_id IN ('w001383', 'w001384')"
+    ).fetchone()[0] == 0
+    assert out_conn.execute(
+        "SELECT COUNT(*) FROM discovery_claim WHERE work_id IN ('w001383', 'w001384')"
+    ).fetchone()[0] == 0
+    assert out_conn.execute(
+        "SELECT COUNT(*) FROM discovery_evidence "
+        "WHERE claim_id IN ('C_NACH', 'C_TORAH')"
+    ).fetchone()[0] == 0
+    assert out_conn.execute(
+        "SELECT COUNT(*) FROM discovery_identification "
+        "WHERE canonical_work_id IN ('w001383', 'w001384')"
+    ).fetchone()[0] == 0
+    assert out_conn.execute(
+        "SELECT COUNT(*) FROM works WHERE work_id='W_OPEN'"
+    ).fetchone()[0] == 1
+    assert dict(out_conn.execute(
+        "SELECT key, value FROM meta WHERE key LIKE 'public_projection_exclu%'"
+    ).fetchall()) == {
+        "public_projection_exclusion_version": "public-projection-exclusions-v1",
+        "public_projection_excluded_canonical_work_count": "2",
+    }
+    assert report["public_projection_exclusions"] == {
+        "policy_version": "public-projection-exclusions-v1",
+        "configured_canonical_work_count": 2,
+        "present_canonical_work_count": 2,
+        "excluded_claim_count": 2,
+        "excluded_evidence_count": 2,
+    }
+
+    private_conn = _open_ro(path)
+    assert private_conn.execute(
+        "SELECT COUNT(*) FROM works WHERE work_id IN ('w001383', 'w001384')"
+    ).fetchone()[0] == 2
+
+
+def test_public_exclusion_policy_rejects_duplicate_work_ids(tmp_path):
+    policy = tmp_path / "bad-exclusions.json"
+    payload = {
+        "schema_version": "discovery-public-projection-exclusions-v1",
+        "policy_version": "test-v1",
+        "ruled_date": "2026-08-14",
+        "ruling": "test",
+        "entries": [
+            {"canonical_work_id": "w001383", "title": "a", "reason": "r"},
+            {"canonical_work_id": "w001383", "title": "b", "reason": "r"},
+        ],
+    }
+    policy.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(proj.ProjectionError, match="duplicate"):
+        proj.load_public_projection_exclusions(str(policy))
 
 
 # ---------------------------------------------------------------------------

--- a/web/pages/findings.py
+++ b/web/pages/findings.py
@@ -83,6 +83,7 @@ import asyncio
 import logging
 import math
 import os
+import re
 from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 from nicegui import ui
@@ -2103,6 +2104,26 @@ async def fetch_locus_units(state: Dict[str, Any]) -> Dict[str, Any]:
     return await get_locus_units_enveloped(str(state.get("work_id") or ""))
 
 
+_JA_PAGE_OPTION_SUFFIX = re.compile(r",\s*עמ['׳]?\s*[^,]+\s*$")
+
+
+def _locus_option_label(label: str, *, family: str = "", grain: str = "") -> str:
+    """Keep JA page precision in citations, but not in the range picker.
+
+    A Judeo-Arabic unit's full label (for example ``פרק יז, עמ' 219``) remains
+    the locus rendered beside a finding.  In the From/To control the page is
+    noisy and makes the structural label hard to scan, so only that control
+    presents ``פרק יז``.  Empty structural labels fail soft to the original;
+    a blank option would be less useful than its page.
+    """
+    value = str(label or "")
+    if family == "ja" and grain == "page":
+        structural = _JA_PAGE_OPTION_SUFFIX.sub("", value).strip()
+        if structural:
+            return structural
+    return value
+
+
 def _render_locus_range(
     envelope: Dict[str, Any], state: Dict[str, Any], lang: str, refresh
 ) -> None:
@@ -2110,9 +2131,14 @@ def _render_locus_range(
     if (envelope or {}).get("status") != "ok":
         return
     items = list(envelope.get("items") or ())
+    meta = envelope.get("meta") or {}
+    family = str(meta.get("family") or "")
+    grain = str(meta.get("grain") or "")
     options = {
-        int(item["citation_pos"]): str(
-            item.get("label_he") or item.get("part_key") or ""
+        int(item["citation_pos"]): _locus_option_label(
+            str(item.get("label_he") or item.get("part_key") or ""),
+            family=family,
+            grain=grain,
         )
         for item in items
     }


### PR DESCRIPTION
## What changed

- adds the V4 public-reference acquisition, matching, reconciliation, masking, and verification pipeline
- expands the public sidecar while preserving the frozen discovery frame and public/private boundary
- adds catalog-ordered bilingual domain hierarchy and parent/child work filtering
- materializes Guide for the Perplexed chapter divisions and range controls
- keeps JA page details in result citations while simplifying range-option labels
- adds a narrow public direct-text fallback for otherwise blank excerpt panes, including four Birkat Hamazon identifications
- adds importer, projection, loader, audit, and mutation coverage for the new artifacts

## Why

The computed-identifications launch needed work- and chapter-level navigation, more public reference coverage, and honest locus/text rendering without exposing private reference identities or fabricating locations.

## Validation

- 1,666 targeted tests passed; 11 skipped
- Ruff clean on every changed Python file
- documentation and JSON checks pass
- private/public discovery verifier passes
- frame regression passes (`90a51e0b…36f9` unchanged)
- integrity, foreign-key, masking, and real-loader gates pass
- local browser smoke verified Hebrew domain ordering, Guide chapter controls, and locus rendering

Public preview asset SHA-256: `528f6d365ac642a7a6cbbfcf16d4d3fed7bc170d310e052fbbd81d70ae8dadaf`.